### PR TITLE
Support for Hong Kong Cantonese input

### DIFF
--- a/hkcantonese.schema.yaml
+++ b/hkcantonese.schema.yaml
@@ -1,0 +1,102 @@
+# Rime schema
+# encoding: utf-8
+
+schema:
+  schema_id: hkcantonese
+  name: 香港廣東話拼音
+  version: "0.1"
+  author:
+    - Matthew Wo <9029537@gmail.com>
+  description: |
+    耶魯粵語拼音方案
+    https://github.com/rime/rime-jyutping
+  dependencies:
+    - luna_pinyin
+
+switches:
+  - name: ascii_mode
+    reset: 0
+    states: [ 中文, 西文 ]
+  - name: full_shape
+    states: [ 半角, 全角 ]
+  - name: simplification
+    states: [ 漢字, 汉字 ]
+  - name: ascii_punct
+    states: [ 。，, ．， ]
+
+engine:
+  processors:
+    - ascii_composer
+    - recognizer
+    - key_binder
+    - speller
+    - punctuator
+    - selector
+    - navigator
+    - express_editor
+  segmentors:
+    - ascii_segmentor
+    - matcher
+    - abc_segmentor
+    - punct_segmentor
+    - fallback_segmentor
+  translators:
+    - punct_translator
+    - script_translator
+    - reverse_lookup_translator
+  filters:
+    - simplifier
+    - uniquifier
+
+speller:
+  alphabet: zyxwvutsrqponmlkjihgfedcba
+  delimiter: " '"
+  algebra:
+    - derive/^jy/y/              # 粵 jyut -> yut
+    - derive/^j/y/               # 用 jung -> yung
+    - derive/^z/j/               # 抓 zaa -> ja
+    - derive/^c/ch/              # 叉 caa -> cha
+    - derive/aa$/a/              # 煆 haa -> ha
+    - derive/eu$/iu/             # 掉 deu -> diu
+    - derive/eo/eu/              # 蹲 deon -> deun
+    - derive/oe/eu/              # 剁 doek -> deuk
+    - derive/em$/im/             # 舐 lem -> lim
+    - derive/ep$/ip/             # 夾 gep -> gip
+    - derive/eoi$/ui/            # 最 zeoi -> jui
+    - derive/eong$/eung/         # 將 zeong -> zeung
+    - derive/^[nl](.)$/l$1/      # 呢 ne -> le
+    - derive/^ng([a-z]*)/$1/     # 牙 ngaa -> aa
+    - derive/^([a-z]*)yu$/$1u/   # 豬 zyu -> ju
+    - derive/^([a-z]*)ou$/$1o/   # 好 hou -> ho
+    - abbrev/^([a-z]).+$/$1/     # 首字母簡拼
+    - abbrev/^(ng).+$/$1/        # 聲母簡拼
+    - abbrev/^(ch).+$/$1/        # 聲母簡拼
+    - abbrev/^([gk]w).+$/$1/     # 聲母簡拼
+
+translator:
+  dictionary: jyutping
+  prism: yale
+  spelling_hints: 10
+  comment_format: &comment_rules
+
+reverse_lookup:
+  dictionary: luna_pinyin
+  prefix: "`"
+  suffix: "'"
+  tips: 〔拼音〕
+  preedit_format:
+    - xform/([nl])v/$1ü/
+    - xform/([nl])ue/$1üe/
+    - xform/([jqxy])v/$1u/
+  comment_format: *comment_rules
+
+punctuator:
+  import_preset: default
+
+key_binder:
+  import_preset: default
+
+recognizer:
+  import_preset: default
+  patterns:
+    reverse_lookup: "`[a-z]*'?$"


### PR DESCRIPTION
- Derived from Yale Cantonese input scheme and added more algebras to support some 懶音 found in everyday Hong Kong Cantonese
    - 呢 ne le
    - 最 zeoi jui zui
    - 牙 ngaa aa
    - 豬 zyu ju
    - 好 hou ho
- more awaiting candidates (5 -> 10)