### PR TITLE
better support for Hong Kong Styled Cantonese

### DIFF
--- a/yale.schema.yaml
+++ b/yale.schema.yaml
@@ -7,6 +7,7 @@ schema:
   version: "0.1"
   author:
     - 幸延 <a0726h77@gmail.com>
+    - Matthew Wo <9029537@gmail.com>
   description: |
     耶魯粵語拼音方案
     https://zh-yue.wikipedia.org/wiki/%E9%A6%99%E6%B8%AF%E8%AA%9E%E8%A8%80%E5%AD%B8%E5%AD%B8%E6%9C%83%E7%B2%B5%E8%AA%9E%E6%8B%BC%E9%9F%B3%E6%96%B9%E6%A1%88
@@ -52,36 +53,32 @@ speller:
   alphabet: zyxwvutsrqponmlkjihgfedcba
   delimiter: " '"
   algebra:
-    - xform/^jy/y/           # 粵 jyut -> yut
-    - xform/^j/y/            # 用 jung -> yung
-    - xform/^z/j/            # 抓 zaa -> ja
-    - xform/^c/ch/           # 叉 caa -> cha
-    - xform/aa$/a/           # 煆 haa -> ha
-    - xform/eu/iu/           # 掉 deu -> diu
-    - xform/eo/eu/           # 蹲 deon -> deun
-    - xform/oe/eu/           # 剁 doek -> deuk
-    - xform/em/im/           # 舐 lem -> lim
-    - xform/ep/ip/           # 夾 gep -> gip
-    - abbrev/^([a-z]).+$/$1/ # 首字母簡拼
-    - abbrev/^(ng).+$/$1/    # 聲母簡拼
-    - abbrev/^(ch).+$/$1/    # 聲母簡拼
-    - abbrev/^([gk]w).+$/$1/ # 聲母簡拼
+    - derive/^jy/y/              # 粵 jyut -> yut
+    - derive/^j/y/               # 用 jung -> yung
+    - derive/^z/j/               # 抓 zaa -> ja
+    - derive/^c/ch/              # 叉 caa -> cha
+    - derive/aa$/a/              # 煆 haa -> ha
+    - derive/eu$/iu/             # 掉 deu -> diu
+    - derive/eo/eu/              # 蹲 deon -> deun
+    - derive/oe/eu/              # 剁 doek -> deuk
+    - derive/em$/im/             # 舐 lem -> lim
+    - derive/ep$/ip/             # 夾 gep -> gip
+    - derive/eoi$/ui/            # 最 zeoi -> jui
+    - derive/eong$/eung/         # 將 zeong -> zeung
+    - derive/^[nl](.)$/l$1/      # 呢 ne -> le
+    - derive/^ng([a-z]*)/$1/     # 牙 ngaa -> aa
+    - derive/^([a-z]*)yu$/$1u/   # 豬 zyu -> ju
+    - derive/^([a-z]*)ou$/$1o/   # 好 hou -> ho
+    - abbrev/^([a-z]).+$/$1/     # 首字母簡拼
+    - abbrev/^(ng).+$/$1/        # 聲母簡拼
+    - abbrev/^(ch).+$/$1/        # 聲母簡拼
+    - abbrev/^([gk]w).+$/$1/     # 聲母簡拼
 
 translator:
   dictionary: jyutping
   prism: yale
-  spelling_hints: 5
+  spelling_hints: 10
   comment_format: &comment_rules
-    - xform/jy/y/
-    - xform/j/y/
-    - xform/z/j/
-    - xform/c/ch/
-    - xform/aa(\>|$)/a/
-    - xform/eu/iu/
-    - xform/eo/eu/
-    - xform/oe/eu/
-    - xform/em/im/
-    - xform/ep/ip/
 
 reverse_lookup:
   dictionary: luna_pinyin


### PR DESCRIPTION
- fixed issue where some characters may not show up due to mismatched algebra.
- added more algebras to support some 懶音 found in everyday Hong Kong Cantonese
    - 呢 ne le
    - 最 zeoi jui zui
    - 牙 ngaa aa
    - 豬 zyu ju
    - 好 hou ho
- more awaiting candidates (5 -> 10)