### PR TITLE
Adjusted Weight

### DIFF
--- a/jyutping.dict.yaml
+++ b/jyutping.dict.yaml
@@ -5,10 +5,10 @@
 #
 #   derived from scim-table-zh Jyutping table.
 #   add phrases from open Cantonese dictionary: http://kaifangcidian.com/han/yue
-
+#   weight adjustment based on http://www.edbchinese.hk/lexlist_ch/ and manual checking
 ---
 name: jyutping
-version: "2013.12.07"
+version: "2018.04.14"
 sort: by_weight
 use_preset_vocabulary: true
 max_phrase_length: 7
@@ -31,21 +31,21 @@ min_phrase_weight: 100
 䳬	tou
 䳬	zik
 䳬	zim
-丫	aa
+丫	aa	1000
 亚	aa
 亚	ngaa
-亞	aa
-亞	ngaa
+亞	aa	1000
+亞	ngaa	0%
 厂	aa
 厂	hon
 厊	aa
 厊	ngaa
-呀	aa
+呀	aa	1000
 咓	aa
 哑	aa
-啊	aa
-啞	aa
-啞	ak
+啊	aa	1000
+啞	aa	1000
+啞	ak	0%
 嗄	aa
 嗄	saa
 埡	aa
@@ -63,20 +63,20 @@ min_phrase_weight: 100
 瘂	aa
 襾	aa
 襾	kaa
-那	aa
-那	naa
-那	no
+那	aa	0%
+那	naa	1000
+那	no	0%
 錏	aa
 錒	aa
 铔	aa
 锕	aa
-阿	aa
-阿	aak
-阿	o
-雅	aa
-雅	ngaa
-鴉	aa
-鴉	ngaa
+阿	aa	1000
+阿	aak	0%
+阿	o	1000
+雅	aa	0%
+雅	ngaa	1000
+鴉	aa	1000
+鴉	ngaa	0%
 鸦	aa
 𠮩	aa
 𠮩	liu
@@ -96,21 +96,21 @@ min_phrase_weight: 100
 㶭	ai
 㶭	jiu
 㶭	zaau
-哎	aai
-哎	ai
-唉	aai
-唉	oi
-埃	aai
-埃	oi
+哎	aai	1000
+哎	ai	200
+唉	aai	1000
+唉	oi	0%
+埃	aai	1000
+埃	oi	1000
 娭	aai
 娭	ngaai
 娭	oi
 欸	aai
 欸	ei
 欸	oi
-矮	aai
-矮	ai
-矮	ngai
+矮	aai	0%
+矮	ai	1000
+矮	ngai	0%
 誒	aai
 誒	e
 誒	ei
@@ -121,7 +121,7 @@ min_phrase_weight: 100
 诶	aai
 诶	ei
 诶	oi
-隘	aai
+隘	aai	1000
 餲	aai
 餲	aat
 㧖	aak
@@ -135,26 +135,26 @@ min_phrase_weight: 100
 䧄	gok
 䮸	aak
 䮸	ak
-厄	aak
-厄	ak
-呃	aak
+厄	aak	1000
+厄	ak	1000
+呃	aak	500
 呃	ak	1000
-扼	aak
-扼	ak
-握	aak
-握	ak
+扼	aak	500
+扼	ak	500
+握	aak	1000
+握	ak	1000
 搹	aak
 搹	ngak
-軛	aak
-軛	ngaak
+軛	aak	500
+軛	ngaak	500
 軶	aak
 軶	ngaak
 轭	aak
 轭	ngaak
 鈪	aak
 鈪	ngaak
-齷	aak
-齷	ak
+齷	aak	500
+齷	ak	500
 龌	aak
 㛪	aam
 㛪	gim
@@ -183,12 +183,12 @@ min_phrase_weight: 100
 䳺	an
 菡	aam
 菡	haam
-贋	aam
-贋	am
-贋	ngaam
-贋	ngam
-贋	ngan
-晏	aan
+贋	aam	500
+贋	am	500
+贋	ngaam	500
+贋	ngam	500
+贋	ngan	500
+晏	aan	500
 晏	ngaan	1000
 鴳	aan
 鴳	ngaan
@@ -202,10 +202,10 @@ min_phrase_weight: 100
 罂	aang
 罌	aang
 㔩	aap
-押	aap
-押	aat
-鴨	aap
-鴨	ngaap
+押	aap	0%
+押	aat	1000
+鴨	aap	1000
+鴨	ngaap	0%
 鸭	aap
 鸭	ngaap
 压	aat
@@ -216,23 +216,23 @@ min_phrase_weight: 100
 堨	ngaat
 堨	ngoi
 堨	oi
-壓	aat
-壓	ngaat
+壓	aat	1000
+壓	ngaat	0%
 恝	aat
 恝	gaat
-戛	aat
-戛	gaat
+戛	aat	500
+戛	gaat	500
 戞	aat
 揠	aat
-桔	aat
-桔	gat
-歹	aat
-歹	daai
+桔	aat	0%
+桔	gat	1000
+歹	aat	0%
+歹	daai	1000
 猒	aat
 猒	jim
 猒	ngaat
-遏	aat
-遏	kit
+遏	aat	500
+遏	kit	500
 閼	aat
 閼	jin
 阏	aat
@@ -270,17 +270,17 @@ min_phrase_weight: 100
 䥲	aau
 䥲	au
 䳼	aau
-凹	aau
-凹	lap
-凹	nap
-凹	waa
+凹	aau	1000
+凹	lap	200
+凹	nap	1000
+凹	waa	0%
 坳	aau
-抓	aau
-抓	zaa
-抓	zaau
+抓	aau	0%
+抓	zaa	501
+抓	zaau	1000
 抝	aau
-拗	aau
-拗	ngaau
+拗	aau	500
+拗	ngaau	500
 靿	aau
 靿	ngaau
 䅬	ai
@@ -290,10 +290,10 @@ min_phrase_weight: 100
 屭	hei
 曀	ai
 曀	ngai
-縊	ai
+縊	ai	500
 缢	ai
-翳	ai
-翳	ji
+翳	ai	500
+翳	ji	500
 豷	ai
 豷	ngai
 躷	ai
@@ -301,12 +301,12 @@ min_phrase_weight: 100
 㬬	ak
 㬬	geoi
 偓	ak
-喔	ak
-喔	o
+喔	ak	1000
+喔	o	1000
 幄	ak
 戹	ak
 搤	ak
-渥	ak
+渥	ak	500
 腛	ak
 腛	ngak
 阨	ak
@@ -324,14 +324,14 @@ min_phrase_weight: 100
 埯	jim
 媕	am
 媕	om
-庵	am
-掩	am
-掩	jim
+庵	am	500
+掩	am	501
+掩	jim	1000
 揞	am
 揞	ngam
 晻	am
-暗	am
-暗	ngam
+暗	am	1000
+暗	ngam	0%
 盦	am
 腤	am
 腤	ngam
@@ -341,11 +341,11 @@ min_phrase_weight: 100
 闇	am
 韽	am
 韽	ngam
-鵪	am
+鵪	am	1000
 鹌	am
 黭	am
 黭	jim
-黯	am
+黯	am	1000
 𡁏	am
 𡁏	ngam
 㜝	an
@@ -362,20 +362,20 @@ min_phrase_weight: 100
 哽	gang	1000
 嘤	ang
 嘤	jing
-嚶	ang
-嚶	jing
-更	ang
-更	gaang
-更	gang
+嚶	ang	500
+嚶	jing	500
+更	ang	501
+更	gaang	1000
+更	gang	1000
 罃	ang
 莺	ang
 鞥	ang
-鶯	ang
+鶯	ang	1000
 噏	ap
 噏	ngap
-洽	ap
-洽	haap
-洽	hap
+洽	ap	0%
+洽	haap	0%
+洽	hap	1000
 㕈	at
 㕈	zi
 㦣	at
@@ -402,21 +402,21 @@ min_phrase_weight: 100
 扤	at
 扤	ngaat
 扤	ngat
-區	au	1%
-區	keoi	99%
+區	au	0.01
+區	keoi	0.99
 㑃	au
 㑃	paai
 㘬	au
 䋁	au
 䋁	gaang
 䫜	au
-勾	au
-勾	gau
-勾	ngau
+勾	au	0%
+勾	gau	0%
+勾	ngau	1000
 区	au
 区	keoi
 呕	au
-嘔	au
+嘔	au	1000
 怄	au
 慪	au
 敺	au
@@ -424,16 +424,16 @@ min_phrase_weight: 100
 櫙	au
 欧	au
 欧	ngau
-歐	au
-歐	ngau
+歐	au	1000
+歐	ngau	0%
 殴	au
-毆	au
+毆	au	1000
 沤	au
 漚	au
 熰	au
 熰	ngau
 瓯	au
-甌	au
+甌	au	500
 謳	au
 讴	au
 鉤	au
@@ -441,7 +441,7 @@ min_phrase_weight: 100
 鉤	ngau
 鏂	au
 鏂	ngau
-鷗	au
+鷗	au	1000
 鸥	au
 𩥋	au
 𩥋	ngau
@@ -464,40 +464,40 @@ min_phrase_weight: 100
 䰾	baa
 䶕	baa
 䶕	paa
-伯	baa
-伯	baak
-叭	baa
-吧	baa
+伯	baa	0%
+伯	baak	1000
+叭	baa	1000
+吧	baa	1000
 坝	baa
 垻	baa
 埧	baa
 埧	geoi
-壩	baa
+壩	baa	500
 峇	baa
 峇	hap
-巴	baa
+巴	baa	1000
 弝	baa
-把	baa
+把	baa	1000
 灞	baa
-爸	baa
-疤	baa
-笆	baa
+爸	baa	1000
+疤	baa	1000
+笆	baa	1000
 粑	baa
 罢	baa
-罷	baa
-罷	pei
+罷	baa	1000
+罷	pei	0%
 羓	baa
-芭	baa
-葩	baa
-葩	paa
+芭	baa	1000
+葩	baa	500
+葩	paa	500
 覇	baa
 豝	baa
 鈀	baa
 鈀	paa
 钯	baa
 钯	paa
-霸	baa
-靶	baa
+霸	baa	1000
+靶	baa	500
 鲃	baa
 㔥	baai
 㔥	pei
@@ -522,55 +522,55 @@ min_phrase_weight: 100
 唄	baai
 惫	baai
 惫	bei
-憊	baai
-憊	bei
-拜	baai
+憊	baai	500
+憊	bei	500
+拜	baai	1000
 捭	baai
 掰	baai
 掰	maak
 摆	baai
-擺	baai
-敗	baai
-湃	baai
-湃	paai
+擺	baai	1000
+敗	baai	1000
+湃	baai	1000
+湃	paai	0%
 稗	baai
 稗	bai
 粺	baai
 粺	bai
 襬	baai
 败	baai
-北	baak	0%
-北	bak
+北	baak	0
+北	bak	1000
 㤳	baak
 㼟	baak
 㼣	baak
 䞳	baak
 䳆	baak
-佰	baak
+佰	baak	500
 僰	baak
 僰	bok
-匐	baak
-帛	baak
+匐	baak	500
+帛	baak	500
 廹	baak
 廹	bik
-柏	baak
-柏	paak
+柏	baak	1000
+柏	paak	1000
 栢	baak
 檗	baak
 檗	paak
-白	baak
-百	baak
+白	baak	1000
+百	baak	1000
 糪	baak
 糪	bok
-舶	baak
-舶	bok
-舶	paak
+舶	baak	0%
+舶	bok	1000
+舶	paak	0%
 菔	baak
 菔	fuk
-蔔	baak
+蔔	baak	1000
 踣	baak
-迫	baak
-迫	bik
+迫	baak	1000
+迫	bik	1000
 㡦	baan
 㡦	faan
 㥹	baan
@@ -591,32 +591,32 @@ min_phrase_weight: 100
 䬱	mang
 办	baan
 坂	baan
-扮	baan
+扮	baan	1000
 攽	baan
 攽	ban
-斑	baan
+斑	baan	1000
 斒	baan
 昄	baan
-板	baan
+板	baan	1000
 湴	baan
 爿	baan
 爿	coeng
-版	baan
-班	baan
-瓣	baan
-瓣	faan
+版	baan	1000
+班	baan	1000
+瓣	baan	1000
+瓣	faan	1000
 瘢	baan
-舨	baan
+舨	baan	500
 蝂	baan
 螌	baan
-辦	baan
+辦	baan	1000
 鈑	baan
 钣	baan
-闆	baan
-阪	baan
-阪	faan
-頒	baan
-頒	paan
+闆	baan	1000
+阪	baan	500
+阪	faan	500
+頒	baan	1000
+頒	paan	0%
 颁	baan
 魬	baan
 洴	baan
@@ -631,10 +631,10 @@ min_phrase_weight: 100
 䨜	wik
 嘭	baang
 嘭	paang
-繃	baang
-繃	bang
-繃	maang
-蹦	baang
+繃	baang	500
+繃	bang	500
+繃	maang	500
+蹦	baang	0%
 𠾴	baang
 𨭌	baang
 𨭌	paang
@@ -662,7 +662,7 @@ min_phrase_weight: 100
 䥬	hot
 䳊	baat
 䳊	but
-八	baat
+八	baat	1000
 捌	baat
 朳	baat
 朳	paa
@@ -670,22 +670,22 @@ min_phrase_weight: 100
 魃	baat
 䭋	baau
 勹	baau
-包	baau
+包	baau	1000
 孢	baau
-炮	baau
-炮	paau
-爆	baau
-砲	baau
-砲	paau
-胞	baau
-苞	baau
-豹	baau
-豹	paau
-飽	baau
+炮	baau	0%
+炮	paau	1000
+爆	baau	1000
+砲	baau	500
+砲	paau	500
+胞	baau	1000
+苞	baau	500
+豹	baau	0%
+豹	paau	1000
+飽	baau	1000
 饱	baau
 骲	baau
 骲	biu
-鮑	baau
+鮑	baau	1000
 鲍	baau
 齙	baau
 龅	baau
@@ -712,31 +712,31 @@ min_phrase_weight: 100
 坒	bai
 坒	bei
 币	bai
-幣	bai
-弊	bai
-敝	bai
-斃	bai
+幣	bai	1000
+弊	bai	1000
+敝	bai	1000
+斃	bai	1000
 梐	bai
 毙	bai
 狴	bai
 獘	bai
 箅	bai
 箅	bei
-蔽	bai
+蔽	bai	1000
 薜	bai
 蜌	bai
 贔	bai
 贔	bei
 赑	bai
-跛	bai
-跛	bei
-跛	bo
+跛	bai	0%
+跛	bei	0%
+跛	bo	1000
 鄨	bai
 鎞	bai
 鎞	pei
-閉	bai
+閉	bai	1000
 闭	bai
-陛	bai
+陛	bai	1000
 𠻻	bai
 𡃇	bai
 𡚁	bai
@@ -755,8 +755,8 @@ min_phrase_weight: 100
 䧶	but
 䧶	git
 䧶	kit
-乓	bam
-乓	pong
+乓	bam	1000
+乓	pong	1000
 泵	bam
 㟗	ban
 㤓	ban
@@ -774,21 +774,21 @@ min_phrase_weight: 100
 䰉	ban
 䰉	bun
 䰉	pun
-份	ban
-份	fan
+份	ban	0%
+份	fan	1000
 体	ban
 体	tai
 傧	ban
-儐	ban
-品	ban
+儐	ban	500
+品	ban	1000
 坋	ban
 坋	fan
 坌	ban
-奔	ban
-嬪	ban
-嬪	pan
+奔	ban	1000
+嬪	ban	500
+嬪	pan	500
 宾	ban
-彬	ban
+彬	ban	500
 捹	ban
 捹	fang
 捹	fing
@@ -797,38 +797,38 @@ min_phrase_weight: 100
 斌	ban
 梹	ban
 槟	ban
-檳	ban
-檳	bing
+檳	ban	500
+檳	bing	500
 殡	ban
-殯	ban
+殯	ban	1000
 汃	ban
 汃	paak
 滨	ban
 濒	ban
 濒	pan
-濱	ban
+濱	ban	1000
 濵	ban
-瀕	ban
-瀕	pan
+瀕	ban	0%
+瀕	pan	1000
 犇	ban
 玢	ban
 玢	fan
 璸	ban
 禀	ban
-稟	ban
-稟	lam
-笨	ban
-繽	ban
+稟	ban	500
+稟	lam	500
+笨	ban	1000
+繽	ban	1000
 缤	ban
 膑	ban
-臏	ban
+臏	ban	500
 蠙	ban
 蠙	pan
 豳	ban
-賁	ban
-賁	bei
-賁	fan
-賓	ban
+賁	ban	500
+賁	bei	500
+賁	fan	500
+賓	ban	1000
 賔	ban
 贲	ban
 贲	bei
@@ -840,7 +840,7 @@ min_phrase_weight: 100
 髌	ban
 髕	ban
 鬓	ban
-鬢	ban
+鬢	ban	1000
 𡣕	ban
 𢷤	ban
 𦆯	ban
@@ -863,13 +863,13 @@ min_phrase_weight: 100
 堋	pang
 塴	bang
 塴	paang
-崩	bang
+崩	bang	1000
 弸	bang
 弸	pang
-憑	bang
-憑	pang
-甭	bang
-甭	bat
+憑	bang	501
+憑	pang	1000
+甭	bang	500
+甭	bat	500
 痭	bang
 祊	bang
 絣	bang
@@ -889,10 +889,10 @@ min_phrase_weight: 100
 䟆	bat
 䟦	bat
 䳁	bat
-不	bat
-不	fau	0%
-佛	bat
-佛	fat
+不	bat	1000
+不	fau	0
+佛	bat	0%
+佛	fat	1000
 冹	bat
 吥	bat
 吥	bau
@@ -901,21 +901,21 @@ min_phrase_weight: 100
 咇	bit
 哔	bat
 嗶	bat
-弼	bat
+弼	bat	500
 彃	bat
-拔	bat
+拔	bat	1000
 毕	bat
-泌	bat
-泌	bei
+泌	bat	0%
+泌	bei	1000
 滗	bat
 滗	bei
 滭	bat
 潷	bat
 潷	bei
 犮	bat
-畢	bat
+畢	bat	1000
 笔	bat
-筆	bat
+筆	bat	1000
 筚	bat
 篳	bat
 縪	bat
@@ -925,14 +925,14 @@ min_phrase_weight: 100
 荜	bat
 菝	bat
 蓽	bat
-跋	bat
-跋	but
+跋	bat	500
+跋	but	500
 跸	bat
 蹕	bat
 軷	bat
 軷	but
-鈸	bat
-鈸	but
+鈸	bat	500
+鈸	but	500
 钹	bat
 韠	bat
 飶	bat
@@ -954,7 +954,7 @@ min_phrase_weight: 100
 㼰	paai
 㼰	pei
 㼰	sit
-啤	be
+啤	be	1000
 畀	bei	10000
 㔗	bei
 㔗	faai
@@ -1010,41 +1010,41 @@ min_phrase_weight: 100
 䴽	bik
 䴽	pei
 俻	bei
-俾	bei
-備	bei
-匕	bei
-卑	bei
+俾	bei	1000
+備	bei	1000
+匕	bei	500
+卑	bei	1000
 吡	bei
 嚊	bei
 备	bei
 奰	bei
-妣	bei
-媲	bei
-媲	pei
+妣	bei	500
+媲	bei	500
+媲	pei	500
 屄	bei
 岥	bei
 岥	pei
 岥	po
-庇	bei
+庇	bei	1000
 庳	bei
 庳	pei
-彼	bei
-悲	bei
+彼	bei	1000
+悲	bei	1000
 柀	bei
 柲	bei
 椑	bei
 椑	pei
-比	bei
-比	pei
+比	bei	1000
+比	pei	0%
 毖	bei
 沘	bei
 犤	bei
 疕	bei
 痹	bei
-痺	bei
-碑	bei
-祕	bei
-祕	bit
+痺	bei	1000
+碑	bei	1000
+祕	bei	1000
+祕	bit	0%
 秕	bei
 秘	bei
 秘	bit
@@ -1058,25 +1058,25 @@ min_phrase_weight: 100
 罴	bei
 羆	bei
 肶	bei
-臂	bei
+臂	bei	1000
 芘	bei
 芘	pei
 萆	bei
 蓖	bei
 藣	bei
-被	bei
-被	pei
-裨	bei
-裨	pei
+被	bei	1000
+被	pei	1000
+裨	bei	500
+裨	pei	500
 襣	bei
 襣	jyu
 詖	bei
 诐	bei
-費	bei
-費	fai
-轡	bei
+費	bei	0%
+費	fai	1000
+轡	bei	500
 辔	bei
-避	bei
+避	bei	1000
 邲	bei
 鄪	bei
 鉍	bei
@@ -1096,20 +1096,20 @@ min_phrase_weight: 100
 髲	bei
 鵯	bei
 鹎	bei
-鼻	bei
+鼻	bei	1000
 𡀠	bei
 𦱔	bei
-壁	bek
-壁	bik
+壁	bek	0%
+壁	bik	1000
 㝸	beng
 㝸	bin
-柄	beng
-柄	bing
-病	beng
-病	bing
+柄	beng	1000
+柄	bing	0%
+病	beng	1000
+病	bing	1000
 窉	beng
-餅	beng
-餅	bing
+餅	beng	1000
+餅	bing	0%
 㱸	bik
 㷶	bik
 㿰	bik
@@ -1120,26 +1120,26 @@ min_phrase_weight: 100
 䮠	bik
 偪	bik
 愊	bik
-愎	bik
-愎	fuk
+愎	bik	500
+愎	fuk	500
 憵	bik
 揊	bik
 楅	bik
 楅	fuk
 湢	bik
 煏	bik
-璧	bik
+璧	bik	1000
 皕	bik
-碧	bik
+碧	bik	1000
 綼	bik
 腷	bik
 襞	bik
 襞	pik
 躄	bik
 躄	pik
-辟	bik
-辟	pik
-逼	bik
+辟	bik	0%
+辟	pik	1000
+逼	bik	1000
 㣐	bin
 㦚	bin
 㭓	bin
@@ -1154,17 +1154,17 @@ min_phrase_weight: 100
 䛒	bin
 䟍	bin
 䪻	bin
-便	bin
-便	pin
-匾	bin
-卞	bin
+便	bin	1000
+便	pin	1000
+匾	bin	1000
+卞	bin	500
 变	bin
-弁	bin
-弁	pun
+弁	bin	500
+弁	pun	500
 忭	bin
 惼	bin
-扁	bin
-扁	pin
+扁	bin	1000
+扁	pin	0%
 抃	bin
 昪	bin
 汳	bin
@@ -1177,7 +1177,7 @@ min_phrase_weight: 100
 猵	bin
 甂	bin
 甂	pin
-砭	bin
+砭	bin	500
 碥	bin
 稨	bin
 窆	bin
@@ -1189,25 +1189,25 @@ min_phrase_weight: 100
 艑	bin
 萹	bin
 萹	pin
-蝙	bin
-蝙	pin
+蝙	bin	1000
+蝙	pin	1000
 褊	bin
-變	bin
-貶	bin
+變	bin	1000
+貶	bin	1000
 贬	bin
-辨	bin
+辨	bin	1000
 辩	bin
 辫	bin
-辮	bin
-辯	bin
+辮	bin	1000
+辯	bin	1000
 边	bin
 辺	bin
-遍	bin
-遍	pin
-邊	bin
+遍	bin	0%
+遍	pin	1000
+邊	bin	1000
 釆	bin
 閞	bin
-鞭	bin
+鞭	bin	1000
 鯿	bin
 㓈	bing
 㨀	bing
@@ -1219,37 +1219,37 @@ min_phrase_weight: 100
 䈂	ping
 䋑	bing
 䴵	bing
-丙	bing
-並	bing
-並	bong	0%
-乒	bing
-乒	ping
-併	bing
-併	ping
+丙	bing	1000
+並	bing	1000
+並	bong	0
+乒	bing	1000
+乒	ping	1000
+併	bing	1000
+併	ping	0%
 偋	bing
 偋	ping
-兵	bing
+兵	bing	1000
 冫	bing
-冰	bing
+冰	bing	1000
 寎	bing
-屏	bing
-屏	ping
+屏	bing	0%
+屏	ping	1000
 屛	bing
-并	bing
+并	bing	500
 幷	bing
 怲	bing
 抦	bing
 掤	bing
 掤	maang
 掤	mang
-摒	bing
+摒	bing	500
 昺	bing
 栟	bing
 氷	bing
-炳	bing
-秉	bing
+炳	bing	500
+秉	bing	1000
 竝	bing
-迸	bing
+迸	bing	500
 邴	bing
 饼	bing
 㓖	bit
@@ -1276,10 +1276,10 @@ min_phrase_weight: 100
 䭱	mok
 䳤	bit
 佖	bit
-別	bit
+別	bit	1000
 别	bit
-彆	bit
-必	bit
+彆	bit	500
+必	bit	1000
 怭	bit
 憋	bit
 珌	bit
@@ -1298,7 +1298,7 @@ min_phrase_weight: 100
 鱉	bit
 鳖	bit
 鷩	bit
-鼈	bit
+鼈	bit	500
 㟽	biu
 㠒	biu
 㧼	biu
@@ -1315,30 +1315,30 @@ min_phrase_weight: 100
 䮽	biu
 俵	biu
 儦	biu
-婊	biu
-彪	biu
+婊	biu	500
+彪	biu	500
 杓	biu
 杓	soek
 标	biu
-標	biu
+標	biu	1000
 滮	biu
 瀌	biu
 熛	biu
 猋	biu
 瘭	biu
-票	biu
-票	piu
+票	biu	0%
+票	piu	1000
 穮	biu
 膘	biu
 臕	biu
 蔈	biu
 藨	biu
-表	biu
+表	biu	1000
 裱	biu
 褾	biu
-錶	biu
-鏢	biu
-鑣	biu
+錶	biu	1000
+鏢	biu	500
+鑣	biu	500
 镖	biu
 镳	biu
 颩	biu
@@ -1356,22 +1356,22 @@ min_phrase_weight: 100
 䝛	bo
 䝛	fu
 啵	bo
-坡	bo
-坡	po
+坡	bo	1000
+坡	po	0%
 嶓	bo
 抪	bo
 抪	bou
-播	bo
-波	bo
-玻	bo
+播	bo	1000
+波	bo	1000
+玻	bo	1000
 碆	bo
-簸	bo
-般	bo
-般	bun
-菠	bo
+簸	bo	1000
+般	bo	0%
+般	bun	1000
+菠	bo	1000
 譒	bo
-鄱	bo
-鄱	po
+鄱	bo	500
+鄱	po	500
 陃	bo
 𡃓	bo
 㗘	bok
@@ -1411,22 +1411,22 @@ min_phrase_weight: 100
 䰊	bok
 䶈	bok
 亳	bok
-剝	bok
-剝	mok
+剝	bok	0%
+剝	mok	1000
 剥	bok
 剥	mok
-博	bok
+博	bok	1000
 嚗	bok
 壆	bok
 嶨	bok
 嶨	hok
 懪	bok
-搏	bok
+搏	bok	1000
 攴	bok
 攴	pok
 欂	bok
-泊	bok
-泊	paak
+泊	bok	1000
+泊	paak	501
 泺	bok
 泺	lok
 濼	bok
@@ -1439,33 +1439,33 @@ min_phrase_weight: 100
 瓟	paau
 礡	bok
 礴	bok
-箔	bok
+箔	bok	500
 簙	bok
-縛	bok
-縛	fok
+縛	bok	1000
+縛	fok	0%
 缚	bok
 缚	fok
 胉	bok
-膊	bok
-薄	bok
+膊	bok	1000
+薄	bok	1000
 襮	bok
 襮	buk
 謈	bok
-鉑	bok
+鉑	bok	500
 鎛	bok
 鑮	bok
 铂	bok
 镈	bok
-雹	bok
+雹	bok	500
 餺	bok
 馎	bok
-駁	bok
+駁	bok	1000
 駮	bok
 驳	bok
 髆	bok
-魄	bok
-魄	paak
-魄	tok
+魄	bok	0%
+魄	paak	1000
+魄	tok	0%
 㙃	bong
 㨍	bong
 㮄	bong
@@ -1480,32 +1480,32 @@ min_phrase_weight: 100
 䩷	pang
 䰃	bong
 䰃	pang
-傍	bong
-傍	pong
+傍	bong	1000
+傍	pong	1000
 埲	bong
 埲	bung
 埲	pung
 帮	bong
 幇	bong
-幫	bong
+幫	bong	1000
 挷	bong
 搒	bong
 搒	pong
-梆	bong
-榜	bong
-榜	pong
+梆	bong	500
+榜	bong	1000
+榜	pong	0%
 牓	bong
 甏	bong
 甏	paang
-磅	bong
-綁	bong
+磅	bong	1000
+綁	bong	1000
 縍	bong
 绑	bong
-膀	bong
-膀	pong
+膀	bong	1000
+膀	pong	1000
 蒡	bong
-邦	bong
-鎊	bong
+邦	bong	1000
+鎊	bong	500
 镑	bong
 鞤	bong
 髈	bong
@@ -1539,38 +1539,38 @@ min_phrase_weight: 100
 䳰	bou
 䴐	bou
 䴺	bou
-佈	bou
-保	bou
+佈	bou	1000
+保	bou	1000
 儤	bou
 勽	bou
-哺	bou
-圃	bou
-圃	pou
-埔	bou
+哺	bou	1000
+圃	bou	0%
+圃	pou	1000
+埔	bou	1000
 埗	bou
-埠	bou
-埠	fau
-堡	bou
-報	bou
+埠	bou	501
+埠	fau	1000
+堡	bou	1000
+報	bou	1000
 媬	bou
 孬	bou
 孬	naau
 宝	bou
-寶	bou
+寶	bou	1000
 峬	bou
-布	bou
-怖	bou
+布	bou	1000
+怖	bou	1000
 报	bou
-抱	bou
-抱	pou
-捕	bou
+抱	bou	0%
+抱	pou	1000
+捕	bou	1000
 晡	bou
-暴	bou
-暴	buk
-步	bou
+暴	bou	1000
+暴	buk	1000
+步	bou	1000
 煲	bou
 篰	bou
-簿	bou
+簿	bou	1000
 缹	bou
 缹	fau
 菢	bou
@@ -1578,12 +1578,12 @@ min_phrase_weight: 100
 蔀	bou
 虣	bou
 补	bou
-補	bou
-褒	bou
-褓	bou
+補	bou	1000
+褒	bou	1000
+褓	bou	500
 襃	bou
 逋	bou
-部	bou
+部	bou	1000
 鈽	bou
 钸	bou
 餔	bou
@@ -1612,27 +1612,27 @@ min_phrase_weight: 100
 偝	bui
 孛	bui
 孛	but
-悖	bui
+悖	bui	500
 揹	bui
-杯	bui
+杯	bui	1000
 桮	bui
 梖	bui
 棓	bui
 棓	paang
 浿	bui
-焙	bui
+焙	bui	500
 狈	bui
-狽	bui
-盃	bui
-背	bui
-蓓	bui
-蓓	pui
+狽	bui	1000
+盃	bui	500
+背	bui	1000
+蓓	bui	500
+蓓	pui	500
 褙	bui
 誖	bui
-貝	bui
+貝	bui	1000
 贝	bui
 軰	bui
-輩	bui
+輩	bui	1000
 辈	bui
 邶	bui
 鋇	bui
@@ -1655,21 +1655,21 @@ min_phrase_weight: 100
 䪁	buk
 䪁	pun
 䴆	buk
-伏	buk
-伏	fuk
-僕	buk
-卜	buk
+伏	buk	501
+伏	fuk	1000
+僕	buk	1000
+卜	buk	1000
 卟	buk
 幞	buk
-曝	buk
-樸	buk
-樸	pok
+曝	buk	1000
+樸	buk	0%
+樸	pok	1000
 濮	buk
-瀑	buk
+瀑	buk	1000
 纀	buk
 纀	fuk
 襆	buk
-蹼	buk
+蹼	buk	500
 轐	buk
 醭	buk
 醭	pok
@@ -1696,27 +1696,27 @@ min_phrase_weight: 100
 䨰	fuk
 䨰	pak
 䨰	pok
-伴	bun
-伴	pun
-半	bun
-叛	bun
+伴	bun	1000
+伴	pun	501
+半	bun	1000
+叛	bun	1000
 姅	bun
-拌	bun
-拌	pun
+拌	bun	1000
+拌	pun	0%
 搫	bun
-搬	bun
-本	bun
+搬	bun	1000
+本	bun	1000
 柈	bun
 牉	bun
 牉	pun
-畔	bun
-畚	bun
+畔	bun	1000
+畚	bun	500
 籓	bun
 籓	faan
-絆	bun
+絆	bun	1000
 绊	bun
-胖	bun
-胖	pun
+胖	bun	1000
+胖	pun	0%
 苯	bun
 靽	bun
 㶻	bung
@@ -1728,9 +1728,9 @@ min_phrase_weight: 100
 䭰	zaai
 塳	bung
 塳	pung
-捧	bung
-捧	fung
-捧	pung
+捧	bung	1000
+捧	fung	0%
+捧	pung	1000
 玤	bung
 琫	bung
 琫	fung
@@ -1751,21 +1751,21 @@ min_phrase_weight: 100
 䭯	but
 䮀	but
 䮂	but
-勃	but
+勃	but	1000
 哱	but
 拨	but
-撥	but
-撥	put
+撥	but	1000
+撥	put	501
 桲	but
 浡	but
-渤	but
+渤	but	1000
 癶	but
 砵	but
 綍	but
 綍	fat
-缽	but
-脖	but
-荸	but
+缽	but	500
+脖	but	1000
+荸	but	500
 葧	but
 袯	but
 襏	but
@@ -1804,23 +1804,23 @@ min_phrase_weight: 100
 䱹	caa
 䱹	zaa
 侘	caa
-叉	caa
-喳	caa
-喳	zaa
+叉	caa	1000
+喳	caa	0%
+喳	zaa	1000
 嗏	caa
 嗏	zaa
 垞	caa
 奼	caa
 姹	caa
-岔	caa
-差	caa
-差	caai	300%
-差	ci
+岔	caa	500
+差	caa	1000
+差	caai	3
+差	ci	0%
 扠	caa
-搽	caa
+搽	caa	500
 杈	caa
-查	caa
-查	zaa
+查	caa	1000
+查	zaa	0%
 査	caa
 楂	caa
 楂	zaa
@@ -1835,12 +1835,12 @@ min_phrase_weight: 100
 秅	caa
 艖	caa
 艖	co
-茶	caa
+茶	caa	1000
 蜡	caa
 蜡	caai
 蜡	zaa
 衩	caa
-詫	caa
+詫	caa	1000
 诧	caa
 蹅	caa
 蹅	zaa
@@ -1876,10 +1876,10 @@ min_phrase_weight: 100
 囆	caai
 搋	caai
 搋	ci
-搓	caai
-搓	co
-柴	caai
-猜	caai
+搓	caai	501
+搓	co	1000
+柴	caai	1000
+猜	caai	1000
 瘥	caai
 瘥	co
 茈	caai
@@ -1887,13 +1887,13 @@ min_phrase_weight: 100
 茈	zi
 虿	caai
 蠆	caai
-豺	caai
-踩	caai
-踩	coi
-踹	caai
-踹	cyun
-踹	jaai
-釵	caai
+豺	caai	500
+踩	caai	1000
+踩	coi	0%
+踹	caai	500
+踹	cyun	500
+踹	jaai	500
+釵	caai	500
 钗	caai
 㥽	caak
 㨲	caak
@@ -1904,30 +1904,30 @@ min_phrase_weight: 100
 㿭	cak
 䊂	caak
 䰹	caak
-冊	caak
+冊	caak	1000
 册	caak
 圠	caak
-坼	caak
-惻	caak
-惻	cak
+坼	caak	500
+惻	caak	500
+惻	cak	500
 戝	caak
-拆	caak
-柵	caak
-柵	saan
+拆	caak	1000
+柵	caak	500
+柵	saan	500
 栅	caak
 栅	saan
-測	caak
-測	cak
+測	caak	1000
+測	cak	1000
 烢	caak
 烢	zaak
-策	caak
+策	caak	1000
 筴	caak
 筴	gaap
 簎	caak
 茦	caak
 茦	zaak
 蠈	caak
-賊	caak
+賊	caak	1000
 贼	caak
 鰂	caak
 鰂	zak
@@ -1986,10 +1986,10 @@ min_phrase_weight: 100
 劖	caam
 参	caam
 参	sam
-參	caam
-參	cam
-參	saam
-參	sam
+參	caam	1000
+參	cam	1000
+參	saam	0%
+參	sam	1000
 叄	caam
 叄	sam
 噆	caam
@@ -2001,19 +2001,19 @@ min_phrase_weight: 100
 忏	caam
 惨	caam
 惭	caam
-慘	caam
+慘	caam	1000
 慙	caam
-慚	caam
+慚	caam	1000
 憯	caam
-懺	caam
+懺	caam	500
 掺	caam
 搀	caam
 摻	caam
 摻	saam
-攙	caam
+攙	caam	500
 朁	caam
-杉	caam
-杉	saam
+杉	caam	500
+杉	saam	500
 枨	caam
 枨	caang
 梫	caam
@@ -2034,16 +2034,16 @@ min_phrase_weight: 100
 舕	taam
 蚕	caam
 蚕	tim
-蠶	caam
-讒	caam
-讖	caam
-讖	cam
+蠶	caam	1000
+讒	caam	1000
+讖	caam	500
+讖	cam	500
 谗	caam
 辿	caam
 辿	cin
 鑱	caam
 镵	caam
-饞	caam
+饞	caam	500
 馋	caam
 驂	caam
 骖	caam
@@ -2080,36 +2080,36 @@ min_phrase_weight: 100
 僝	saan
 刬	caan
 剗	caan
-剷	caan
-孱	caan
-孱	saan
+剷	caan	500
+孱	caan	500
+孱	saan	500
 残	caan
-殘	caan
+殘	caan	1000
 浐	caan
 滻	caan
 澯	caan
-燦	caan
+燦	caan	1000
 璨	caan
-產	caan
+產	caan	1000
 粲	caan
 羼	caan
 羼	can
-鏟	caan
+鏟	caan	1000
 铲	caan
 飡	caan
-餐	caan
-撐	caang	500%
+餐	caan	1000
+撐	caang	5
 䁎	caang
 䟫	caang
 䟫	jaang
 䟫	zing
 伧	caang
 伧	cong
-倀	caang
-倀	coeng
-倀	zaang
-傖	caang
-傖	cong
+倀	caang	500
+倀	coeng	500
+倀	zaang	500
+傖	caang	500
+傖	cong	500
 掁	caang
 撑	caang
 撜	caang
@@ -2119,13 +2119,13 @@ min_phrase_weight: 100
 棦	caang
 棦	zaang
 橕	caang
-橙	caang
-爭	caang
-爭	zaang
-爭	zang
-瞠	caang
-瞠	tong
-瞠	zaang
+橙	caang	1000
+爭	caang	501
+爭	zaang	501
+爭	zang	1000
+瞠	caang	500
+瞠	tong	500
+瞠	zaang	500
 𥋇	caang
 𦉘	caang
 㠍	caap
@@ -2147,7 +2147,7 @@ min_phrase_weight: 100
 䐕	tou
 䶓	caap
 䶓	zaai
-插	caap
+插	caap	1000
 臿	caap
 鍤	caap
 锸	caap
@@ -2155,18 +2155,18 @@ min_phrase_weight: 100
 䃰	caat
 䕓	caat
 䶪	caat
-刷	caat
-刷	saat
+刷	caat	1000
+刷	saat	0%
 刹	caat
 刹	saat
-剎	caat
-剎	saat
+剎	caat	0%
+剎	saat	1000
 唰	caat
 嚓	caat
-察	caat
-擦	caat
+察	caat	1000
+擦	caat	1000
 獭	caat
-獺	caat
+獺	caat	500
 礤	caat
 詧	caat
 𩟔	caat
@@ -2211,20 +2211,20 @@ min_phrase_weight: 100
 䵎	toi
 䵎	zyun
 䵸	caau
-剿	caau
-剿	ziu
+剿	caau	500
+剿	ziu	500
 勦	caau
 勦	cau
 勦	ziu
-吵	caau
-巢	caau
-抄	caau
+吵	caau	1000
+巢	caau	1000
+抄	caau	1000
 摷	caau
 摷	ziu
 樔	caau
 樔	ziu
 漅	caau
-炒	caau
+炒	caau	1000
 罺	caau
 耖	caau
 肏	caau
@@ -2232,7 +2232,7 @@ min_phrase_weight: 100
 訬	miu
 轈	caau
 鄛	caau
-鈔	caau
+鈔	caau	1000
 钞	caau
 𠳕	caau
 𤙴	caau
@@ -2252,25 +2252,25 @@ min_phrase_weight: 100
 䶒	cai
 傺	cai
 凄	cai
-切	cai
-切	cit
+切	cai	1000
+切	cit	1000
 哜	cai
 啛	cai
 嚌	cai
 嚌	zai
-妻	cai
-悽	cai
+妻	cai	1000
+悽	cai	1000
 懠	cai
 摕	cai
 栖	cai
-棲	cai
+棲	cai	1000
 沏	cai
 沏	cit
-淒	cai
-砌	cai
+淒	cai	500
+砌	cai	1000
 艩	cai
 荠	cai
-萋	cai
+萋	cai	500
 薺	cai
 薺	ci
 蛴	cai
@@ -2280,16 +2280,16 @@ min_phrase_weight: 100
 鮆	zai
 鱭	cai
 鲚	cai
-齊	cai
-齊	zai
-齊	zi
+齊	cai	1000
+齊	zai	0%
+齊	zi	0%
 齐	cai
 𠯦	cai
 䍉	cak
 䍉	zak
 䞣	cak
-廁	cak
-廁	ci
+廁	cak	0%
+廁	ci	1000
 恻	cak
 测	cak
 畟	cak
@@ -2328,7 +2328,7 @@ min_phrase_weight: 100
 䫖	cam
 䫮	cam
 䰼	cam
-侵	cam
+侵	cam	1000
 吣	cam
 唚	cam
 噖	cam
@@ -2337,17 +2337,17 @@ min_phrase_weight: 100
 墋	cam
 寑	cam
 寝	cam
-寢	cam
+寢	cam	500
 寻	cam
-尋	cam
+尋	cam	1000
 嵾	cam
 挦	cam
 撏	cam
 棽	cam
-沈	cam
-沈	sam
-沉	cam
-沉	zam
+沈	cam	500
+沈	sam	500
+沉	cam	1000
+沉	zam	0%
 浔	cam
 潯	cam
 灊	cam
@@ -2394,12 +2394,12 @@ min_phrase_weight: 100
 亲	can
 儭	can
 吲	can
-哂	can
-哂	saai
+哂	can	500
+哂	saai	500
 嗔	can
 嗔	zan
 嚫	can
-塵	can
+塵	can	1000
 尘	can
 抻	can
 捵	can
@@ -2411,14 +2411,14 @@ min_phrase_weight: 100
 瀙	can
 灿	can
 疢	can
-疹	can
-疹	zan
+疹	can	500
+疹	zan	500
 眕	can
 眕	zan
 瞋	can
 矧	can
-稱	can
-稱	cing
+稱	can	0%
+稱	cing	1000
 紖	can
 紖	jan
 紖	zan
@@ -2431,17 +2431,17 @@ min_phrase_weight: 100
 衬	can
 袗	can
 袗	zan
-襯	can
-親	can
+襯	can	1000
+親	can	1000
 訠	can
-診	can
-診	zan
+診	can	1000
+診	zan	0%
 诊	can
-趁	can
+趁	can	1000
 辴	can
 陈	can
-陳	can
-陳	zan
+陳	can	1000
+陳	zan	0%
 齔	can
 龀	can
 㓌	cang
@@ -2473,16 +2473,16 @@ min_phrase_weight: 100
 噌	cang
 噌	zang
 层	cang
-層	cang
+層	cang	1000
 嶒	cang
-曾	cang
-曾	zang
+曾	cang	1000
+曾	zang	1000
 竀	cang
 竀	cing
 罉	cang
 鄫	cang
-鐺	cang
-鐺	dong
+鐺	cang	500
+鐺	dong	500
 铛	cang
 铛	dong
 㔍	cap
@@ -2506,14 +2506,14 @@ min_phrase_weight: 100
 䮜	cap
 䮜	saap
 咠	cap
-戢	cap
+戢	cap	500
 濈	cap
 緁	cap
-緝	cap
+緝	cap	1000
 缉	cap
 葺	cap
 蕺	cap
-輯	cap
+輯	cap	1000
 辑	cap
 㭍	cat
 㯃	cat
@@ -2522,13 +2522,13 @@ min_phrase_weight: 100
 䌨	cat
 䓭	cat
 䵽	cat
-七	cat
+七	cat	1000
 柒	cat
 桼	cat
-漆	cat
+漆	cat	1000
 𠀁	cat
 𨳍	cat
-抽	cau	500%
+抽	cau	5
 㗜	cau
 㤽	cau
 㦞	cau
@@ -2551,20 +2551,20 @@ min_phrase_weight: 100
 䠗	cau
 䨂	cau
 䲡	cau
-丑	cau
-仇	cau
-仇	kau
-仇	sau
+丑	cau	1000
+仇	cau	0%
+仇	kau	0%
+仇	sau	1000
 俦	cau
 偢	cau
 偢	ciu
 傶	cau
 傶	cik
-儔	cau
+儔	cau	500
 凑	cau
-嗅	cau
-嗅	hung
-囚	cau
+嗅	cau	1000
+嗅	hung	0%
+囚	cau	1000
 崷	cau
 帱	cau
 帱	dou
@@ -2572,7 +2572,7 @@ min_phrase_weight: 100
 幬	cau
 幬	dou
 幬	tou
-惆	cau
+惆	cau	500
 懤	cau
 揫	cau
 揫	zau
@@ -2584,32 +2584,32 @@ min_phrase_weight: 100
 楱	zeon
 楸	cau
 殠	cau
-泅	cau
-泅	jau
-湊	cau
+泅	cau	500
+泅	jau	500
+湊	cau	1000
 溴	cau
 煍	cau
 煍	ciu
 犨	cau
 畴	cau
-疇	cau
+疇	cau	500
 瘳	cau
 瞅	cau
-秋	cau
+秋	cau	1000
 秌	cau
-稠	cau
+稠	cau	1000
 筹	cau
 篘	cau
-籌	cau
+籌	cau	1000
 糗	cau
 糗	jau
 糗	zau
 紬	cau
-綢	cau
+綢	cau	1000
 緧	cau
 绸	cau
 腠	cau
-臭	cau
+臭	cau	1000
 萩	cau
 蝤	cau
 蝤	jau
@@ -2618,26 +2618,26 @@ min_phrase_weight: 100
 讎	cau
 讐	cau
 踌	cau
-躊	cau
+躊	cau	500
 輳	cau
 辏	cau
 遒	cau
-酋	cau
-酋	jau
+酋	cau	0%
+酋	jau	1000
 酘	cau
 酘	tau
 酧	cau
-酬	cau
-醜	cau
+酬	cau	1000
+醜	cau	1000
 雔	cau
 雔	sau
 雠	cau
-鞦	cau
+鞦	cau	500
 鞧	cau
 鮂	cau
 鰌	cau
 鰌	jau
-鰍	cau
+鰍	cau	500
 鳅	cau
 鶖	cau
 鹙	cau
@@ -2661,36 +2661,36 @@ min_phrase_weight: 100
 䏡	to
 䔑	ce
 䵦	ce
-且	ce
-且	zeoi
-且	zoeng	0%
+且	ce	1000
+且	zeoi	0%
+且	zoeng	0
 哆	ce
 哆	ci
 哆	do
-奢	ce
-奢	se
+奢	ce	1000
+奢	se	0%
 奲	ce
 奲	do
-尺	ce
-尺	cek
-扯	ce
+尺	ce	0%
+尺	cek	1000
+扯	ce	1000
 抯	ce
 撦	ce
-斜	ce
-斜	je
+斜	ce	1000
+斜	je	0%
 檨	ce
 檨	se
 灺	ce
 灺	se
 砗	ce
 硨	ce
-車	ce
-車	geoi
+車	ce	1000
+車	geoi	1000
 輋	ce
 车	ce
 车	geoi
-邪	ce
-邪	je
+邪	ce	1000
+邪	je	0%
 𠳏	ce
 𠾏	ce
 㕽	cek
@@ -2702,22 +2702,22 @@ min_phrase_weight: 100
 䨏	cek
 䨏	ci
 䨏	maan
-呎	cek
-赤	cek
-赤	cik
+呎	cek	1000
+赤	cek	1000
+赤	cik	1000
 𤆍	cek
 𤷫	cek
 𤷫	cik
 䙲	ceng
 䙲	cin
-晴	ceng
-晴	cing
-清	ceng
-清	cing
-請	ceng
-請	cing
-青	ceng
-青	cing
+晴	ceng	0%
+晴	cing	1000
+清	ceng	0%
+清	cing	1000
+請	ceng	0%
+請	cing	1000
+青	ceng	501
+青	cing	1000
 㕑	ceoi
 㕑	cyu
 㜠	ceoi
@@ -2785,42 +2785,42 @@ min_phrase_weight: 100
 䶴	ceoi
 倅	ceoi
 倅	zeot
-催	ceoi
+催	ceoi	1000
 厜	ceoi
 厜	seoi
 厨	ceoi
 厨	cyu
-取	ceoi
-吹	ceoi
+取	ceoi	1000
+吹	ceoi	1000
 啐	ceoi
 啐	seoi
 嗺	ceoi
 墔	ceoi
-娶	ceoi
-崔	ceoi
-廚	ceoi
-廚	cyu
-徐	ceoi
-捶	ceoi
-推	ceoi
-推	teoi
-揣	ceoi
-揣	cyun
+娶	ceoi	1000
+崔	ceoi	500
+廚	ceoi	1000
+廚	cyu	1000
+徐	ceoi	1000
+捶	ceoi	500
+推	ceoi	0%
+推	teoi	1000
+揣	ceoi	500
+揣	cyun	500
 搥	ceoi
-摧	ceoi
+摧	ceoi	1000
 棰	ceoi
 棰	zeoi
-椎	ceoi
-椎	zeoi
+椎	ceoi	500
+椎	zeoi	500
 榱	ceoi
-槌	ceoi
-橇	ceoi
-橇	hiu
+槌	ceoi	500
+橇	ceoi	500
+橇	hiu	500
 毳	ceoi
 淬	ceoi
 淬	seoi
 漼	ceoi
-炊	ceoi
+炊	ceoi	500
 焠	ceoi
 焠	seoi
 璀	ceoi
@@ -2834,9 +2834,9 @@ min_phrase_weight: 100
 綷	ceoi
 縗	ceoi
 缞	ceoi
-翠	ceoi
+翠	ceoi	1000
 脃	ceoi
-脆	ceoi
+脆	ceoi	1000
 脺	ceoi
 脺	seoi
 腄	ceoi
@@ -2844,13 +2844,13 @@ min_phrase_weight: 100
 膗	saai
 膬	ceoi
 菙	ceoi
-蛆	ceoi
-蛆	zeoi
+蛆	ceoi	500
+蛆	zeoi	500
 蜍	ceoi
 蜍	cyu
 蜍	syu
-衰	ceoi
-衰	seoi
+衰	ceoi	0%
+衰	seoi	1000
 覰	ceoi
 覷	ceoi
 觑	ceoi
@@ -2861,22 +2861,22 @@ min_phrase_weight: 100
 趋	ceoi
 趍	ceoi
 趡	ceoi
-趣	ceoi
-趣	cuk
-趨	ceoi
-趨	cuk
-錘	ceoi
-錘	seoi
+趣	ceoi	1000
+趣	cuk	0%
+趨	ceoi	1000
+趨	cuk	0%
+錘	ceoi	500
+錘	seoi	500
 鎚	ceoi
 鏙	ceoi
 锤	ceoi
 陏	ceoi
 陏	do
-除	ceoi
-除	cyu
-隋	ceoi
+除	ceoi	1000
+除	cyu	0%
+隋	ceoi	1000
 随	ceoi
-隨	ceoi
+隨	ceoi	1000
 龡	ceoi
 𡃴	ceoi
 𢊍	ceoi
@@ -2900,44 +2900,44 @@ min_phrase_weight: 100
 䮞	ceon
 䲠	ceon
 偆	ceon
-巡	ceon
+巡	ceon	1000
 廵	ceon
-循	ceon
+循	ceon	1000
 惷	ceon
-旬	ceon
-春	ceon
+旬	ceon	1000
+春	ceon	1000
 杶	ceon
 栒	ceon
 栒	seon
 椿	ceon
 橁	ceon
-秦	ceon
+秦	ceon	1000
 紃	ceon
 膥	ceon
 螓	ceon
-蠢	ceon
+蠢	ceon	1000
 賰	ceon
 賰	seon
 踳	ceon
 踳	cyun
 輴	ceon
-馴	ceon
-馴	seon
+馴	ceon	0%
+馴	seon	1000
 驯	ceon
 驯	seon
 鰆	ceon
 鰆	zeon
 䢺	ceot
-出	ceot
+出	ceot	1000
 焌	ceot
 焌	zeon
-絀	ceot
-絀	zeot
-絀	zyut
-黜	ceot
-黜	zeot
-黜	zyut
-齣	ceot
+絀	ceot	500
+絀	zeot	500
+絀	zyut	500
+黜	ceot	500
+黜	zeot	500
+黜	zyut	500
+齣	ceot	500
 㓨	ci
 㔭	ci
 㖢	ci
@@ -3046,56 +3046,56 @@ min_phrase_weight: 100
 䶔	ci
 䶵	ci
 䶵	si
-似	ci
+似	ci	1000
 佌	ci
 佽	ci
-侈	ci
+侈	ci	1000
 偨	ci
 偨	zi
 儩	ci
-刺	ci
-刺	cik
-刺	sik
-匙	ci
-匙	si
+刺	ci	1000
+刺	cik	0%
+刺	sik	0%
+匙	ci	1000
+匙	si	1000
 厕	ci
 厠	ci
 哧	ci
-啻	ci
-嗤	ci
+啻	ci	500
+嗤	ci	500
 嘁	ci
 嘁	cik
 坻	ci
 坻	dai
-墀	ci
+墀	ci	500
 奓	ci
 奓	se
 奓	zaa
-始	ci
-姒	ci
+始	ci	1000
+姒	ci	500
 姼	ci
 姼	si
 媸	ci
-峙	ci
-峙	si
+峙	ci	500
+峙	si	500
 帜	ci
-幟	ci
+幟	ci	1000
 庛	ci
-弛	ci
+弛	ci	1000
 恀	ci
-恃	ci
-恃	si
-恣	ci
-恣	zi
-恥	ci
-慈	ci
+恃	ci	500
+恃	si	500
+恣	ci	500
+恣	zi	500
+恥	ci	1000
+慈	ci	1000
 懥	ci
 懥	zi
 扡	ci
 扡	to
 拸	ci
 拸	ji
-持	ci
+持	ci	1000
 揓	ci
 揓	to
 摛	ci
@@ -3108,41 +3108,41 @@ min_phrase_weight: 100
 柂	ci
 柂	ji
 柂	to
-柿	ci
-次	ci
+柿	ci	1000
+次	ci	1000
 欼	ci
 欼	syut
-此	ci
+此	ci	1000
 歭	ci
 歭	zi
 歯	ci
 汜	ci
-池	ci
-治	ci
-治	zi
+池	ci	1000
+治	ci	0%
+治	zi	1000
 泚	ci
 泜	ci
 泜	zi
 滍	ci
 滍	zi
 炽	ci
-熾	ci
+熾	ci	1000
 玆	ci
 玆	zi
 玼	ci
-瓷	ci
+瓷	ci	1000
 瓻	ci
-疵	ci
-痴	ci
+疵	ci	500
+痴	ci	1000
 癡	ci
 眙	ci
 眙	ji
 眡	ci
 眵	ci
-矢	ci
-磁	ci
-祠	ci
-笞	ci
+矢	ci	500
+磁	ci	1000
+祠	ci	1000
+笞	ci	500
 箈	ci
 箎	ci
 篪	ci
@@ -3150,7 +3150,7 @@ min_phrase_weight: 100
 絘	ci
 絺	ci
 翄	ci
-翅	ci
+翅	ci	1000
 翨	ci
 翨	si
 耻	ci
@@ -3160,48 +3160,48 @@ min_phrase_weight: 100
 胣	ji
 胵	ci
 脐	ci
-臍	ci
+臍	ci	1000
 茌	ci
 茨	ci
 茬	ci
-茲	ci
-茲	zi
+茲	ci	0%
+茲	zi	1000
 荎	ci
 莿	ci
 薋	ci
 蚝	ci
 蚝	hou
-蚩	ci
+蚩	ci	500
 蚳	ci
 蛓	ci
 蛓	zi
 螭	ci
-褫	ci
-詞	ci
+褫	ci	500
+詞	ci	1000
 誃	ci
 誃	zi
 謻	ci
 謻	ji
 词	ci
-豕	ci
-賜	ci
+豕	ci	500
+賜	ci	1000
 赐	ci
 跐	ci
 跐	coi
 跮	ci
-踟	ci
+踟	ci	500
 辞	ci
 辤	ci
-辭	ci
+辭	ci	1000
 迉	ci
 迟	ci
-遲	ci
+遲	ci	1000
 郗	ci
-雌	ci
+雌	ci	1000
 飺	ci
 餈	ci
 饎	ci
-馳	ci
+馳	ci	1000
 驰	ci
 骴	ci
 髊	ci
@@ -3213,7 +3213,7 @@ min_phrase_weight: 100
 鸱	ci
 鹚	ci
 黐	ci
-齒	ci
+齒	ci	1000
 齝	ci
 齿	ci
 𦙼	ci
@@ -3231,31 +3231,31 @@ min_phrase_weight: 100
 勅	cik
 勑	cik
 勑	loi
-叱	cik
+叱	cik	1000
 彳	cik
-慼	cik
+慼	cik	500
 慽	cik
-戚	cik
+戚	cik	1000
 抶	cik
 抶	maat
 抶	mut
 摵	cik
 摵	saak
 敕	cik
-斥	cik
-析	cik
-析	sik
+斥	cik	1000
+析	cik	0%
+析	sik	1000
 栻	cik
 栻	sik
 槭	cik
 槭	zik
 磩	cik
 磩	cit
-螫	cik
-螫	sik
+螫	cik	500
+螫	sik	500
 鏚	cik
-飭	cik
-飭	sik
+飭	cik	500
+飭	sik	500
 饬	cik
 鶒	cik
 鷘	cik
@@ -3312,10 +3312,10 @@ min_phrase_weight: 100
 䵌	cim
 佥	cim
 僉	cim
-僭	cim
-僭	zim
+僭	cim	500
+僭	zim	500
 堑	cim
-塹	cim
+塹	cim	500
 壍	cim
 嬐	cim
 孅	cim
@@ -3324,14 +3324,14 @@ min_phrase_weight: 100
 憸	cim
 撍	cim
 攕	cim
-暹	cim
+暹	cim	500
 椠	cim
 槧	cim
 櫼	cim
 櫼	zim
 歼	cim
-殲	cim
-潛	cim
+殲	cim	1000
+潛	cim	1000
 潜	cim
 濳	cim
 瀸	cim
@@ -3339,10 +3339,10 @@ min_phrase_weight: 100
 燂	cim
 燂	taam
 签	cim
-簽	cim
-籤	cim
+簽	cim	1000
+籤	cim	500
 纎	cim
-纖	cim
+纖	cim	1000
 纤	cim
 莶	cim
 薟	cim
@@ -3350,7 +3350,7 @@ min_phrase_weight: 100
 襳	cim
 襳	sam
 襳	sim
-諂	cim
+諂	cim	500
 讇	cim
 谄	cim
 酟	cim
@@ -3378,15 +3378,15 @@ min_phrase_weight: 100
 䤔	zim
 䤔	zit
 䧖	cin
-仟	cin
+仟	cin	500
 俴	cin
 俴	zin
 儃	cin
 儃	sin
 儃	taan
 冁	cin
-前	cin
-千	cin
+前	cin	1000
+千	cin	1000
 嘽	cin
 嘽	taan
 嘽	zin
@@ -3397,7 +3397,7 @@ min_phrase_weight: 100
 扦	cin
 梴	cin
 浅	cin
-淺	cin
+淺	cin	1000
 瀍	cin
 灛	cin
 灛	zin
@@ -3406,8 +3406,8 @@ min_phrase_weight: 100
 燀	zin
 瓩	cin
 瓩	ngaa
-纏	cin
-纏	zin
+纏	cin	1000
+纏	zin	0%
 缠	cin
 芊	cin
 蒇	cin
@@ -3415,20 +3415,20 @@ min_phrase_weight: 100
 蕆	cin
 蕆	zin
 践	cin
-踐	cin
-踐	zin
+踐	cin	1000
+踐	zin	0%
 躔	cin
 迁	cin
-遷	cin
-錢	cin
-錢	zin
+遷	cin	1000
+錢	cin	1000
+錢	zin	0%
 钱	cin
-闡	cin
-闡	zin
+闡	cin	500
+闡	zin	500
 阐	cin
 阐	zin
-阡	cin
-韆	cin
+阡	cin	1000
+韆	cin	500
 驏	cin
 驏	zaan
 骣	cin
@@ -3453,49 +3453,49 @@ min_phrase_weight: 100
 䡕	cing
 䨝	cing
 偁	cing
-呈	cing
+呈	cing	1000
 圊	cing
 埕	cing
-情	cing
+情	cing	1000
 惩	cing
-懲	cing
-成	cing
-成	seng
-成	sing
-拯	cing
+懲	cing	1000
+成	cing	0%
+成	seng	501
+成	sing	1000
+拯	cing	1000
 掅	cing
 柽	cing
 檉	cing
 氰	cing
 氶	cing
 澂	cing
-澄	cing
-澄	dang
+澄	cing	1000
+澄	dang	1000
 珵	cing
-瞪	cing
-瞪	dang
-秤	cing
+瞪	cing	0%
+瞪	dang	1000
+秤	cing	1000
 称	cing
-程	cing
+程	cing	1000
 脀	cing
-菁	cing
-菁	zing
+菁	cing	500
+菁	zing	500
 蛏	cing
-蜻	cing
+蜻	cing	1000
 蟶	cing
 裎	cing
 请	cing
 赪	cing
 赬	cing
-逞	cing
+逞	cing	1000
 郢	cing
 郢	jing
 酲	cing
 靘	cing
 餳	cing
 饧	cing
-騁	cing
-騁	ping
+騁	cing	500
+騁	ping	500
 骋	cing
 鯖	cing
 鲭	cing
@@ -3514,7 +3514,7 @@ min_phrase_weight: 100
 唼	cip
 唼	saap
 唼	zaap
-妾	cip
+妾	cip	1000
 菨	cip
 菨	zip
 詀	cip
@@ -3538,22 +3538,22 @@ min_phrase_weight: 100
 䱨	zaai
 屮	cit
 彻	cit
-徹	cit
+徹	cit	1000
 懘	cit
-掣	cit
+掣	cit	0%
 掣	zai	1000
-撤	cit
-澈	cit
+撤	cit	1000
+澈	cit	1000
 硩	cit
 硩	zit
 蔎	cit
-設	cit
+設	cit	1000
 设	cit
 踅	cit
 踅	cyut
 踅	zai
 踅	zi
-轍	cit
+轍	cit	500
 辙	cit
 㣍	ciu
 㣍	cong
@@ -3569,11 +3569,11 @@ min_phrase_weight: 100
 䫿	ciu
 䫿	coi
 䵲	ciu
-俏	ciu
+俏	ciu	500
 劁	ciu
 嫶	ciu
 嫶	ziu
-峭	ciu
+峭	ciu	1000
 嶕	ciu
 嶕	ziu
 帩	ciu
@@ -3581,21 +3581,21 @@ min_phrase_weight: 100
 弨	ciu
 怊	ciu
 怊	tiu
-悄	ciu
-愀	ciu
-憔	ciu
-昭	ciu
-昭	ziu
+悄	ciu	1000
+愀	ciu	500
+憔	ciu	1000
+昭	ciu	500
+昭	ziu	500
 晁	ciu
-朝	ciu
-朝	ziu
-樵	ciu
-潮	ciu
+朝	ciu	1000
+朝	ziu	1000
+樵	ciu	500
+潮	ciu	1000
 燋	ciu
 燋	ziu
 睄	ciu
 睄	saau
-瞧	ciu
+瞧	ciu	1000
 繰	ciu
 繰	sou
 繰	tiu
@@ -3603,20 +3603,20 @@ min_phrase_weight: 100
 缲	ciu
 缲	sou
 缲	tiu
-肖	ciu
+肖	ciu	1000
 誚	ciu
 譙	ciu
 诮	ciu
 谯	ciu
-超	ciu
-釗	ciu
+超	ciu	1000
+釗	ciu	500
 鍫	ciu
-鍬	ciu
+鍬	ciu	500
 钊	ciu
 锹	ciu
 陗	ciu
-鞘	ciu
-鞘	saau
+鞘	ciu	500
+鞘	saau	500
 顦	ciu
 㟇	co
 㭫	co
@@ -3645,16 +3645,16 @@ min_phrase_weight: 100
 傞	co
 儊	co
 刍	co
-初	co
+初	co	1000
 剉	co
-坐	co
-坐	zo
+坐	co	501
+坐	zo	1000
 媰	co
 媰	zau
 嵯	co
 憷	co
-挫	co
-楚	co
+挫	co	1000
+楚	co	1000
 檚	co
 濋	co
 犓	co
@@ -3662,25 +3662,25 @@ min_phrase_weight: 100
 痤	co
 矬	co
 础	co
-磋	co
-礎	co
+磋	co	1000
+礎	co	1000
 耡	co
 脞	co
-芻	co
+芻	co	500
 莏	co
 莏	so
 莝	co
 莝	zo
 蒭	co
 蓌	co
-蹉	co
+蹉	co	1000
 醝	co
 鉏	co
-銼	co
-鋤	co
-錯	co
-錯	cok
-錯	cou
+銼	co	500
+鋤	co	1000
+錯	co	1000
+錯	cok	1000
+錯	cou	0%
 锄	co
 锉	co
 错	co
@@ -3688,7 +3688,7 @@ min_phrase_weight: 100
 阤	to
 阤	zi
 雏	co
-雛	co
+雛	co	1000
 鶵	co
 鹺	co
 鹾	co
@@ -3732,20 +3732,20 @@ min_phrase_weight: 100
 勺	coek
 勺	soek
 勺	zoek
-卓	coek
-卓	zoek
-噱	coek
-噱	kek
-噱	koek
+卓	coek	1000
+卓	zoek	0%
+噱	coek	500
+噱	kek	500
+噱	koek	500
 婥	coek
 婼	coek
-戳	coek
-桌	coek
-桌	zoek
+戳	coek	500
+桌	coek	1000
+桌	zoek	1000
 潟	coek
 潟	sik
-灼	coek
-灼	zoek
+灼	coek	501
+灼	zoek	1000
 焯	coek
 焯	zoek
 皵	coek
@@ -3754,18 +3754,18 @@ min_phrase_weight: 100
 碏	zoek
 穛	coek
 穛	zoek
-綽	coek
+綽	coek	1000
 绰	coek
-芍	coek
-芍	zoek
+芍	coek	500
+芍	zoek	500
 趠	coek
 踔	coek
 辵	coek
 逴	coek
-鵲	coek
-鵲	zoek
+鵲	coek	0%
+鵲	zoek	1000
 鹊	coek
-暢	coeng	500%
+暢	coeng	5
 㙊	coeng
 㟄	coeng
 㡧	coeng
@@ -3795,47 +3795,47 @@ min_phrase_weight: 100
 䵁	coeng
 伥	coeng
 伥	zaang
-倡	coeng
-償	coeng
-償	soeng
+倡	coeng	1000
+償	coeng	0%
+償	soeng	1000
 呛	coeng
-唱	coeng
-嗆	coeng
+唱	coeng	1000
+嗆	coeng	500
 囪	coeng
 囪	cung
-囱	coeng
-囱	cung
+囱	coeng	0%
+囱	cung	1000
 场	coeng
-場	coeng
+場	coeng	1000
 塲	coeng
 墙	coeng
 墻	coeng
-娼	coeng
+娼	coeng	500
 嫱	coeng
 嬙	coeng
-庠	coeng
+庠	coeng	500
 廧	coeng
 怅	coeng
-悵	coeng
-悵	zoeng
-戕	coeng
+悵	coeng	500
+悵	zoeng	500
+戕	coeng	500
 戗	coeng
 戧	coeng
 抢	coeng
-搶	coeng
-搶	cong
+搶	coeng	1000
+搶	cong	0%
 斨	coeng
-昌	coeng
+昌	coeng	1000
 枪	coeng
-槍	coeng
+槍	coeng	1000
 樯	coeng
 檣	coeng
 炝	coeng
 熗	coeng
 牄	coeng
-牆	coeng
+牆	coeng	1000
 牕	coeng
-猖	coeng
+猖	coeng	500
 玱	coeng
 瑒	coeng
 瑒	dong
@@ -3845,22 +3845,22 @@ min_phrase_weight: 100
 磢	coeng
 磢	cong
 磢	saang
-祥	coeng
+祥	coeng	1000
 窓	coeng
-窗	coeng
+窗	coeng	1000
 窻	coeng
 羥	coeng
 羥	koeng
-翔	coeng
+翔	coeng	1000
 肠	coeng
-腸	coeng
+腸	coeng	1000
 苌	coeng
 菖	coeng
 萇	coeng
 蔷	coeng
-薔	coeng
+薔	coeng	500
 蘠	coeng
-詳	coeng
+詳	coeng	1000
 謒	coeng
 详	coeng
 跄	coeng
@@ -3869,11 +3869,11 @@ min_phrase_weight: 100
 錆	coeng
 錩	coeng
 鎗	coeng
-鏘	coeng
+鏘	coeng	500
 锠	coeng
 锵	coeng
-長	coeng
-長	zoeng
+長	coeng	1000
+長	zoeng	1000
 长	coeng
 长	zoeng
 閶	coeng
@@ -3893,29 +3893,29 @@ min_phrase_weight: 100
 䴭	coi
 啋	coi
 埰	coi
-塞	coi
-塞	sak
+塞	coi	1000
+塞	sak	1000
 寀	coi
-彩	coi
-才	coi
-採	coi
-材	coi
-睬	coi
-綵	coi
+彩	coi	1000
+才	coi	1000
+採	coi	1000
+材	coi	1000
+睬	coi	1000
+綵	coi	1000
 縩	coi
 縩	zoi
 纔	coi
 茞	coi
 茞	zi
-菜	coi
-蔡	coi
-裁	coi
-財	coi
-賽	coi
+菜	coi	1000
+蔡	coi	1000
+裁	coi	1000
+財	coi	1000
+賽	coi	1000
 财	coi
 赛	coi
 跴	coi
-采	coi
+采	coi	1000
 䥘	cok
 䥘	cou
 䱜	cok
@@ -3935,43 +3935,43 @@ min_phrase_weight: 100
 䡴	cung
 䭚	cong
 仓	cong
-倉	cong
+倉	cong	1000
 凔	cong
 创	cong
 刱	cong
-創	cong
+創	cong	1000
 厰	cong
-幢	cong
-幢	tong
-幢	zong
+幢	cong	0%
+幢	tong	0%
+幢	zong	1000
 床	cong
-廠	cong
+廠	cong	1000
 怆	cong
 惝	cong
 惝	tong
-愴	cong
+愴	cong	500
 戃	cong
 戃	tong
-撞	cong
-撞	zong
-敞	cong
+撞	cong	0%
+撞	zong	1000
+敞	cong	1000
 昶	cong
 橦	cong
 橦	tung
 氅	cong
 沧	cong
-滄	cong
-牀	cong
+滄	cong	1000
+牀	cong	1000
 疮	cong
-瘡	cong
+瘡	cong	1000
 舱	cong
-艙	cong
+艙	cong	1000
 苍	cong
-蒼	cong
-藏	cong
-藏	zong
+蒼	cong	1000
+藏	cong	1000
+藏	zong	1000
 鋹	cong
-闖	cong
+闖	cong	1000
 闯	cong
 駔	cong
 駔	zong
@@ -3999,46 +3999,46 @@ min_phrase_weight: 100
 傮	zou
 厝	cou
 喿	cou
-嘈	cou
-噪	cou
+嘈	cou	1000
+噪	cou	1000
 徂	cou
 慅	cou
 慅	sou
 慥	cou
 慥	zou
 懆	cou
-措	cou
-措	zaak
-操	cou
-曹	cou
-槽	cou
+措	cou	1000
+措	zaak	0%
+操	cou	1000
+曹	cou	1000
+槽	cou	1000
 殂	cou
 氉	cou
 氉	so
-漕	cou
-澡	cou
-澡	zou
-燥	cou
+漕	cou	500
+澡	cou	1000
+澡	zou	1000
+燥	cou	1000
 矂	cou
-粗	cou
-糙	cou
+粗	cou	1000
+糙	cou	1000
 艚	cou
 艸	cou
-草	cou
+草	cou	1000
 螬	cou
 觕	cou
 譟	cou
 趮	cou
 跿	cou
 跿	tou
-躁	cou
-造	cou
-造	zou
+躁	cou	1000
+造	cou	1000
+造	zou	1000
 鄵	cou
 酢	cou
 酢	zaa
 酢	zok
-醋	cou
+醋	cou	1000
 騲	cou
 鰽	cou
 麤	cou
@@ -4071,7 +4071,7 @@ min_phrase_weight: 100
 䠞	cuk
 䩳	cuk
 亍	cuk
-促	cuk
+促	cuk	1000
 俶	cuk
 俶	suk
 俶	tik
@@ -4083,7 +4083,7 @@ min_phrase_weight: 100
 搐	cuk
 敊	cuk
 斶	cuk
-束	cuk
+束	cuk	1000
 樕	cuk
 樕	sok
 歜	cuk
@@ -4091,34 +4091,34 @@ min_phrase_weight: 100
 滀	cuk
 琡	cuk
 琡	zyut
-畜	cuk
+畜	cuk	1000
 瘯	cuk
-矗	cuk
-簇	cuk
+矗	cuk	1000
+簇	cuk	1000
 簌	cuk
-蓄	cuk
+蓄	cuk	1000
 蔌	cuk
 蔟	cuk
 触	cuk
 触	zuk
 觫	cuk
-觸	cuk
-觸	zuk
+觸	cuk	0%
+觸	zuk	1000
 諔	cuk
 諔	suk
 豖	cuk
 豖	doek
 踧	cuk
 踧	dik
-蹙	cuk
+蹙	cuk	500
 蹴	cuk
 蹵	cuk
-速	cuk
+速	cuk	1000
 遫	cuk
 鄐	cuk
 顣	cuk
 餗	cuk
-齪	cuk
+齪	cuk	500
 齱	cuk
 齱	zau
 龊	cuk
@@ -4167,20 +4167,20 @@ min_phrase_weight: 100
 䳷	cung
 丛	cung
 从	cung
-充	cung
-冢	cung
+充	cung	1000
+冢	cung	1000
 冲	cung
-匆	cung
-叢	cung
+匆	cung	1000
+叢	cung	1000
 埇	cung
 埇	jung
 埇	tung
-塚	cung
+塚	cung	500
 宠	cung
-寵	cung
-從	cung
-從	sung
-從	zung
+寵	cung	1000
+從	cung	1000
+從	sung	1000
+從	zung	0%
 忡	cung
 怱	cung
 悤	cung
@@ -4190,19 +4190,19 @@ min_phrase_weight: 100
 慒	zou
 憃	cung
 憃	zung
-憧	cung
-憧	tung
+憧	cung	1000
+憧	tung	0%
 揰	cung
 摐	cung
-松	cung
+松	cung	1000
 枞	cung
 樅	cung
-沖	cung
+沖	cung	1000
 浺	cung
-涌	cung
-涌	jung
-淙	cung
-淙	zung
+涌	cung	500
+涌	jung	500
+淙	cung	500
+淙	zung	500
 漎	cung
 漎	sung
 潀	cung
@@ -4220,22 +4220,22 @@ min_phrase_weight: 100
 翀	zung
 聦	cung
 聪	cung
-聰	cung
+聰	cung	1000
 苁	cung
 茺	cung
-葱	cung
+葱	cung	1000
 蓯	cung
 蔥	cung
 藂	cung
-虫	cung
-虫	wai
-蟲	cung
-衝	cung
-衷	cung
-衷	zung
+虫	cung	500
+虫	wai	500
+蟲	cung	1000
+衝	cung	1000
+衷	cung	1000
+衷	zung	0%
 賨	cung
-重	cung
-重	zung
+重	cung	1000
+重	zung	1000
 銃	cung
 鏦	cung
 铳	cung
@@ -4264,42 +4264,42 @@ min_phrase_weight: 100
 䣝	cyu
 䣝	tou
 伫	cyu
-佇	cyu
+佇	cyu	500
 储	cyu
-儲	cyu
+儲	cyu	1000
 処	cyu
 处	cyu
 宁	cyu
 幮	cyu
-曙	cyu
-曙	syu
-杵	cyu
+曙	cyu	1000
+曙	syu	0%
+杵	cyu	1000
 杼	cyu
-柱	cyu
+柱	cyu	1000
 楮	cyu
 橱	cyu
-櫥	cyu
+櫥	cyu	1000
 滁	cyu
 砫	cyu
 砫	zyu
 竚	cyu
 紵	cyu
 纻	cyu
-署	cyu
-署	syu
+署	cyu	1000
+署	syu	0%
 羜	cyu
 芧	cyu
 芧	seoi
 芧	zeoi
 苎	cyu
-苧	cyu
-處	cyu
-處	syu
-褚	cyu
-貯	cyu
+苧	cyu	500
+處	cyu	1000
+處	syu	0%
+褚	cyu	500
+貯	cyu	1000
 贮	cyu
 蹰	cyu
-躇	cyu
+躇	cyu	500
 躕	cyu
 麆	cyu
 㒰	cyun
@@ -4324,26 +4324,26 @@ min_phrase_weight: 100
 䞼	zan
 䞼	zat
 䰖	cyun
-串	cyun
-串	gwaan	0%
+串	cyun	1000
+串	gwaan	0
 传	cyun
 佺	cyun
-傳	cyun
-傳	zyun
-全	cyun
+傳	cyun	1000
+傳	zyun	1000
+全	cyun	1000
 刌	cyun
-吋	cyun
-喘	cyun
+吋	cyun	1000
+喘	cyun	1000
 圌	cyun
 圌	seoi
-存	cyun
-寸	cyun
+存	cyun	1000
+寸	cyun	1000
 巑	cyun
-川	cyun
-忖	cyun
+川	cyun	1000
+忖	cyun	500
 恮	cyun
-惴	cyun
-惴	zeoi
+惴	cyun	500
+惴	zeoi	500
 撺	cyun
 攅	cyun
 攒	cyun
@@ -4351,7 +4351,7 @@ min_phrase_weight: 100
 攛	cyun
 攢	cyun
 攢	zaan
-村	cyun
+村	cyun	1000
 椽	cyun
 欑	cyun
 欑	zaan
@@ -4359,29 +4359,29 @@ min_phrase_weight: 100
 氚	cyun
 汆	cyun
 汆	tan
-泉	cyun
-爨	cyun
+泉	cyun	1000
+爨	cyun	500
 牷	cyun
 玔	cyun
-痊	cyun
-穿	cyun
+痊	cyun	1000
+穿	cyun	1000
 窜	cyun
-竄	cyun
+竄	cyun	1000
 筌	cyun
 縓	cyun
 縓	jyun
-舛	cyun
-荃	cyun
+舛	cyun	500
+荃	cyun	500
 荈	cyun
-詮	cyun
+詮	cyun	500
 譐	cyun
 诠	cyun
 跧	cyun
 踆	cyun
 踆	seon
 踆	zeon
-蹲	cyun
-蹲	deon
+蹲	cyun	1000
+蹲	deon	1000
 蹿	cyun
 躥	cyun
 輇	cyun
@@ -4389,11 +4389,11 @@ min_phrase_weight: 100
 遄	cyun
 邨	cyun
 醛	cyun
-釧	cyun
+釧	cyun	500
 鉆	cyun
 鉆	kim
 鉆	zyun
-銓	cyun
+銓	cyun	500
 鋑	cyun
 鋑	zeon
 钏	cyun
@@ -4413,13 +4413,13 @@ min_phrase_weight: 100
 䯿	zeot
 䱣	cyut
 䱣	zeot
-卒	cyut
-卒	zeot
-咄	cyut
-咄	deot
+卒	cyut	0%
+卒	zeot	1000
+咄	cyut	500
+咄	deot	500
 捽	cyut
 捽	zeot
-撮	cyut
+撮	cyut	500
 椊	cyut
 椊	zyut
 猝	cyut
@@ -4429,7 +4429,7 @@ min_phrase_weight: 100
 踤	seoi
 踤	zeot
 𠾼	cyut
-打	daa
+打	daa	1000
 㐲	daai
 㗣	daai
 㗣	taai
@@ -4471,12 +4471,12 @@ min_phrase_weight: 100
 䲦	daai
 傣	daai
 傣	taai
-呆	daai
-呆	ngoi
-大	daai
+呆	daai	1000
+呆	ngoi	1000
+大	daai	1000
 带	daai
-帶	daai
-戴	daai
+帶	daai	1000
+戴	daai	1000
 歺	daai
 汏	daai
 獃	daai
@@ -4516,7 +4516,7 @@ min_phrase_weight: 100
 䱋	daam
 䱋	gung
 儋	daam
-啖	daam
+啖	daam	500
 啗	daam
 噉	daam
 噉	gam	1000
@@ -4524,31 +4524,31 @@ min_phrase_weight: 100
 嚪	taam
 憺	daam
 担	daam
-擔	daam
-氮	daam
-淡	daam
-淡	taam
-湛	daam
-湛	zaam
-澹	daam
-澹	taam
+擔	daam	1000
+氮	daam	500
+淡	daam	1000
+淡	taam	501
+湛	daam	500
+湛	zaam	500
+澹	daam	500
+澹	taam	500
 甔	daam
 眈	daam
-石	daam
-石	sek
+石	daam	200
+石	sek	1000
 禫	daam
 禫	taam
 窞	daam
 紞	daam
-耽	daam
+耽	daam	1000
 聃	daam
 胆	daam
-膽	daam
+膽	daam	1000
 萏	daam
 賧	daam
 賧	zin
 贱	daam
-躭	daam
+躭	daam	500
 酖	daam
 酖	zam
 霮	daam
@@ -4570,25 +4570,25 @@ min_phrase_weight: 100
 䐷	daan
 䒟	daan
 䜥	daan
-丹	daan
-但	daan
+丹	daan	1000
+但	daan	1000
 僤	daan
 勯	daan
 匰	daan
 单	daan
-單	daan
-單	sin
+單	daan	1000
+單	sin	200
 弹	daan
 弹	taan
-彈	daan
-彈	taan
+彈	daan	1000
+彈	taan	1000
 惮	daan
-憚	daan
+憚	daan	500
 掸	daan
 掸	sin
 撣	daan
 撣	sin
-旦	daan
+旦	daan	1000
 殚	daan
 殫	daan
 狚	daan
@@ -4597,12 +4597,12 @@ min_phrase_weight: 100
 癉	daan
 癉	taan
 箪	daan
-簞	daan
+簞	daan	500
 繵	daan
-蛋	daan
+蛋	daan	1000
 蜑	daan
 襌	daan
-誕	daan
+誕	daan	1000
 诞	daan
 郸	daan
 鄲	daan
@@ -4634,18 +4634,18 @@ min_phrase_weight: 100
 傝	taap
 匒	daap
 嚃	daap
-搭	daap
+搭	daap	1000
 沓	daap
 畣	daap
-疊	daap
-疊	dip
-瘩	daap
-答	daap
+疊	daap	501
+疊	dip	1000
+瘩	daap	500
+答	daap	1000
 耷	daap
 荅	daap
 褡	daap
-踏	daap
-蹋	daap
+踏	daap	1000
+蹋	daap	500
 遝	daap
 錔	daap
 錔	taap
@@ -4664,19 +4664,19 @@ min_phrase_weight: 100
 妲	daat
 妲	taan
 怛	daat
-撻	daat
-撻	taat
+撻	daat	501
+撻	taat	1000
 笪	daat
 繨	daat
 荙	daat
 薘	daat
-躂	daat
-躂	taat
+躂	daat	500
+躂	taat	500
 达	daat
-達	daat
-達	taat
+達	daat	1000
+達	taat	0%
 鐽	daat
-靼	daat
+靼	daat	500
 𢴈	daat
 㛒	daau
 㛒	zaau
@@ -4704,76 +4704,76 @@ min_phrase_weight: 100
 䣌	dai
 䱥	dai
 䱥	zaai
-低	dai
+低	dai	1000
 埭	dai
 埭	doi
 墆	dai
 墆	dit
-娣	dai
-娣	tai
+娣	dai	500
+娣	tai	500
 嵽	dai
 嵽	dit
-帝	dai
-底	dai
-弟	dai
-弟	tai
+帝	dai	1000
+底	dai	1000
+弟	dai	1000
+弟	tai	0%
 弤	dai
 彽	dai
-悌	dai
-悌	tai
-提	dai
-提	tai
+悌	dai	500
+悌	tai	500
+提	dai	0%
+提	tai	1000
 揥	dai
 揥	tai
 揥	zaai
 杕	dai
 柢	dai
-棣	dai
-氐	dai
+棣	dai	500
+氐	dai	500
 渧	dai
-牴	dai
+牴	dai	500
 睼	dai
 睼	tai
-砥	dai
-砥	zi
+砥	dai	500
+砥	zi	500
 碲	dai
 磾	dai
 禘	dai
 笫	dai
 笫	zi
-第	dai
-締	dai
-締	tai
+第	dai	1000
+締	dai	1000
+締	tai	0%
 缔	dai
 羝	dai
 胝	dai
 胝	zi
-蒂	dai
+蒂	dai	1000
 蝃	dai
 螮	dai
 袛	dai
 袛	zi
 觝	dai
-詆	dai
-諦	dai
+詆	dai	500
+諦	dai	500
 诋	dai
 谛	dai
 踶	dai
 踶	tai
 軧	dai
 递	dai
-逮	dai
-逮	doi
-遞	dai
+逮	dai	1000
+逮	doi	0%
+遞	dai	1000
 遰	dai
 遰	sai
-邸	dai
+邸	dai	500
 阺	dai
 隶	dai
 隷	dai
 隷	lai
-隸	dai
-隸	lai
+隸	dai	1000
+隸	lai	0%
 鞮	dai
 鷤	dai
 鷤	taan
@@ -4781,11 +4781,11 @@ min_phrase_weight: 100
 㝶	dak
 㥁	dak
 䙸	dak
-得	dak
-德	dak
+得	dak	1000
+德	dak	1000
 悳	dak
 淂	dak
-特	dak
+特	dak	1000
 犆	dak
 犆	dat
 犆	zik
@@ -4836,13 +4836,13 @@ min_phrase_weight: 100
 撴	dan
 炖	dan
 炖	deon
-燉	dan
-燉	deon
+燉	dan	500
+燉	deon	500
 礅	dan
 礅	deon
 趸	dan
 蹾	dan
-躉	dan
+躉	dan	500
 𣎴	dan
 㲪	dang
 㽅	dang
@@ -4852,25 +4852,25 @@ min_phrase_weight: 100
 䠬	dang
 䮴	dang
 䳾	dang
-凳	dang
+凳	dang	1000
 噔	dang
 墱	dang
 崂	dang
 嶗	dang
 嶗	lou
-嶝	dang
+嶝	dang	500
 戥	dang
 櫈	dang
 灯	dang
-燈	dang
-登	dang
-磴	dang
-等	dang
+燈	dang	1000
+登	dang	1000
+磴	dang	500
+等	dang	1000
 簦	dang
 豋	dang
-蹬	dang
+蹬	dang	500
 邓	dang
-鄧	dang
+鄧	dang	1000
 鐙	dang
 镫	dang
 㗳	dap
@@ -4901,11 +4901,11 @@ min_phrase_weight: 100
 𦖿	dap
 䩢	dat
 䩢	dik
-凸	dat
-凸	gu
+凸	dat	1000
+凸	gu	0%
 怢	dat
 揬	dat
-突	dat
+突	dat	1000
 腯	dat
 葖	dat
 蟘	dat
@@ -4916,52 +4916,52 @@ min_phrase_weight: 100
 㪷	dau
 㿡	dau
 䬦	dau
-兜	dau
+兜	dau	1000
 哣	dau
 唗	dau
 唞	dau
 唞	tau
-抖	dau
-斗	dau
+抖	dau	1000
+斗	dau	1000
 枓	dau
 枓	zyu
 梪	dau
 浢	dau
-痘	dau
+痘	dau	1000
 窦	dau
-竇	dau
+竇	dau	500
 篼	dau
-糾	dau
-糾	gau
+糾	dau	0%
+糾	gau	1000
 脰	dau
 荳	dau
 蔸	dau
-蚪	dau
-讀	dau
-讀	duk
-豆	dau
-赳	dau
-赳	gau
-逗	dau
+蚪	dau	500
+讀	dau	0%
+讀	duk	1000
+豆	dau	1000
+赳	dau	1000
+赳	gau	1000
+逗	dau	1000
 郖	dau
 鈄	dau
 鋀	dau
 钭	dau
-陡	dau
+陡	dau	1000
 餖	dau
 饾	dau
-鬥	dau
+鬥	dau	1000
 鬦	dau
 鬪	dau
 鬭	dau
 𠻼	dau
 𢭃	dau
 嗲	de
-爹	de
+爹	de	500
 哋	dei	10000
 哋	di
-地	dei
-地	deng
+地	dei	1000
+地	deng	200
 墬	dei
 墬	zeoi
 㣙	dek
@@ -4971,27 +4971,27 @@ min_phrase_weight: 100
 㰅	zak
 䊮	dek
 䨀	dek
-笛	dek
+笛	dek	1000
 篴	dek
 篴	dik
 籴	dek
 糴	dek
 埞	deng	1000
 掟	deng	1000
-定	deng
-定	ding
+定	deng	501
+定	ding	1000
 疔	deng
 疔	ding
 矴	deng
 矴	ding
-訂	deng
-訂	ding
-釘	deng
-釘	ding
+訂	deng	501
+訂	ding	1000
+釘	deng	1000
+釘	ding	0%
 钉	deng
 钉	ding
-頂	deng
-頂	ding
+頂	deng	501
+頂	ding	1000
 顶	deng
 顶	ding
 㒛	deoi
@@ -5037,19 +5037,19 @@ min_phrase_weight: 100
 䭔	deoi
 䯟	deoi
 兌	deoi
-兑	deoi
+兑	deoi	1000
 嚉	deoi
-堆	deoi
-堆	zeoi
+堆	deoi	1000
+堆	zeoi	0%
 对	deoi
-對	deoi
+對	deoi	1000
 怼	deoi
 怼	zeoi
 憝	deoi
 懟	deoi
 懟	zeoi
-敦	deoi
-敦	deon
+敦	deoi	0%
+敦	deon	1000
 碓	deoi
 祋	deoi
 祋	doi
@@ -5064,7 +5064,7 @@ min_phrase_weight: 100
 鐓	deoi
 鐓	deon
 队	deoi
-隊	deoi
+隊	deoi	1000
 駾	deoi
 駾	teoi
 𠂤	deoi
@@ -5083,33 +5083,33 @@ min_phrase_weight: 100
 伅	deon
 吨	deon
 吨	zeon
-噸	deon
-囤	deon
-囤	tyun
+噸	deon	1000
+囤	deon	500
+囤	tyun	500
 惇	deon
-沌	deon
-盹	deon
+沌	deon	500
+盹	deon	500
 蜳	deon
-諄	deon
-諄	zeon
-遁	deon
+諄	deon	500
+諄	zeon	500
+遁	deon	500
 遯	deon
-鈍	deon
+鈍	deon	1000
 钝	deon
 镦	deon
-頓	deon
-頓	duk
+頓	deon	1000
+頓	duk	0%
 顿	deon
 顿	duk
 𥫱	deon
 㘞	deot
 柮	deot
-掉	deu
-掉	diu
-掉	zaau
-調	deu
-調	diu
-調	tiu
+掉	deu	501
+掉	diu	1000
+掉	zaau	0%
+調	deu	501
+調	diu	1000
+調	tiu	1000
 啲	di	10000
 啲	dit
 㢩	dik
@@ -5124,26 +5124,26 @@ min_phrase_weight: 100
 䨤	dik
 䯼	dik
 䴞	dik
-嘀	dik
-嫡	dik
+嘀	dik	500
+嫡	dik	500
 掦	dik
 敌	dik
-敵	dik
+敵	dik	1000
 旳	dik
 浟	dik
 浟	jau
 涤	dik
-滌	dik
-滴	dik
-狄	dik
+滌	dik	1000
+滴	dik	1000
+狄	dik	500
 玓	dik
 甋	dik
-的	dik
+的	dik	1000
 籊	dik
 籊	tik
-翟	dik
-翟	zaak
-荻	dik
+翟	dik	500
+翟	zaak	500
+荻	dik	500
 菂	dik
 藋	dik
 藋	diu
@@ -5154,12 +5154,12 @@ min_phrase_weight: 100
 豴	dik
 蹢	dik
 蹢	zaak
-迪	dik
-適	dik
-適	sik
+迪	dik	1000
+適	dik	0%
+適	sik	1000
 鍉	dik
 鍉	si
-鏑	dik
+鏑	dik	500
 镝	dik
 靮	dik
 鸐	dik
@@ -5173,16 +5173,16 @@ min_phrase_weight: 100
 㼭	dim
 䍄	dim
 坫	dim
-墊	dim
-墊	din
-墊	zin
-店	dim
-惦	dim
+墊	dim	0%
+墊	din	1000
+墊	zin	501
+店	dim	1000
+惦	dim	1000
 扂	dim
 掂	dim
 敁	dim
 点	dim
-玷	dim
+玷	dim	500
 痁	dim
 磹	dim
 磹	taam
@@ -5190,7 +5190,7 @@ min_phrase_weight: 100
 踮	dim
 阽	dim
 阽	jim
-點	dim
+點	dim	1000
 𠶧	dim
 㒹	din
 㙉	din
@@ -5199,28 +5199,28 @@ min_phrase_weight: 100
 㹠	din
 㹠	tyun
 䓦	din
-佃	din
-佃	tin
+佃	din	500
+佃	tin	500
 傎	din
-典	din
+典	din	1000
 垫	din
-奠	din
+奠	din	500
 巅	din
 巓	din
-巔	din
-殿	din
+巔	din	500
+殿	din	1000
 淀	din
-滇	din
-滇	tin
-澱	din
+滇	din	500
+滇	tin	500
+澱	din	1000
 电	din
-甸	din
+甸	din	1000
 痶	din
 瘨	din
 癜	din
 癫	din
-癲	din
-碘	din
+癲	din	500
+碘	din	500
 蕇	din
 蜔	din
 蹎	din
@@ -5228,10 +5228,10 @@ min_phrase_weight: 100
 鈿	tin
 钿	din
 钿	tin
-電	din
-靛	din
+電	din	1000
+靛	din	500
 顚	din
-顛	din
+顛	din	1000
 颠	din
 齻	din
 㓅	ding
@@ -5243,35 +5243,35 @@ min_phrase_weight: 100
 䟓	ding
 䵺	ding
 䵺	ting
-丁	ding
-丁	zaang
-丁	zang	0%
-仃	ding
-叮	ding
+丁	ding	1000
+丁	zaang	0%
+丁	zang	0
+仃	ding	500
+叮	ding	1000
 啶	ding
 圢	ding
 圢	ting
 椗	ding
-汀	ding
-汀	ting
+汀	ding	500
+汀	ting	500
 濎	ding
 濎	ting
 玎	ding
-盯	ding
+盯	ding	1000
 碇	ding
 耵	ding
 耵	ting
 艼	ding
 薡	ding
 订	ding
-酊	ding
-錠	ding
+酊	ding	500
+錠	ding	500
 锭	ding
 靪	ding
 顁	ding
 飣	ding
 饤	ding
-鼎	ding
+鼎	ding	1000
 㑙	dip
 㜼	dip
 㜼	zaat
@@ -5295,7 +5295,7 @@ min_phrase_weight: 100
 叠	dip
 啑	dip
 啑	saap
-喋	dip
+喋	dip	500
 堞	dip
 惵	dip
 揲	dip
@@ -5303,16 +5303,16 @@ min_phrase_weight: 100
 揲	sit
 楪	dip
 楪	jip
-牒	dip
-碟	dip
+牒	dip	500
+碟	dip	1000
 艓	dip
 蜨	dip
-蝶	dip
+蝶	dip	1000
 褋	dip
-褶	dip
-褶	zaap
-褶	zip
-諜	dip
+褶	dip	500
+褶	zaap	500
+褶	zip	500
+諜	dip	1000
 谍	dip
 蹀	dip
 鍱	dip
@@ -5336,7 +5336,7 @@ min_phrase_weight: 100
 柣	dit
 瓞	dit
 眣	dit
-秩	dit
+秩	dit	1000
 紩	dit
 紩	zat
 絰	dit
@@ -5350,10 +5350,10 @@ min_phrase_weight: 100
 螲	zat
 袟	dit
 詄	dit
-跌	dit
-軼	dit
-軼	jat
-迭	dit
+跌	dit	1000
+軼	dit	500
+軼	jat	500
+迭	dit	500
 㓮	diu
 㚋	diu
 㚋	niu
@@ -5375,23 +5375,23 @@ min_phrase_weight: 100
 䥫	diu
 䥫	tit
 䳂	diu
-丟	diu
+丟	diu	1000
 丢	diu
-凋	diu
-刁	diu
-叼	diu
-吊	diu
+凋	diu	1000
+刁	diu	500
+叼	diu	1000
+吊	diu	1000
 屌	diu
-弔	diu
-彫	diu
-彫	tiu
+弔	diu	1000
+彫	diu	500
+彫	tiu	500
 扚	diu
 琱	diu
 盄	diu
-碉	diu
+碉	diu	500
 窎	diu
-窕	diu
-窕	tiu
+窕	diu	500
+窕	tiu	500
 窵	diu
 罀	diu
 蓧	diu
@@ -5401,8 +5401,8 @@ min_phrase_weight: 100
 誂	tiu
 调	diu
 调	tiu
-貂	diu
-釣	diu
+貂	diu	500
+釣	diu	1000
 銚	diu
 銚	jiu
 銚	siu
@@ -5411,7 +5411,7 @@ min_phrase_weight: 100
 钓	diu
 铥	diu
 铫	diu
-雕	diu
+雕	diu	1000
 鯛	diu
 鲷	diu
 鵰	diu
@@ -5438,25 +5438,25 @@ min_phrase_weight: 100
 䴱	to
 亸	do
 刴	do
-剁	do
-剁	doek
+剁	do	500
+剁	doek	500
 嚲	do
 垛	do
 垜	do
 埵	do
 堕	do
-墮	do
-墮	fai
+墮	do	1000
+墮	fai	0%
 墯	do
 墯	fai
-多	do
+多	do	1000
 嶞	do
-惰	do
-朵	do
-朵	doe
-跺	do
+惰	do	1000
+朵	do	1000
+朵	doe	0%
+跺	do	500
 躱	do
-躲	do
+躲	do	1000
 陊	do
 鬌	do
 𥞛	do
@@ -5471,8 +5471,8 @@ min_phrase_weight: 100
 䐁	doek
 䐁	duk
 䐁	zaa
-啄	doek
-啄	doeng
+啄	doek	1000
+啄	doeng	0%
 啅	doek
 噣	doek
 噣	zau
@@ -5480,46 +5480,46 @@ min_phrase_weight: 100
 斲	doek
 椓	doek
 涿	doek
-琢	doek
+琢	doek	1000
 諑	doek
 诼	doek
 𡁷	doeng
 㻖	doi
 䒫	doi
-代	doi
+代	doi	1000
 偫	doi
 偫	zi
-岱	doi
+岱	doi	500
 帒	doi
-待	doi
-怠	doi
-怠	toi
-殆	doi
-殆	toi
-玳	doi
+待	doi	1000
+怠	doi	0%
+怠	toi	1000
+殆	doi	0%
+殆	toi	1000
+玳	doi	500
 瑇	doi
 紿	doi
 绐	doi
 蝳	doi
-袋	doi
+袋	doi	1000
 迨	doi
 酨	doi
 酨	zoi
 靆	doi
-黛	doi
+黛	doi	1000
 㡯	dok
 㡯	dou
 㡯	saam
 㡯	zak
 剫	dok
-度	dok
-度	dou
+度	dok	1000
+度	dou	1000
 襗	dok
 襗	jik
 襗	zaak
-踱	dok
-鐸	dok
-鐸	nok
+踱	dok	1000
+鐸	dok	500
+鐸	nok	500
 铎	dok
 㼕	dong
 㽆	dong
@@ -5527,7 +5527,7 @@ min_phrase_weight: 100
 䣣	dong
 䦒	dong
 党	dong
-噹	dong
+噹	dong	500
 婸	dong
 宕	dong
 当	dong
@@ -5536,10 +5536,10 @@ min_phrase_weight: 100
 戙	dong
 戙	dung
 挡	dong
-擋	dong
+擋	dong	1000
 攩	dong
 档	dong
-檔	dong
+檔	dong	1000
 欓	dong
 潒	dong
 玚	dong
@@ -5547,9 +5547,9 @@ min_phrase_weight: 100
 璗	dong
 璫	dong
 瓽	dong
-當	dong
-盪	dong
-盪	tong
+當	dong	1000
+盪	dong	1000
+盪	tong	0%
 砀	dong
 碭	dong
 筜	dong
@@ -5558,10 +5558,10 @@ min_phrase_weight: 100
 艡	dong
 荡	dong
 菪	dong
-蕩	dong
+蕩	dong	1000
 蟷	dong
 裆	dong
-襠	dong
+襠	dong	500
 讜	dong
 谠	dong
 踼	dong
@@ -5570,7 +5570,7 @@ min_phrase_weight: 100
 逿	tong
 钂	dong
 钂	tong
-黨	dong
+黨	dong	1000
 鼞	dong
 鼞	tong
 㓃	dou
@@ -5590,49 +5590,49 @@ min_phrase_weight: 100
 䩲	dou
 䬰	dou
 䬰	siu
-倒	dou
-刀	dou
-到	dou
-叨	dou
-叨	tou
+倒	dou	1000
+刀	dou	1000
+到	dou	1000
+叨	dou	500
+叨	tou	500
 喥	dou
-嘟	dou
-堵	dou
+嘟	dou	500
+堵	dou	1000
 壔	dou
-妒	dou
+妒	dou	1000
 妬	dou
 导	dou
-導	dou
+導	dou	1000
 岛	dou
-島	dou
+島	dou	1000
 帾	dou
 忉	dou
 忉	tou
-悼	dou
+悼	dou	1000
 捣	dou
 捯	dou
-搗	dou
+搗	dou	1000
 擣	dou
 斁	dou
 斁	jik
-杜	dou
+杜	dou	1000
 氘	dou
-渡	dou
+渡	dou	1000
 焘	dou
 焘	tou
 燾	dou
 燾	tou
 盗	dou
-盜	dou
-睹	dou
+盜	dou	1000
+睹	dou	1000
 禂	dou
 禂	tou
-禱	dou
-禱	tou
+禱	dou	0%
+禱	tou	1000
 秺	dou
 稌	dou
 稌	tou
-稻	dou
+稻	dou	1000
 纛	dou
 纛	duk
 翿	dou
@@ -5640,15 +5640,15 @@ min_phrase_weight: 100
 舠	dou
 艔	dou
 芏	dou
-蠹	dou
+蠹	dou	500
 覩	dou
-賭	dou
+賭	dou	1000
 赌	dou
-蹈	dou
-蹈	tou
-道	dou
-都	dou
-鍍	dou
+蹈	dou	1000
+蹈	tou	0%
+道	dou	1000
+都	dou	1000
+鍍	dou	500
 镀	dou
 闍	dou
 闍	se
@@ -5671,22 +5671,22 @@ min_phrase_weight: 100
 厾	duk
 叾	duk
 椟	duk
-櫝	duk
+櫝	duk	500
 殰	duk
-毒	duk
+毒	duk	1000
 渎	duk
-瀆	duk
+瀆	duk	500
 牍	duk
-牘	duk
+牘	duk	500
 犊	duk
-犢	duk
+犢	duk	500
 独	duk
-獨	duk
+獨	duk	1000
 皾	duk
-督	duk
+督	duk	1000
 碡	duk
 笃	duk
-篤	duk
+篤	duk	500
 裻	duk
 襡	duk
 襡	suk
@@ -5697,7 +5697,7 @@ min_phrase_weight: 100
 韣	duk
 髑	duk
 黩	duk
-黷	duk
+黷	duk	500
 𡰪	duk
 𢽴	duk
 𦢌	duk
@@ -5721,31 +5721,31 @@ min_phrase_weight: 100
 东	dung
 侗	dung
 侗	tung
-冬	dung
+冬	dung	1000
 冻	dung
-凍	dung
+凍	dung	1000
 动	dung
-動	dung
-咚	dung
+動	dung	1000
+咚	dung	1000
 垌	dung
 垌	tung
 峒	dung
 峒	tung
 崠	dung
-恫	dung
-恫	tung
+恫	dung	500
+恫	tung	500
 恸	dung
-慟	dung
-懂	dung
+慟	dung	500
+懂	dung	1000
 挏	dung
 挏	tung
-東	dung
+東	dung	1000
 柊	dung
 柊	zung
 栋	dung
-棟	dung
+棟	dung	1000
 氡	dung
-洞	dung
+洞	dung	1000
 涷	dung
 湩	dung
 炵	dung
@@ -5753,22 +5753,22 @@ min_phrase_weight: 100
 畽	dung
 畽	teon
 硐	dung
-胴	dung
-董	dung
+胴	dung	500
+董	dung	1000
 蕫	dung
 蝀	dung
 衕	dung
 衕	tung
-踵	dung
-踵	zung
+踵	dung	500
+踵	zung	500
 迵	dung
 鮦	dung
 鮦	tung
 鮦	zau
 鶇	dung
 鸫	dung
-鼕	dung
-鼕	tung
+鼕	dung	500
+鼕	tung	500
 㫁	dyun
 㱭	dyun
 䠪	dyun
@@ -5779,31 +5779,31 @@ min_phrase_weight: 100
 剬	zai
 断	dyun
 断	tyun
-斷	dyun
-斷	tyun
+斷	dyun	1000
+斷	tyun	501
 椴	dyun
-段	dyun
+段	dyun	1000
 毈	dyun
 毈	wo
 煅	dyun
 煆	dyun
 煆	haa
-短	dyun
+短	dyun	1000
 碫	dyun
-端	dyun
+端	dyun	1000
 簖	dyun
 籪	dyun
-緞	dyun
+緞	dyun	500
 缎	dyun
 耑	dyun
 耑	zyun
 腶	dyun
-鍛	dyun
+鍛	dyun	1000
 鍜	dyun
 锻	dyun
 㣞	dyut
 夺	dyut
-奪	dyut
+奪	dyut	1000
 敓	dyut
 罬	dyut
 罬	zyut
@@ -5817,13 +5817,13 @@ min_phrase_weight: 100
 㩛	faa
 㩛	tyun
 㳸	faa
-化	faa
+化	faa	1000
 擭	faa
 擭	wok
 杹	faa
-花	faa
-華	faa
-華	waa
+花	faa	1000
+華	faa	0%
+華	waa	1000
 蘤	faa
 㕒	faai
 㕒	waai
@@ -5844,20 +5844,20 @@ min_phrase_weight: 100
 䘗	gwan
 䘗	pui
 䠊	faai
-傀	faai
-傀	gwai
+傀	faai	500
+傀	gwai	500
 哙	faai
 噲	faai
 块	faai
-塊	faai
-快	faai
+塊	faai	1000
+快	faai	1000
 磈	faai
-筷	faai
+筷	faai	1000
 𫂈	faai
-拂	faak
-拂	fat
-沸	faak
-沸	fai
+拂	faak	500
+拂	fat	500
+沸	faak	0%
+沸	fai	1000
 㕨	faan
 㖧	faan
 㠶	faan
@@ -5888,61 +5888,61 @@ min_phrase_weight: 100
 䴊	faan
 䴊	gon
 䴊	zi
-凡	faan
+凡	faan	1000
 凢	faan
-反	faan
+反	faan	1000
 墦	faan
-帆	faan
+帆	faan	1000
 幡	faan
 旛	faan
-梵	faan
-樊	faan
-氾	faan
+梵	faan	500
+樊	faan	500
+氾	faan	1000
 汎	faan
-泛	faan
+泛	faan	1000
 瀿	faan
 烦	faan
-煩	faan
+煩	faan	1000
 燔	faan
-犯	faan
+犯	faan	1000
 璠	faan
 畈	faan
 畨	faan
-番	faan
-番	pun
+番	faan	1000
+番	pun	0%
 矾	faan
-礬	faan
+礬	faan	500
 笲	faan
 笵	faan
-範	faan
-繁	faan
+範	faan	1000
+繁	faan	1000
 繙	faan
 羳	faan
-翻	faan
+翻	faan	1000
 膰	faan
-范	faan
-蕃	faan
+范	faan	500
+蕃	faan	500
 薠	faan
-藩	faan
+藩	faan	500
 蘩	faan
 蟠	faan
 蟠	pun
 蠜	faan
 覂	faan
 覂	fung
-販	faan
+販	faan	1000
 贩	faan
 蹯	faan
 軓	faan
 軬	faan
 轓	faan
-返	faan
+返	faan	1000
 釩	faan
 鋄	faan
 鐇	faan
 钒	faan
 颿	faan
-飯	faan
+飯	faan	1000
 饭	faan
 鷭	faan
 𠆩	faan
@@ -5977,13 +5977,13 @@ min_phrase_weight: 100
 发	faat
 沷	faat
 沷	fat
-法	faat
+法	faat	1000
 珐	faat
-琺	faat
-發	faat
-砝	faat
-砝	fat
-髮	faat
+琺	faat	500
+發	faat	1000
+砝	faat	500
+砝	fat	500
+髮	faat	1000
 𠵽	faat
 㕻	faau
 㕻	fu
@@ -6027,19 +6027,19 @@ min_phrase_weight: 100
 䶐	fai
 俷	fai
 俷	fei
-吠	fai
+吠	fai	1000
 废	fai
 廃	fai
-廢	fai
-徽	fai
+廢	fai	1000
+徽	fai	1000
 怫	fai
 怫	fat
 挥	fai
-揮	fai
+揮	fai	1000
 撝	fai
 昲	fai
 晖	fai
-暉	fai
+暉	fai	1000
 楎	fai
 楎	wan
 櫠	fai
@@ -6047,27 +6047,27 @@ min_phrase_weight: 100
 煇	wai
 疿	fai
 疿	fei
-痱	fai
-痱	fei
+痱	fai	500
+痱	fei	500
 癈	fai
 翬	fai
-肺	fai
+肺	fai	1000
 芾	fai
 芾	fat
-虧	fai
-虧	kwai
+虧	fai	0%
+虧	kwai	1000
 袆	fai
 袚	fai
 袚	fat
 褘	fai
 费	fai
-輝	fai
+輝	fai	1000
 辉	fai
 鐨	fai
 镄	fai
 隳	fai
 鰴	fai
-麾	fai
+麾	fai	500
 瞓	fan	1000
 㓩	fan
 㓩	hin
@@ -6104,24 +6104,24 @@ min_phrase_weight: 100
 僨	fan
 分	fan
 勋	fan
-勛	fan
+勛	fan	1000
 勳	fan
-吩	fan
-噴	fan
-噴	pan
+吩	fan	1000
+噴	fan	0%
+噴	pan	1000
 坆	fan
 坟	fan
-墳	fan
+墳	fan	1000
 奋	fan
-奮	fan
+奮	fan	1000
 妢	fan
-婚	fan
+婚	fan	1000
 幩	fan
-忿	fan
+忿	fan	1000
 惛	fan
 愤	fan
-憤	fan
-昏	fan
+憤	fan	1000
+昏	fan	1000
 曛	fan
 枌	fan
 棔	fan
@@ -6130,16 +6130,16 @@ min_phrase_weight: 100
 歕	fan
 歕	pan
 殙	fan
-氛	fan
-汾	fan
+氛	fan	1000
+汾	fan	500
 涽	fan
 濆	fan
 濆	pan
 瀵	fan
 焄	fan
-焚	fan
+焚	fan	1000
 熏	fan
-燻	fan
+燻	fan	500
 獯	fan
 痻	fan
 痻	man
@@ -6149,10 +6149,10 @@ min_phrase_weight: 100
 窨	jam
 籸	fan
 籸	saam
-粉	fan
+粉	fan	1000
 粪	fan
-糞	fan
-紛	fan
+糞	fan	1000
+紛	fan	1000
 緡	fan
 緡	man
 纁	fan
@@ -6163,20 +6163,20 @@ min_phrase_weight: 100
 羵	fan
 翂	fan
 臐	fan
-芬	fan
+芬	fan	1000
 荤	fan
-葷	fan
+葷	fan	500
 蒶	fan
 蕡	fan
-薰	fan
+薰	fan	1000
 蚡	fan
-訓	fan
+訓	fan	1000
 训	fan
 豮	fan
 豶	fan
 轒	fan
 酚	fan
-醺	fan
+醺	fan	500
 閽	fan
 阍	fan
 雰	fan
@@ -6205,8 +6205,8 @@ min_phrase_weight: 100
 䨚	fat
 䬍	fat
 䴯	fat
-乏	fat
-伐	fat
+乏	fat	1000
+伐	fat	1000
 刜	fat
 咈	fat
 唿	fat
@@ -6220,13 +6220,13 @@ min_phrase_weight: 100
 巿	fat
 巿	si
 帗	fat
-弗	fat
-彿	fat
-忽	fat
-惚	fat
+弗	fat	1000
+彿	fat	1000
+忽	fat	1000
+惚	fat	1000
 昒	fat
 曶	fat
-氟	fat
+氟	fat	500
 淴	fat
 狒	fat
 狒	fei
@@ -6235,20 +6235,20 @@ min_phrase_weight: 100
 祓	fat
 笏	fat
 笰	fat
-筏	fat
+筏	fat	500
 紱	fat
-紼	fat
+紼	fat	500
 绂	fat
 绋	fat
 罚	fat
-罰	fat
+罰	fat	1000
 艴	fat
 芴	fat
 芴	mat
 茀	fat
 茷	fat
 茷	pui
-閥	fat
+閥	fat	500
 阀	fat
 韍	fat
 韨	fat
@@ -6257,21 +6257,21 @@ min_phrase_weight: 100
 魆	jyut
 黻	fat
 𦡆	fat
-剖	fau
-剖	pau
-否	fau
-否	pei
+剖	fau	1000
+剖	pau	0%
+否	fau	1000
+否	pei	0%
 峊	fau
-復	fau
-復	fuk
-浮	fau
+復	fau	0%
+復	fuk	1000
+浮	fau	1000
 涪	fau
 烰	fau
 琈	fau
 稃	fau
 稃	fu
 紑	fau
-缶	fau
+缶	fau	500
 罘	fau
 罦	fau
 罦	fu
@@ -6280,13 +6280,13 @@ min_phrase_weight: 100
 蜉	fau
 裒	fau
 裒	pau
-覆	fau
-覆	fuk
-阜	fau
+覆	fau	1000
+覆	fuk	1000
+阜	fau	500
 鴀	fau
 𧌓	fau
-啡	fe
-啡	fei
+啡	fe	1000
+啡	fei	0%
 㥱	fei
 㫵	fei
 㹃	fei
@@ -6297,14 +6297,14 @@ min_phrase_weight: 100
 䩁	fei
 䬠	fei
 剕	fei
-匪	fei
+匪	fei	1000
 厞	fei
-妃	fei
+妃	fei	1000
 婓	fei
 屝	fei
 悱	fei
-扉	fei
-斐	fei
+扉	fei	1000
+斐	fei	500
 朏	fei
 棐	fei
 榧	fei
@@ -6312,20 +6312,20 @@ min_phrase_weight: 100
 篚	fei
 緋	fei
 绯	fei
-翡	fei
-肥	fei
+翡	fei	1000
+肥	fei	1000
 胐	fei
 腓	fei
-菲	fei
-蜚	fei
+菲	fei	1000
+蜚	fei	500
 蜰	fei
 裶	fei
 誹	fei
 诽	fei
 陫	fei
-霏	fei
-非	fei
-飛	fei
+霏	fei	500
+非	fei	1000
+飛	fei	1000
 飞	fei
 馡	fei
 騑	fei
@@ -6351,28 +6351,28 @@ min_phrase_weight: 100
 䌀	fo
 䍫	fo
 䍫	to
-伙	fo
+伙	fo	1000
 吙	fo
 吙	hoe
 堁	fo
-夥	fo
-棵	fo
-棵	po
-火	fo
-科	fo
+夥	fo	1000
+棵	fo	1000
+棵	po	0%
+火	fo	1000
+科	fo	1000
 稞	fo
-窠	fo
-窠	wo
+窠	fo	500
+窠	wo	500
 窾	fo
 窾	fun
-蝌	fo
-課	fo
+蝌	fo	500
+課	fo	1000
 课	fo
-貨	fo
+貨	fo	1000
 货	fo
 鈥	fo
 钬	fo
-顆	fo
+顆	fo	1000
 颗	fo
 騍	fo
 骒	fo
@@ -6388,7 +6388,7 @@ min_phrase_weight: 100
 彏	fok
 戄	fok
 攉	fok
-攫	fok
+攫	fok	500
 玃	fok
 矍	fok
 臛	fok
@@ -6403,7 +6403,7 @@ min_phrase_weight: 100
 钁	fok
 钁	kyut
 镢	fok
-霍	fok
+霍	fok	1000
 㑂	fong
 㑂	pong
 㕫	fong
@@ -6428,48 +6428,48 @@ min_phrase_weight: 100
 䌙	fong
 䢍	fong
 䲱	fong
-仿	fong
-倣	fong
+仿	fong	1000
+倣	fong	500
 况	fong
 匚	fong
-坊	fong
-妨	fong
+坊	fong	1000
+妨	fong	1000
 巟	fong
-幌	fong
-彷	fong
-彷	pong
+幌	fong	500
+彷	fong	1000
+彷	pong	0%
 怳	fong
-恍	fong
-慌	fong
-房	fong
-放	fong
-方	fong
+恍	fong	1000
+慌	fong	1000
+房	fong	1000
+放	fong	1000
+方	fong	1000
 昉	fong
-晃	fong
+晃	fong	1000
 枋	fong
 榥	fong
 汸	fong
 汸	pong
-況	fong
+況	fong	1000
 滉	fong
 熀	fong
 瓬	fong
 瓬	ling
 皝	fong
-紡	fong
+紡	fong	1000
 絖	fong
 絖	kong
 絖	kwong
 纺	fong
-肓	fong
-肪	fong
-舫	fong
-芳	fong
-荒	fong
+肓	fong	500
+肪	fong	1000
+舫	fong	500
+芳	fong	1000
+荒	fong	1000
 衁	fong
-訪	fong
+訪	fong	1000
 詤	fong
-謊	fong
+謊	fong	1000
 访	fong
 谎	fong
 貺	fong
@@ -6477,12 +6477,12 @@ min_phrase_weight: 100
 邡	fong
 鈁	fong
 钫	fong
-防	fong
+防	fong	1000
 髣	fong
 魴	fong
 鲂	fong
-戲	fu	0%
-戲	hei	100%
+戲	fu	0
+戲	hei	1
 㐻	fu
 㐻	mou
 㐻	noi
@@ -6547,51 +6547,51 @@ min_phrase_weight: 100
 䴣	fu
 䴸	fu
 䵾	fu
-乎	fu
-乎	wu
-仆	fu
-仆	puk
-付	fu
-伕	fu
-俘	fu
+乎	fu	1000
+乎	wu	0%
+仆	fu	500
+仆	puk	500
+付	fu	1000
+伕	fu	500
+俘	fu	1000
 俛	fu
 俛	min
-俯	fu
+俯	fu	1000
 偩	fu
-傅	fu
+傅	fu	1000
 凫	fu
 刳	fu
-副	fu
-呼	fu
-咐	fu
-唬	fu
+副	fu	1000
+呼	fu	1000
+咐	fu	1000
+唬	fu	500
 嘸	fu
 嘸	mou
 垺	fu
 垺	pau
-夫	fu
+夫	fu	1000
 妇	fu
-婦	fu
-孚	fu
-孵	fu
-富	fu
+婦	fu	1000
+孚	fu	500
+孵	fu	1000
+富	fu	1000
 尃	fu
 幠	fu
 库	fu
-府	fu
-庫	fu
+府	fu	1000
+庫	fu	1000
 弣	fu
 戽	fu
-扶	fu
+扶	fu	1000
 抚	fu
 拊	fu
 挎	fu
 挎	kwaa
-撫	fu
-敷	fu
-斧	fu
+撫	fu	1000
+敷	fu	1000
+斧	fu	1000
 枎	fu
-枯	fu
+枯	fu	1000
 枹	fu
 柎	fu
 桴	fu
@@ -6602,33 +6602,33 @@ min_phrase_weight: 100
 泭	fu
 滏	fu
 滹	fu
-父	fu
-琥	fu
-甫	fu
-甫	pou
+父	fu	1000
+琥	fu	500
+甫	fu	1000
+甫	pou	0%
 痡	fu
 痡	pou
 盙	fu
 砆	fu
 祔	fu
-符	fu
+符	fu	1000
 箍	fu
 箍	ku
 簠	fu
 絝	fu
 肤	fu
 胕	fu
-脯	fu
-脯	pou
-腐	fu
-腑	fu
+脯	fu	500
+脯	pou	500
+腐	fu	1000
+腑	fu	500
 膍	fu
 膍	pei
-膚	fu
+膚	fu	1000
 膴	fu
 膴	mou
-芙	fu
-苦	fu
+芙	fu	500
+苦	fu	1000
 苻	fu
 荴	fu
 莆	fu
@@ -6636,7 +6636,7 @@ min_phrase_weight: 100
 莩	fu
 莩	piu
 虍	fu
-虎	fu
+虎	fu	1000
 虖	fu
 蚨	fu
 蚹	fu
@@ -6646,39 +6646,39 @@ min_phrase_weight: 100
 袴	fu
 裤	fu
 褔	fu
-褲	fu
-訃	fu
+褲	fu	1000
+訃	fu	500
 謼	fu
 讣	fu
-負	fu
-賦	fu
+負	fu	1000
+賦	fu	1000
 賻	fu
 负	fu
 赋	fu
 赙	fu
-赴	fu
+赴	fu	1000
 趺	fu
 跗	fu
 軵	fu
 軵	jung
-輔	fu
+輔	fu	1000
 辅	fu
 郙	fu
 郛	fu
 鄜	fu
-釜	fu
+釜	fu	500
 鈇	fu
-附	fu
+附	fu	1000
 頫	fu
 颫	fu
-駙	fu
+駙	fu	500
 驸	fu
-骷	fu
+骷	fu	500
 鮒	fu
 鲋	fu
 鳧	fu
 鳺	fu
-麩	fu
+麩	fu	500
 麱	fu
 麸	fu
 黼	fu
@@ -6707,15 +6707,15 @@ min_phrase_weight: 100
 䵋	fui
 䵋	kui
 喙	fui
-奎	fui
-奎	kwai
-恢	fui
-悔	fui
+奎	fui	500
+奎	kwai	500
+恢	fui	1000
+悔	fui	1000
 悝	fui
-晦	fui
+晦	fui	500
 櫆	fui
 洧	fui
-灰	fui
+灰	fui	1000
 痏	fui
 痗	fui
 痗	mui
@@ -6728,13 +6728,13 @@ min_phrase_weight: 100
 虺	wai
 襘	fui
 襘	kui
-詼	fui
-誨	fui
+詼	fui	500
+誨	fui	1000
 诙	fui
 诲	fui
 豗	fui
-賄	fui
-賄	kui
+賄	fui	0%
+賄	kui	1000
 贿	fui
 闠	fui
 闠	gwai
@@ -6743,7 +6743,7 @@ min_phrase_weight: 100
 靧	fui
 顪	fui
 顪	wai
-魁	fui
+魁	fui	500
 鮪	fui
 鲔	fui
 𠧩	fui
@@ -6765,25 +6765,25 @@ min_phrase_weight: 100
 复	fuk
 宓	fuk
 宓	mat
-幅	fuk
-服	fuk
+幅	fuk	1000
+服	fuk	1000
 洑	fuk
-福	fuk
+福	fuk	1000
 箙	fuk
-腹	fuk
+腹	fuk	1000
 茯	fuk
 葍	fuk
 蕧	fuk
 虙	fuk
-蝠	fuk
+蝠	fuk	1000
 蝮	fuk
-袱	fuk
-複	fuk
+袱	fuk	1000
+複	fuk	1000
 輹	fuk
-輻	fuk
+輻	fuk	1000
 辐	fuk
 鍑	fuk
-馥	fuk
+馥	fuk	500
 鰒	fuk
 鳆	fuk
 鴔	fuk
@@ -6802,20 +6802,20 @@ min_phrase_weight: 100
 䢵	waat
 䥗	fun
 䲌	fun
-喚	fun
-喚	wun
+喚	fun	0%
+喚	wun	1000
 嚾	fun
 宽	fun
-寬	fun
+寬	fun	1000
 懽	fun
 梡	fun
 欢	fun
 欵	fun
-款	fun
-歡	fun
+款	fun	1000
+歡	fun	1000
 獾	fun
-盥	fun
-盥	gun
+盥	fun	500
+盥	gun	500
 窽	fun
 臗	fun
 讙	fun
@@ -6851,57 +6851,57 @@ min_phrase_weight: 100
 䩼	fung
 䵄	fung
 丰	fung
-俸	fung
+俸	fung	500
 冯	fung
 凤	fung
 唪	fung
 夆	fung
-奉	fung
+奉	fung	1000
 妦	fung
-封	fung
-峯	fung
+封	fung	1000
+峯	fung	1000
 峰	fung
 崶	fung
 摓	fung
 枫	fung
-楓	fung
+楓	fung	1000
 沣	fung
 渢	fung
 灃	fung
-烽	fung
+烽	fung	1000
 犎	fung
 甮	fung
 疯	fung
-瘋	fung
-縫	fung
+瘋	fung	1000
+縫	fung	1000
 缝	fung
 葑	fung
-蓬	fung
-蓬	pung
+蓬	fung	0%
+蓬	pung	1000
 蘴	fung
-蜂	fung
+蜂	fung	1000
 蠭	fung
-諷	fung
+諷	fung	1000
 讽	fung
-豐	fung
+豐	fung	1000
 賵	fung
 赗	fung
-逢	fung
+逢	fung	1000
 酆	fung
-鋒	fung
+鋒	fung	1000
 锋	fung
-風	fung
+風	fung	1000
 飌	fung
 风	fung
-馮	fung
-馮	pang
-鳳	fung
+馮	fung	500
+馮	pang	500
+鳳	fung	1000
 麷	fung
 䦢	fut
 濶	fut
 蛞	fut
 蛞	kut
-闊	fut
+闊	fut	1000
 阔	fut
 㗎	gaa	1000
 㗇	gaa
@@ -6919,26 +6919,26 @@ min_phrase_weight: 100
 䑝	gaa
 䕒	gaa
 䴥	gaa
-伽	gaa
-伽	ke
-假	gaa
-傢	gaa
-價	gaa
-加	gaa
-咖	gaa
-咖	kaa
-嘉	gaa
+伽	gaa	500
+伽	ke	500
+假	gaa	1000
+傢	gaa	1000
+價	gaa	1000
+加	gaa	1000
+咖	gaa	1000
+咖	kaa	0%
+嘉	gaa	1000
 嘎	gaa
 嘏	gaa
 嘏	gu
 噶	gaa
-嫁	gaa
-家	gaa
-家	gu	0%
+嫁	gaa	1000
+家	gaa	1000
+家	gu	0
 尕	gaa
 幏	gaa
 斝	gaa
-架	gaa
+架	gaa	1000
 枷	gaa
 椵	gaa
 榎	gaa
@@ -6953,23 +6953,23 @@ min_phrase_weight: 100
 瘕	haa
 癿	gaa
 癿	ke
-稼	gaa
+稼	gaa	1000
 笳	gaa
 耞	gaa
-茄	gaa
-茄	ke
+茄	gaa	1000
+茄	ke	1000
 葭	gaa
-袈	gaa
+袈	gaa	500
 豭	gaa
-賈	gaa
-賈	gu
+賈	gaa	1000
+賈	gu	200
 贾	gaa
 贾	gu
 跏	gaa
-迦	gaa
+迦	gaa	500
 鎵	gaa
 镓	gaa
-駕	gaa
+駕	gaa	1000
 驾	gaa
 鴐	gaa
 𠺢	gaa
@@ -6993,47 +6993,47 @@ min_phrase_weight: 100
 䲸	gaai
 䳶	gaai
 䳶	haai
-介	gaai
+介	gaai	1000
 价	gaai
-佳	gaai
-偕	gaai
+佳	gaai	1000
+偕	gaai	1000
 喈	gaai
 堦	gaai
 妎	gaai
 妎	hai
-尬	gaai
-屆	gaai
+尬	gaai	500
+屆	gaai	1000
 届	gaai
 廨	gaai
 廨	haai
 悈	gaai
-懈	gaai
-懈	haai
-戒	gaai
-楷	gaai
-楷	kaai
+懈	gaai	0%
+懈	haai	1000
+戒	gaai	1000
+楷	gaai	0%
+楷	kaai	1000
 檞	gaai
 檞	haai
 湝	gaai
 犗	gaai
 玠	gaai
-界	gaai
-疥	gaai
+界	gaai	1000
+疥	gaai	500
 痎	gaai
-皆	gaai
+皆	gaai	1000
 秸	gaai
-芥	gaai
+芥	gaai	500
 薢	gaai
 蚧	gaai
 蝔	gaai
-街	gaai
-解	gaai
-解	haai
+街	gaai	1000
+解	gaai	1000
+解	haai	0%
 觧	gaai
-誡	gaai
+誡	gaai	1000
 诫	gaai
 阶	gaai
-階	gaai
+階	gaai	1000
 骱	gaai
 骱	haai
 𠝹	gaai
@@ -7045,9 +7045,9 @@ min_phrase_weight: 100
 䪂	gaak
 仡	gaak
 仡	ngat
-咯	gaak
+咯	gaak	500
 咯	lo	1000
-咯	lok
+咯	lok	500
 嗝	gaak
 圪	gaak
 圪	ngat
@@ -7059,23 +7059,23 @@ min_phrase_weight: 100
 曱	gaat
 曱	gat
 曱	zaat
-格	gaak
+格	gaak	1000
 滆	gaak
 翮	gaak
 翮	hat
-胳	gaak
-胳	lok
-膈	gaak
+胳	gaak	1000
+胳	lok	0%
+膈	gaak	500
 茖	gaak
 茖	gok
 觡	gaak
 鎘	gaak
 镉	gaak
-隔	gaak
-革	gaak
-革	gaap
-革	gik
-骼	gaak
+隔	gaak	1000
+革	gaak	1000
+革	gaap	200
+革	gik	0%
+骼	gaak	1000
 鬲	gaak
 鬲	lik
 𠺝	gaak
@@ -7106,22 +7106,22 @@ min_phrase_weight: 100
 减	gaam
 尲	gaam
 尴	gaam
-尷	gaam
+尷	gaam	500
 椷	gaam
-橄	gaam
-橄	gam
+橄	gaam	1000
+橄	gam	0%
 淦	gaam
 淦	gam
-減	gaam
+減	gaam	1000
 监	gaam
-監	gaam
-緘	gaam
-緘	zin
+監	gaam	1000
+緘	gaam	500
+緘	zin	500
 缄	gaam
 鉴	gaam
-鑑	gaam
-鑒	gaam
-揀	gaan	300%
+鑑	gaam	1000
+鑒	gaam	1000
+揀	gaan	3
 㢙	gaan
 㢙	kaan
 㢙	saap
@@ -7138,41 +7138,41 @@ min_phrase_weight: 100
 䰙	gei
 䰙	ngaai
 堿	gaan
-奸	gaan
-姦	gaan
+奸	gaan	1000
+姦	gaan	500
 拣	gaan
 枧	gaan
-柬	gaan
+柬	gaan	1000
 梘	gaan
 橺	gaan
 涧	gaan
-澗	gaan
+澗	gaan	500
 瞷	gaan
 硷	gaan
 碱	gaan
 筧	gaan
 筧	gan
 简	gaan
-簡	gaan
-繭	gaan
-艱	gaan
+簡	gaan	1000
+繭	gaan	500
+艱	gaan	1000
 茧	gaan
 茧	gin
-菅	gaan
+菅	gaan	500
 葌	gaan
 蕑	gaan
 襉	gaan
 襺	gaan
 襺	gin
-諫	gaan
+諫	gaan	1000
 谏	gaan
 鐧	gaan
-閒	gaan
-閒	haan
-間	gaan
+閒	gaan	0%
+閒	haan	1000
+間	gaan	1000
 间	gaan
 鹻	gaan
-鹼	gaan
+鹼	gaan	500
 𢵧	gaan
 㪅	gaang
 㪅	sing
@@ -7184,10 +7184,10 @@ min_phrase_weight: 100
 浭	gaang
 浭	gang
 畊	gaang
-耕	gaang
-耕	gang
-逕	gaang
-逕	ging
+耕	gaang	1000
+耕	gang	0%
+逕	gaang	500
+逕	ging	500
 𨁈	gaang
 㕅	gaap
 㝓	gaap
@@ -7204,23 +7204,23 @@ min_phrase_weight: 100
 䲯	kaap
 唊	gaap
 夹	gaap
-夾	gaap
-夾	gap
-夾	gep
-夾	gip
+夾	gaap	1000
+夾	gap	501
+夾	gep	501
+夾	gip	501
 岬	gaap
 搿	gaap
 梜	gaap
 浹	gaap
 浹	zip
-甲	gaap
-胛	gaap
+甲	gaap	1000
+胛	gaap	500
 舺	gaap
 荚	gaap
-莢	gaap
-蛤	gaap
-蛤	gap
-蛤	haa
+莢	gaap	500
+蛤	gaap	500
+蛤	gap	500
+蛤	haa	500
 蛱	gaap
 蛺	gaap
 袷	gaap
@@ -7228,17 +7228,17 @@ min_phrase_weight: 100
 跲	gaap
 郏	gaap
 郟	gaap
-鉀	gaap
+鉀	gaap	500
 鋏	gaap
 钾	gaap
 铗	gaap
 鞈	gaap
 韐	gaap
-頰	gaap
-頰	haap
+頰	gaap	1000
+頰	haap	200
 颊	gaap
-鴿	gaap
-鴿	gap
+鴿	gaap	0%
+鴿	gap	1000
 鵊	gaap
 㔕	gaat
 㔕	kaau
@@ -7247,17 +7247,17 @@ min_phrase_weight: 100
 䢀	gaat
 甴	gaat
 甴	zaat	1000
-軋	gaat
-軋	zaat
+軋	gaat	500
+軋	zaat	500
 轧	gaat
 轧	zaat
 釓	gaat
 钆	gaat
 鞂	gaat
 攪	gaau	1000
-覺	gaau	5%
-覺	gok	95%
-搞	gaau	500%
+覺	gaau	0.05
+覺	gok	0.95
+搞	gaau	5
 㗕	gaau
 㗕	ngaau
 㚣	gaau
@@ -7303,33 +7303,33 @@ min_phrase_weight: 100
 䲫	gaau
 䲫	kaau
 䴔	gaau
-交	gaau
+交	gaau	1000
 佼	gaau
-姣	gaau
-姣	haau
+姣	gaau	500
+姣	haau	500
 搅	gaau
 撹	gaau
 敎	gaau
-教	gaau
+教	gaau	1000
 斠	gaau
 斠	gau
 斠	gok
-校	gaau
-校	haau
+校	gaau	1000
+校	haau	1000
 滘	gaau
 漖	gaau
-狡	gaau
+狡	gaau	1000
 珓	gaau
-皎	gaau
+皎	gaau	1000
 窌	gaau
-窖	gaau
+窖	gaau	500
 筊	gaau
-絞	gaau
+絞	gaau	500
 绞	gaau
 胶	gaau
-膠	gaau
+膠	gaau	1000
 茭	gaau
-蛟	gaau
+蛟	gaau	500
 覐	gaau
 覐	gok
 覚	gaau
@@ -7337,19 +7337,19 @@ min_phrase_weight: 100
 觉	gaau
 觉	gok
 跤	gaau
-較	gaau
+較	gaau	1000
 轇	gaau
 较	gaau
-郊	gaau
-酵	gaau
-酵	haau
+郊	gaau	1000
+酵	gaau	500
+酵	haau	500
 鉸	gaau
 铰	gaau
-餃	gaau
+餃	gaau	1000
 饺	gaau
 骹	gaau
 骹	haau
-鮫	gaau
+鮫	gaau	500
 鲛	gaau
 鵁	gaau
 偈	gai	1000
@@ -7373,7 +7373,7 @@ min_phrase_weight: 100
 笄	gai
 筀	gai
 紒	gai
-繼	gai
+繼	gai	1000
 继	gai
 罽	gai
 蓟	gai
@@ -7381,11 +7381,11 @@ min_phrase_weight: 100
 蘮	gai
 蟿	gai
 蟿	kai
-計	gai
-計	gei
+計	gai	1000
+計	gei	0%
 计	gai
-雞	gai
-髻	gai
+雞	gai	1000
+髻	gai	500
 鷄	gai
 鸡	gai
 枅	gai
@@ -7413,30 +7413,30 @@ min_phrase_weight: 100
 䛓	gam
 䛓	ham
 䲺	gam
-今	gam
+今	gam	1000
 僸	gam
 冚	gam
 冚	ham	1000
 冚	kam
 凎	gam
-噤	gam
-噤	kam
+噤	gam	500
+噤	kam	500
 坅	gam
 坅	jam
-感	gam
+感	gam	1000
 揿	gam
 搇	gam
 搇	kam
 撳	gam
-敢	gam
-柑	gam
+敢	gam	1000
+柑	gam	500
 泔	gam
 澉	gam
 灨	gam
-甘	gam
-疳	gam
-禁	gam
-禁	kam
+甘	gam	1000
+疳	gam	500
+禁	gam	1000
+禁	kam	501
 紟	gam
 紟	kam
 紺	gam
@@ -7444,11 +7444,11 @@ min_phrase_weight: 100
 苷	gam
 衿	gam
 衿	kam
-贛	gam
-贛	gung
+贛	gam	500
+贛	gung	500
 赣	gam
-金	gam
-錦	gam
+金	gam	1000
+錦	gam	1000
 锦	gam
 鰔	gam
 鰔	zam
@@ -7475,18 +7475,18 @@ min_phrase_weight: 100
 䵤	gan
 仅	gan
 伒	gan
-僅	gan
+僅	gan	1000
 哏	gan
 堇	gan
 墐	gan
 峎	gan
 峎	jan
 巹	gan
-巾	gan
+巾	gan	1000
 廑	gan
 廑	kan
-斤	gan
-根	gan
+斤	gan	1000
+根	gan	1000
 槿	gan
 殣	gan
 瑾	gan
@@ -7494,23 +7494,23 @@ min_phrase_weight: 100
 瘽	kan
 硍	gan
 笕	gan
-筋	gan
+筋	gan	1000
 紧	gan
-艮	gan
+艮	gan	500
 艰	gan
 茛	gan
 茛	loeng
 茛	long
 菫	gan
 蓳	gan
-覲	gan
+覲	gan	500
 觐	gan
 觔	gan
-謹	gan
+謹	gan	1000
 谨	gan
-跟	gan
-近	gan
-近	kan
+跟	gan	1000
+近	gan	1000
+近	kan	501
 釿	gan
 靳	gan
 饉	gan
@@ -7523,25 +7523,25 @@ min_phrase_weight: 100
 䱍	gang
 䱎	gang
 䱭	gang
-亙	gang
+亙	gang	500
 埂	gang
 堩	gang
-庚	gang
-梗	gang
-梗	gwaang
+庚	gang	1000
+梗	gang	500
+梗	gwaang	500
 焿	gang
 熲	gang
 熲	gwing
 熲	wing
 秔	gang
 稉	gang
-粳	gang
+粳	gang	500
 綆	gang
 緪	gang
 绠	gang
 羮	gang
-羹	gang
-耿	gang
+羹	gang	1000
+耿	gang	500
 賡	gang
 赓	gang
 郠	gang
@@ -7569,26 +7569,26 @@ min_phrase_weight: 100
 䇲	gok
 䛟	gap
 䧻	gap
-及	gap
-及	kap
-合	gap
-合	hap
-岌	gap
-岌	kap
+及	gap	0%
+及	kap	1000
+合	gap	0%
+合	hap	1000
+岌	gap	500
+岌	kap	500
 峆	gap
 峆	hap
 忣	gap
-急	gap
+急	gap	1000
 芨	gap
-蓋	gap
-蓋	goi
-蓋	hap
-蓋	koi
+蓋	gap	0%
+蓋	goi	1000
+蓋	hap	0%
+蓋	koi	1000
 郃	gap
 郃	hap
-閤	gap
-閤	gok
-閤	hap
+閤	gap	500
+閤	gok	500
+閤	hap	500
 頜	gap
 頜	hap
 颌	gap
@@ -7606,28 +7606,28 @@ min_phrase_weight: 100
 䰴	gat
 佶	gat
 佶	git
-吃	gat
-吃	hat
-吃	hek
-吃	jaak
-吉	gat
+吃	gat	0%
+吃	hat	0%
+吃	hek	1000
+吃	jaak	501
+吉	gat	1000
 咭	gat
 咭	kaat
 咭	kat
 咭	kit
 姞	gat
-疙	gat
-紇	gat
-紇	hat
+疙	gat	500
+紇	gat	500
+紇	hat	500
 纥	gat
 肐	gat
 虼	gat
 蛣	gat
 蛣	kit
-訖	gat
-訖	ngat
-詰	gat
-詰	kit
+訖	gat	0%
+訖	ngat	1000
+詰	gat	500
+詰	kit	500
 讫	gat
 讫	ngat
 诘	gat
@@ -7663,27 +7663,27 @@ min_phrase_weight: 100
 䰘	hip
 䰘	laau
 䲥	gau
-久	gau
-九	gau
+久	gau	1000
+九	gau	1000
 倃	gau
 傋	gau
 冓	gau
 勼	gau
 勼	kau
 厩	gau
-句	gau
-句	geoi
-咎	gau
-咎	gou
+句	gau	0%
+句	geoi	1000
+咎	gau	500
+咎	gou	500
 嚿	gau
-垢	gau
+垢	gau	1000
 夂	gau
 夂	ji
 夂	zi
 够	gau
-夠	gau
+夠	gau	1000
 姤	gau
-媾	gau
+媾	gau	500
 岣	gau
 岣	keoi
 廄	gau
@@ -7695,28 +7695,28 @@ min_phrase_weight: 100
 搆	kau
 摎	gau
 摎	lau
-救	gau
+救	gau	1000
 旧	gau
 朻	gau
 构	gau
 构	kau
-枸	gau
-枸	geoi
-柩	gau
-構	gau
-構	kau
+枸	gau	500
+枸	geoi	500
+柩	gau	500
+構	gau	1000
+構	kau	1000
 樛	gau
 沟	gau
 泃	gau
 泃	geoi
 泃	keoi
-溝	gau
-溝	kau
-灸	gau
-狗	gau
-玖	gau
-疚	gau
-究	gau
+溝	gau	0%
+溝	kau	1000
+灸	gau	1000
+狗	gau	1000
+玖	gau	1000
+疚	gau	500
+究	gau	1000
 笱	gau
 篝	gau
 簼	gau
@@ -7725,44 +7725,44 @@ min_phrase_weight: 100
 緱	kau
 纠	gau
 耇	gau
-舊	gau
+舊	gau	1000
 芶	gau
-苟	gau
+苟	gau	1000
 茍	gau
 袧	gau
 覯	gau
 觏	gau
-詬	gau
-詬	hau
+詬	gau	500
+詬	hau	500
 诟	gau
 诟	hau
-購	gau
-購	kau
+購	gau	1000
+購	kau	1000
 购	gau
-遘	gau
-鈎	gau
-鈎	ngau
+遘	gau	500
+鈎	gau	0%
+鈎	ngau	1000
 钩	gau
 钩	ngau
 阄	gau
 雊	gau
 韝	gau
-韭	gau
+韭	gau	500
 韮	gau
 鬮	gau
-鳩	gau
-鳩	kau
+鳩	gau	1000
+鳩	kau	0%
 鸠	gau
 鸠	kau
-龜	gau
-龜	gwai
-龜	gwan
+龜	gau	0%
+龜	gwai	1000
+龜	gwan	0%
 龟	gau
 龟	gwai
 龟	gwan
-龜	gau
-龜	gwai
-龜	gwan
+龜	gau	0%
+龜	gwai	1000
+龜	gwan	0%
 𠴰	gau
 𨳊	gau
 嘅	ge	10000
@@ -7814,67 +7814,67 @@ min_phrase_weight: 100
 䢳	gei
 䩭	gei
 丌	gei
-乩	gei
+乩	gei	500
 伎	gei
 倛	gei
 倛	hei
-其	gei
-其	kei
-几	gei
+其	gei	0%
+其	kei	1000
+几	gei	500
 刉	gei
 剞	gei
 叽	gei
 唭	gei
 唭	kei
-嘰	gei
-基	gei
-奇	gei
-奇	kei
-妓	gei
-姬	gei
-寄	gei
+嘰	gei	500
+基	gei	1000
+奇	gei	1000
+奇	kei	1000
+妓	gei	500
+姬	gei	1000
+寄	gei	1000
 屺	gei
 屺	hei
-己	gei
-幾	gei
+己	gei	1000
+幾	gei	1000
 庋	gei
 庋	gwai
 庪	gei
 庪	gwai
-忌	gei
+忌	gei	1000
 忮	gei
 忮	zi
 惎	gei
-技	gei
+技	gei	1000
 掎	gei
 敧	gei
-既	gei
+既	gei	1000
 旣	gei
 朞	gei
-期	gei
-期	kei
+期	gei	0%
+期	kei	1000
 机	gei
-杞	gei
-機	gei
+杞	gei	500
+機	gei	1000
 洎	gei
-犄	gei
+犄	gei	500
 玑	gei
-璣	gei
-畸	gei
-畸	kei
+璣	gei	500
+畸	gei	0%
+畸	kei	1000
 畿	gei
 矶	gei
-磯	gei
+磯	gei	500
 禨	gei
 稘	gei
 穊	gei
-箕	gei
-紀	gei
+箕	gei	500
+紀	gei	1000
 纪	gei
 羁	gei
 羇	gei
-羈	gei
-肌	gei
+羈	gei	1000
+肌	gei	1000
 芑	gei
 芑	hei
 芰	gei
@@ -7882,13 +7882,13 @@ min_phrase_weight: 100
 虮	gei
 蟣	gei
 覊	gei
-覬	gei
+覬	gei	500
 觊	gei
 觭	gei
 觭	kei
-記	gei
+記	gei	1000
 誋	gei
-譏	gei
+譏	gei	500
 讥	gei
 记	gei
 跽	gei
@@ -7899,12 +7899,12 @@ min_phrase_weight: 100
 錤	gei
 鐖	gei
 鞿	gei
-飢	gei
-饑	gei
+飢	gei	500
+饑	gei	1000
 饥	gei
-騎	gei
-騎	ke
-騎	kei
+騎	gei	0%
+騎	ke	1000
+騎	kei	200
 骩	gei
 鬾	gei
 鵋	gei
@@ -7916,12 +7916,12 @@ min_phrase_weight: 100
 𧝞	gei
 擏	geng
 擏	king
-鏡	geng
+鏡	geng	1000
 镜	geng
-頸	geng
+頸	geng	1000
 颈	geng
-驚	geng
-驚	ging
+驚	geng	0%
+驚	ging	1000
 麠	geng
 麠	ging
 𢠃	geng
@@ -7946,29 +7946,29 @@ min_phrase_weight: 100
 䶙	geoi
 䶚	geoi
 举	geoi
-俱	geoi
-俱	keoi
-倨	geoi
+俱	geoi	0%
+俱	keoi	1000
+倨	geoi	500
 倶	geoi
 偊	geoi
 偊	jyu
-具	geoi
+具	geoi	1000
 啹	geoi
 啹	goe
 啹	koe
 寠	geoi
 寠	lau
 寠	leoi
-居	geoi
+居	geoi	1000
 屦	geoi
 屨	geoi
 岠	geoi
 崌	geoi
-巨	geoi
+巨	geoi	1000
 惧	geoi
-懼	geoi
+懼	geoi	1000
 据	geoi
-據	geoi
+據	geoi	1000
 柜	geoi
 椇	geoi
 椐	geoi
@@ -7977,12 +7977,12 @@ min_phrase_weight: 100
 榉	geoi
 櫸	geoi
 澽	geoi
-炬	geoi
+炬	geoi	1000
 犋	geoi
 琚	geoi
-瞿	geoi
-瞿	keoi
-矩	geoi
+瞿	geoi	500
+瞿	keoi	500
+矩	geoi	1000
 秬	geoi
 窭	geoi
 窭	lau
@@ -7992,9 +7992,9 @@ min_phrase_weight: 100
 粔	geoi
 腒	geoi
 腒	keoi
-舉	geoi
-苣	geoi
-莒	geoi
+舉	geoi	1000
+苣	geoi	500
+莒	geoi	500
 萭	geoi
 萭	jyu
 蒟	geoi
@@ -8006,26 +8006,26 @@ min_phrase_weight: 100
 讵	geoi
 豦	geoi
 豦	keoi
-距	geoi
-距	keoi
+距	geoi	0%
+距	keoi	1000
 踞	geoi
 踽	geoi
 躆	geoi
-遽	geoi
+遽	geoi	500
 醵	geoi
 醵	koek
 鉅	geoi
-鋸	geoi
-鋸	goe
+鋸	geoi	1000
+鋸	goe	501
 鐻	geoi
 鐻	keoi
 钜	geoi
 锯	geoi
-颶	geoi
+颶	geoi	1000
 飓	geoi
 駏	geoi
 鶋	geoi
-齲	geoi
+齲	geoi	500
 龋	geoi
 喼	gep
 喼	gip
@@ -8043,21 +8043,21 @@ min_phrase_weight: 100
 䁶	gik
 䓧	gik
 䩯	gik
-亟	gik
-亟	kei
+亟	gik	500
+亟	kei	500
 击	gik
 墼	gik
-戟	gik
+戟	gik	500
 撠	gik
 撽	gik
-擊	gik
+擊	gik	1000
 极	gik
 极	kap
-棘	gik
-極	gik
+棘	gik	500
+極	gik	1000
 殛	gik
 毄	gik
-激	gik
+激	gik	1000
 衱	gik
 衱	gip
 襋	gik
@@ -8068,22 +8068,22 @@ min_phrase_weight: 100
 㐸	him
 䯡	gim
 俭	gim
-儉	gim
-兼	gim
+儉	gim	1000
+兼	gim	1000
 剑	gim
-劍	gim
+劍	gim	1000
 捡	gim
 搛	gim
-撿	gim
+撿	gim	1000
 检	gim
 檐	gim
 檐	jam
 檐	jim
-檢	gim
+檢	gim	1000
 睑	gim
 瞼	gim
 瞼	lim
-縑	gim
+縑	gim	500
 缣	gim
 蒹	gim
 鰜	gim
@@ -8124,24 +8124,24 @@ min_phrase_weight: 100
 䵛	gin
 䵛	hin
 䶬	gin
-件	gin
-健	gin
+件	gin	1000
+健	gin	1000
 坚	gin
-堅	gin
+堅	gin	1000
 寋	gin
 幵	gin
 幵	hin
-建	gin
+建	gin	1000
 楗	gin
 楗	kin
-毽	gin
-毽	jin
+毽	gin	1000
+毽	jin	1000
 犍	gin
-肩	gin
-腱	gin
+肩	gin	1000
+腱	gin	500
 菺	gin
-見	gin
-見	jin
+見	gin	1000
+見	jin	0%
 见	gin
 謇	gin
 謇	hin
@@ -8150,7 +8150,7 @@ min_phrase_weight: 100
 趼	jin
 蹇	gin
 鈃	gin
-鍵	gin
+鍵	gin	1000
 键	gin
 靬	gin
 鞬	gin
@@ -8169,16 +8169,16 @@ min_phrase_weight: 100
 䓳	haan
 䔔	ging
 䜘	ging
-京	ging
+京	ging	1000
 俓	ging
 倞	ging
 倞	loeng
-兢	ging
+兢	ging	500
 刭	ging
 剄	ging
 劲	ging
-勁	ging
-境	ging
+勁	ging	1000
+境	ging	1000
 墇	ging
 墇	zoeng
 婛	ging
@@ -8186,41 +8186,41 @@ min_phrase_weight: 100
 幜	ging
 弳	ging
 径	ging
-徑	ging
+徑	ging	1000
 惊	ging
-憬	ging
-憬	gwing
+憬	ging	1000
+憬	gwing	0%
 憼	ging
-敬	ging
-景	ging
-景	jing
+敬	ging	1000
+景	ging	1000
+景	jing	0%
 桱	ging
 殑	ging
 殑	king
 泾	ging
-涇	ging
+涇	ging	500
 獍	ging
 璚	ging
 璚	king
 璟	ging
 痉	ging
-痙	ging
-矜	ging
-矜	gwaan
-矜	gwan
+痙	ging	1000
+矜	ging	500
+矜	gwaan	500
+矜	gwan	500
 竞	ging
-竟	ging
-競	ging
-經	ging
+竟	ging	1000
+競	ging	1000
+經	ging	1000
 经	ging
 脛	ging
 脛	hing
 荆	ging
-荊	ging
-莖	ging
-莖	hang
+荊	ging	1000
+莖	ging	1000
+莖	hang	1000
 蟼	ging
-警	ging
+警	ging	1000
 迳	ging
 鵛	ging
 鶁	ging
@@ -8233,14 +8233,14 @@ min_phrase_weight: 100
 䂶	gip
 刦	gip
 刧	gip
-劫	gip
+劫	gip	1000
 抾	gip
 抾	keoi
-澀	gip
-澀	saap
-澀	sap
-狹	gip
-狹	haap
+澀	gip	1000
+澀	saap	1000
+澀	sap	0%
+狹	gip	0%
+狹	haap	1000
 硤	gip
 硤	haap
 陜	gip
@@ -8255,30 +8255,30 @@ min_phrase_weight: 100
 䥛	git
 䩤	git
 䩤	kit
-傑	git
-拮	git
+傑	git	1000
+拮	git	500
 撷	git
 撷	kit
 擷	git
 擷	kit
-杰	git
-桀	git
+杰	git	500
+桀	git	500
 榤	git
 洁	git
 滐	git
-潔	git
-竭	git
-竭	kit
-結	git
-結	lit
+潔	git	1000
+竭	git	0%
+竭	kit	1000
+結	git	1000
+結	lit	0%
 絜	git
 絜	kit
 结	git
 袺	git
 襭	git
 襭	kit
-頡	git
-頡	kit
+頡	git	500
+頡	kit	500
 颉	git
 颉	kit
 鮚	git
@@ -8293,17 +8293,17 @@ min_phrase_weight: 100
 䮦	giu
 侥	giu
 侥	hiu
-僥	giu
-僥	hiu
-僥	jiu
+僥	giu	0%
+僥	hiu	1000
+僥	jiu	0%
 儌	giu
 儌	hiu
-叫	giu
+叫	giu	1000
 呌	giu
 嘂	giu
 噭	giu
 娇	giu
-嬌	giu
+嬌	giu	1000
 嬓	giu
 峤	giu
 峤	kiu
@@ -8313,28 +8313,28 @@ min_phrase_weight: 100
 徼	jiu
 憍	giu
 撟	giu
-撬	giu
-撬	hiu
+撬	giu	500
+撬	hiu	500
 敿	giu
 浇	giu
 浇	hiu
-澆	giu
-澆	hiu
+澆	giu	1000
+澆	hiu	0%
 皦	giu
 矫	giu
-矯	giu
-矯	kiu
-繳	giu
-繳	zoek
+矯	giu	1000
+矯	kiu	0%
+繳	giu	1000
+繳	zoek	0%
 缴	giu
 蟜	giu
 譑	giu
 譥	giu
 蹻	giu
 蹻	hiu
-轎	giu
+轎	giu	1000
 轿	giu
-驕	giu
+驕	giu	1000
 骄	giu
 鱎	giu
 鷮	giu
@@ -8350,12 +8350,12 @@ min_phrase_weight: 100
 㢦	go
 㤎	go
 个	go
-個	go
-哥	go
+個	go	1000
+哥	go	1000
 哿	go
 哿	ho
 旮	go
-歌	go
+歌	go	1000
 渮	go
 牁	go
 牁	o
@@ -8373,7 +8373,7 @@ min_phrase_weight: 100
 䖼	goek
 屩	goek
 脚	goek
-腳	goek
+腳	goek	1000
 𪨗	goek
 㛨	goeng
 㩀	goeng
@@ -8385,27 +8385,27 @@ min_phrase_weight: 100
 䱟	goeng
 䲔	goeng
 䲔	king
-僵	goeng
+僵	goeng	1000
 唴	goeng
-姜	goeng
-強	goeng
-強	koeng
+姜	goeng	500
+強	goeng	0%
+強	koeng	1000
 彊	goeng
 彊	koeng
 橿	goeng
 殭	goeng
-疆	goeng
+疆	goeng	1000
 礓	goeng
 糨	goeng
 繮	goeng
 缰	goeng
-羌	goeng
+羌	goeng	1000
 羗	goeng
 蔃	goeng
 蔃	koeng
-薑	goeng
+薑	goeng	1000
 蜣	goeng
-韁	goeng
+韁	goeng	500
 㨟	goi
 㱯	goi
 㱯	ngoi
@@ -8420,7 +8420,7 @@ min_phrase_weight: 100
 䶣	ngoi
 侅	goi
 垓	goi
-改	goi
+改	goi	1000
 盖	goi
 盖	koi
 祴	goi
@@ -8430,9 +8430,9 @@ min_phrase_weight: 100
 荄	goi
 葢	goi
 葢	koi
-該	goi
+該	goi	1000
 该	goi
-賅	goi
+賅	goi	500
 賌	goi
 赅	goi
 阣	goi
@@ -8453,24 +8453,24 @@ min_phrase_weight: 100
 䫦	haap
 䫦	koi
 傕	gok
-各	gok
+各	gok	1000
 埆	gok
 埆	kok
 捔	gok
 搁	gok
-擱	gok
+擱	gok	1000
 桷	gok
 玨	gok
 硌	gok
 硌	lok
 袼	gok
-角	gok
-角	luk
+角	gok	1000
+角	luk	0%
 郝	gok
 郝	kok
 鉻	gok
 铬	gok
-閣	gok
+閣	gok	1000
 阁	gok
 㶥	gon
 㶥	soeng
@@ -8479,30 +8479,30 @@ min_phrase_weight: 100
 䯎	gon
 䵟	gon
 乹	gon
-乾	gon
-乾	kin
-干	gon
-幹	gon
+乾	gon	1000
+乾	kin	0%
+干	gon	1000
+幹	gon	1000
 旰	gon
 旰	hon
-杆	gon
-桿	gon
-榦	gon
-榦	hon
+杆	gon	1000
+桿	gon	1000
+榦	gon	1000
+榦	hon	0%
 漧	gon
 玕	gon
 皯	gon
 矸	gon
 秆	gon
-稈	gon
-竿	gon
+稈	gon	500
+竿	gon	1000
 筸	gon
 簳	gon
-肝	gon
+肝	gon	1000
 虷	gon
 虷	hon
 赶	gon
-趕	gon
+趕	gon	1000
 酐	gon
 酐	hong
 骭	gon
@@ -8529,23 +8529,23 @@ min_phrase_weight: 100
 亢	kong
 冈	gong
 刚	gong
-剛	gong
+剛	gong	1000
 堈	gong
 堽	gong
 岗	gong
-岡	gong
+岡	gong	1000
 崗	gong
-扛	gong
-扛	kong
+扛	gong	1000
+扛	kong	0%
 摃	gong
 杠	gong
 棡	gong
-槓	gong
-槓	gung
-槓	lung
-江	gong
+槓	gong	1000
+槓	gung	1000
+槓	lung	0%
+江	gong	1000
 洚	gong
-港	gong
+港	gong	1000
 犅	gong
 瓨	gong
 疘	gong
@@ -8554,37 +8554,37 @@ min_phrase_weight: 100
 矼	kung
 碙	gong
 絳	gong
-綱	gong
+綱	gong	1000
 纲	gong
 绛	gong
-缸	gong
+缸	gong	1000
 罁	gong
 罡	gong
 耩	gong
 耩	kau
-肛	gong
+肛	gong	1000
 肮	gong
 肮	hong
 舡	gong
 舡	syun
 茳	gong
-講	gong
+講	gong	1000
 讲	gong
 豇	gong
 釭	gong
-鋼	gong
+鋼	gong	1000
 钢	gong
-降	gong
-降	hong
+降	gong	1000
+降	hong	1000
 顜	gong
 𧊵	gong
 㓣	got
 㓣	zak
 䈓	got
 䈓	haap
-割	got
+割	got	1000
 嶱	got
-葛	got
+葛	got	1000
 輵	got
 轕	got
 㚏	gou
@@ -8595,30 +8595,30 @@ min_phrase_weight: 100
 㰏	gou
 㾸	gou
 䆁	gou
-告	gou
-告	guk
+告	gou	1000
+告	guk	1000
 暠	gou
 杲	gou
 槀	gou
-槁	gou
+槁	gou	500
 槔	gou
 槹	gou
 櫜	gou
 皋	gou
-皓	gou
-皓	hou
+皓	gou	500
+皓	hou	500
 睾	gou
 稾	gou
-稿	gou
-篙	gou
-糕	gou
+稿	gou	1000
+篙	gou	500
+糕	gou	1000
 縞	gou
 缟	gou
-羔	gou
-膏	gou
+羔	gou	1000
+膏	gou	1000
 臯	gou
 藁	gou
-誥	gou
+誥	gou	500
 诰	gou
 郜	gou
 鋯	gou
@@ -8626,13 +8626,13 @@ min_phrase_weight: 100
 鎬	hou
 锆	gou
 餻	gou
-高	gou
+高	gou	1000
 鼛	gou
 𣉞	gou
 𣓌	gou
 𦤎	gou
-果	gu	0%
-果	gwo	100%
+果	gu	0
+果	gwo	1
 㚉	gu
 㼋	gu
 㽽	gu
@@ -8645,61 +8645,61 @@ min_phrase_weight: 100
 䓢	gu
 䧸	gu
 䧸	zing
-估	gu
-僱	gu
-古	gu
-呱	gu
-呱	gwaa
-呱	waa
-咕	gu
-固	gu
+估	gu	1000
+僱	gu	1000
+古	gu	1000
+呱	gu	500
+呱	gwaa	500
+呱	waa	500
+咕	gu	500
+固	gu	1000
 堌	gu
-姑	gu
-孤	gu
+姑	gu	1000
+孤	gu	1000
 崮	gu
-故	gu
+故	gu	1000
 柧	gu
-沽	gu
+沽	gu	500
 泒	gu
-牯	gu
+牯	gu	500
 狜	gu
 痼	gu
 皷	gu
 盬	gu
-瞽	gu
+瞽	gu	500
 稒	gu
 箛	gu
 罛	gu
-罟	gu
+罟	gu	500
 羖	gu
-股	gu
+股	gu	1000
 胍	gu
 胍	gwaa
 臌	gu
 苽	gu
 菇	gu
-菰	gu
+菰	gu	500
 蛄	gu
 蛊	gu
 蛌	gu
-蠱	gu
+蠱	gu	500
 觚	gu
-詁	gu
+詁	gu	500
 诂	gu
 軱	gu
-辜	gu
+辜	gu	1000
 酤	gu
-鈷	gu
+鈷	gu	500
 錮	gu
 钴	gu
 锢	gu
-雇	gu
+雇	gu	500
 頋	gu
-顧	gu
+顧	gu	1000
 顾	gu
-鴣	gu
+鴣	gu	500
 鸪	gu
-鼓	gu
+鼓	gu	1000
 鼔	gu
 𦍩	gu
 𦙶	gu
@@ -8745,9 +8745,9 @@ min_phrase_weight: 100
 唃	guk
 喾	guk
 嚳	guk
-局	guk
+局	guk	1000
 挶	guk
-掬	guk
+掬	guk	500
 梏	guk
 梮	guk
 椈	guk
@@ -8757,37 +8757,37 @@ min_phrase_weight: 100
 瀔	guk
 焅	guk
 牿	guk
-穀	guk
+穀	guk	1000
 糓	guk
-菊	guk
+菊	guk	1000
 蘜	guk
 諊	guk
-谷	guk
-谷	juk
+谷	guk	1000
+谷	juk	0%
 趜	guk
-跼	guk
+跼	guk	500
 踘	guk
 軗	guk
 軗	syu
 輂	guk
-轂	guk
+轂	guk	500
 鋊	guk
 鋊	juk
 鋦	guk
 锔	guk
-鞠	guk
+鞠	guk	1000
 鞫	guk
 頊	guk
 頊	juk
 顼	guk
 顼	juk
-鵠	guk
-鵠	huk
+鵠	guk	0%
+鵠	huk	1000
 鹄	guk
 鹄	huk
 麯	guk
-麴	guk
-麴	kuk
+麴	guk	500
+麴	kuk	500
 㐫	gun
 㐫	hung
 㐫	zung
@@ -8807,20 +8807,20 @@ min_phrase_weight: 100
 䩪	gun
 䲘	gun
 䲘	sung
-倌	gun
-冠	gun
-官	gun
+倌	gun	500
+冠	gun	1000
+官	gun	1000
 悺	gun
-斡	gun
-斡	waat
-斡	wat
+斡	gun	500
+斡	waat	500
+斡	wat	500
 朊	gun
 朊	jyun
-棺	gun
+棺	gun	500
 毌	gun
 毌	kwun
 涫	gun
-灌	gun
+灌	gun	1000
 爟	gun
 琯	gun
 瓘	gun
@@ -8829,20 +8829,20 @@ min_phrase_weight: 100
 礶	gun
 祼	gun
 筦	gun
-管	gun
-罐	gun
+管	gun	1000
+罐	gun	1000
 脘	gun
 舘	gun
-莞	gun
-莞	wun
+莞	gun	500
+莞	wun	500
 覌	gun
-觀	gun
+觀	gun	1000
 观	gun
-貫	gun
+貫	gun	1000
 贯	gun
 錧	gun
 鑵	gun
-館	gun
+館	gun	1000
 馆	gun
 鸛	gun
 鹳	gun
@@ -8871,46 +8871,46 @@ min_phrase_weight: 100
 䰸	gung
 䲲	gung
 䳍	gung
-供	gung
-公	gung
-共	gung
-功	gung
+供	gung	1000
+公	gung	1000
+共	gung	1000
+功	gung	1000
 唝	gung
 嗊	gung
 嗊	hung
 塨	gung
 宫	gung
-宮	gung
-工	gung
+宮	gung	1000
+工	gung	1000
 巩	gung
 廾	gung
 廾	jaa
 廾	je
-弓	gung
-恭	gung
-拱	gung
+弓	gung	1000
+恭	gung	1000
+拱	gung	1000
 拲	gung
-攻	gung
+攻	gung	1000
 栱	gung
 涳	gung
 涳	hung
 珙	gung
-紅	gung
-紅	hung
+紅	gung	0%
+紅	hung	1000
 芎	gung
 芎	hung
 芎	kung
-蚣	gung
+蚣	gung	1000
 蛬	gung
-貢	gung
+貢	gung	1000
 贡	gung
-躬	gung
+躬	gung	1000
 躳	gung
 輁	gung
-鞏	gung
+鞏	gung	1000
 魟	gung
 魟	hung
-龔	gung
+龔	gung	500
 龚	gung
 𡎴	gung
 𫚉	gung
@@ -8922,20 +8922,20 @@ min_phrase_weight: 100
 㶽	gwaa
 䈑	gwaa
 䫚	gwaa
-卦	gwaa
+卦	gwaa	1000
 呙	gwaa
 咼	gwaa
 咼	waa
-寡	gwaa
+寡	gwaa	1000
 挂	gwaa
-掛	gwaa
-掛	kwaa
-瓜	gwaa
+掛	gwaa	1000
+掛	kwaa	501
+瓜	gwaa	1000
 絓	gwaa
 緺	gwaa
 罣	gwaa
-褂	gwaa
-褂	kwaa
+褂	gwaa	500
+褂	kwaa	500
 詿	gwaa
 诖	gwaa
 騧	gwaa
@@ -8972,20 +8972,20 @@ min_phrase_weight: 100
 䳏	gwaai
 䶯	gwaai
 䶯	kwaai
-乖	gwaai
+乖	gwaai	1000
 夬	gwaai
-怪	gwaai
+怪	gwaai	1000
 恠	gwaai
-拐	gwaai
-枴	gwaai
+拐	gwaai	1000
+枴	gwaai	1000
 柺	gwaai
 罫	gwaai
 罫	waa
 蒯	gwaai
 𧊅	gwaai
 掴	gwaak
-摑	gwaak
-摑	gwok
+摑	gwaak	500
+摑	gwok	500
 㙥	gwaan
 㙥	waan
 㙥	wat
@@ -9004,21 +9004,21 @@ min_phrase_weight: 100
 丱	gwaan
 关	gwaan
 惯	gwaan
-慣	gwaan
+慣	gwaan	1000
 掼	gwaan
 摜	gwaan
 擐	gwaan
 瘝	gwaan
-綸	gwaan
-綸	gwan
-綸	leon
+綸	gwaan	500
+綸	gwan	500
+綸	leon	500
 躀	gwaan
 躀	kwaang
 躀	kwong
 関	gwaan
 闗	gwaan
-關	gwaan
-鰥	gwaan
+關	gwaan	1000
+鰥	gwaan	500
 鳏	gwaan
 𨶹	gwaan
 㧦	gwaang
@@ -9030,8 +9030,8 @@ min_phrase_weight: 100
 俇	gwaang
 俇	gwong
 俇	hong
-逛	gwaang
-逛	kwaang
+逛	gwaang	0%
+逛	kwaang	1000
 㑮	gwaat
 㑮	waan
 㓉	gwaat
@@ -9058,12 +9058,12 @@ min_phrase_weight: 100
 䴜	waai
 䴜	wai
 䴜	wun
-刮	gwaat
+刮	gwaat	1000
 劀	gwaat
 劀	wat
 捖	gwaat
 捖	jyun
-颳	gwaat
+颳	gwaat	500
 㑧	gwai
 㧔	gwai
 㧔	tim
@@ -9087,30 +9087,30 @@ min_phrase_weight: 100
 匦	gwai
 匭	gwai
 匮	gwai
-匱	gwai
+匱	gwai	500
 厬	gwai
-圭	gwai
+圭	gwai	1000
 垝	gwai
 妫	gwai
 姽	gwai
 媯	gwai
 嬀	gwai
-季	gwai
+季	gwai	1000
 宄	gwai
 嶡	gwai
 嶡	kyut
 廆	gwai
 廆	wai
 归	gwai
-悸	gwai
+悸	gwai	500
 撌	gwai
 晷	gwai
 朹	gwai
 朹	kau
-桂	gwai
+桂	gwai	1000
 樻	gwai
-櫃	gwai
-歸	gwai
+櫃	gwai	1000
+歸	gwai	1000
 氿	gwai
 沩	gwai
 溈	gwai
@@ -9119,10 +9119,10 @@ min_phrase_weight: 100
 炅	gwai
 炅	gwing
 珪	gwai
-瑰	gwai
+瑰	gwai	1000
 痵	gwai
-癸	gwai
-皈	gwai
+癸	gwai	1000
+皈	gwai	500
 瞆	gwai
 瞆	kui
 瞶	gwai
@@ -9130,34 +9130,34 @@ min_phrase_weight: 100
 硅	gwai
 篑	gwai
 簋	gwai
-簣	gwai
+簣	gwai	500
 籄	gwai
 蒉	gwai
 蕢	gwai
 蘬	gwai
-詭	gwai
+詭	gwai	1000
 诡	gwai
-貴	gwai
+貴	gwai	1000
 贵	gwai
-跪	gwai
-蹶	gwai
-蹶	kyut
-軌	gwai
+跪	gwai	1000
+蹶	gwai	500
+蹶	kyut	500
+軌	gwai	1000
 轨	gwai
 邽	gwai
 鐀	gwai
-閨	gwai
+閨	gwai	1000
 闺	gwai
-餽	gwai
+餽	gwai	500
 饋	gwai
 馈	gwai
 騩	gwai
 騩	kwai
-鬼	gwai
+鬼	gwai	1000
 鮭	gwai
 鯚	gwai
-鱖	gwai
-鱖	kyut
+鱖	gwai	500
+鱖	kyut	500
 鲑	gwai
 鳜	gwai
 㯻	gwan
@@ -9165,31 +9165,31 @@ min_phrase_weight: 100
 䜇	gwan
 䵪	gwan
 军	gwan
-君	gwan
-均	gwan
-均	kwan
-均	wan
-崑	gwan
-崑	kwan
+君	gwan	1000
+均	gwan	1000
+均	kwan	0%
+均	wan	0%
+崑	gwan	500
+崑	kwan	500
 掍	gwan
 掍	wan
-昆	gwan
-昆	kwan
+昆	gwan	0%
+昆	kwan	1000
 晜	gwan
 晜	kwan
-棍	gwan
+棍	gwan	1000
 滚	gwan
 滚	kwan
-滾	gwan
-滾	kwan
+滾	gwan	1000
+滾	kwan	0%
 焜	gwan
 珺	gwan
 琨	gwan
 皲	gwan
 皸	gwan
 睔	gwan
-筠	gwan
-筠	wan
+筠	gwan	500
+筠	wan	500
 緄	gwan
 縜	gwan
 縜	wan
@@ -9201,18 +9201,18 @@ min_phrase_weight: 100
 蜫	gwan
 衮	gwan
 袀	gwan
-袞	gwan
+袞	gwan	500
 袬	gwan
 裈	gwan
 裷	gwan
 裷	jyun
 褌	gwan
-軍	gwan
+軍	gwan	1000
 輥	gwan
 辊	gwan
-郡	gwan
-鈞	gwan
-鈞	kwan
+郡	gwan	1000
+鈞	gwan	500
+鈞	kwan	500
 銁	gwan
 錕	gwan
 钧	gwan
@@ -9228,13 +9228,13 @@ min_phrase_weight: 100
 麇	kwan
 厷	gwang
 渹	gwang
-肱	gwang
+肱	gwang	500
 薨	gwang
 觥	gwang
 觵	gwang
 訇	gwang
 輷	gwang
-轟	gwang
+轟	gwang	1000
 轰	gwang
 鍧	gwang
 頵	gwang
@@ -9248,24 +9248,24 @@ min_phrase_weight: 100
 㭾	gwat
 㻕	gwat
 㾶	gwat
-倔	gwat
-崛	gwat
+倔	gwat	1000
+崛	gwat	1000
 愲	gwat
 憰	gwat
 憰	kyut
 扢	gwat
 扢	ngat
-掘	gwat
+掘	gwat	1000
 榾	gwat
-橘	gwat
+橘	gwat	500
 汩	gwat
 淈	gwat
-滑	gwat
-滑	waat
+滑	gwat	1000
+滑	waat	1000
 縎	gwat
 蓇	gwat
 镼	gwat
-骨	gwat
+骨	gwat	1000
 鶌	gwat
 鶻	gwat
 鶻	wat
@@ -9316,7 +9316,7 @@ min_phrase_weight: 100
 闅	gwik
 闅	man
 阒	gwik
-隙	gwik
+隙	gwik	1000
 馘	gwik
 鵙	gwik
 鵙	kyut
@@ -9341,7 +9341,7 @@ min_phrase_weight: 100
 扃	gwing
 檾	gwing
 泂	gwing
-炯	gwing
+炯	gwing	500
 烱	gwing
 煚	gwing
 絅	gwing
@@ -9349,7 +9349,7 @@ min_phrase_weight: 100
 詗	gwing
 詗	hing
 诇	gwing
-迥	gwing
+迥	gwing	500
 顈	gwing
 顈	king
 駉	gwing
@@ -9368,26 +9368,26 @@ min_phrase_weight: 100
 婐	o
 婐	wo
 惈	gwo
-戈	gwo
+戈	gwo	1000
 挝	gwo
 挝	zaa
 撾	gwo
 撾	zaa
 涡	gwo
 涡	wo
-渦	gwo
-渦	wo
+渦	gwo	500
+渦	wo	500
 猓	gwo
 簻	gwo
 粿	gwo
 菓	gwo
 薖	gwo
 蜾	gwo
-裹	gwo
+裹	gwo	1000
 褁	gwo
 輠	gwo
 过	gwo
-過	gwo
+過	gwo	1000
 錁	gwo
 锞	gwo
 餜	gwo
@@ -9409,44 +9409,44 @@ min_phrase_weight: 100
 嘓	gwok
 囯	gwok
 国	gwok
-國	gwok
+國	gwok	1000
 墎	gwok
 崞	gwok
 帼	gwok
-幗	gwok
-廓	gwok
-廓	kwok
-擴	gwok
-擴	kong
-擴	kwok
-擴	kwong
+幗	gwok	500
+廓	gwok	500
+廓	kwok	500
+擴	gwok	0%
+擴	kong	0%
+擴	kwok	1000
+擴	kwong	200
 椁	gwok
-槨	gwok
+槨	gwok	500
 漷	gwok
 漷	kwok
 簂	gwok
 膕	gwok
 蝈	gwok
-蟈	gwok
-郭	gwok
+蟈	gwok	500
+郭	gwok	1000
 霩	gwok
 㤮	gwong
 㤮	kwong
 㫕	gwong
 㫛	gwong
-光	gwong
-廣	gwong
+光	gwong	1000
+廣	gwong	1000
 桄	gwong
 洸	gwong
 犷	gwong
-獷	gwong
-礦	gwong
-礦	kwong
+獷	gwong	500
+礦	gwong	0%
+礦	kwong	1000
 穬	gwong
 穬	kong
 穬	kwong
-胱	gwong
-誑	gwong
+胱	gwong	500
+誑	gwong	500
 诳	gwong
 銧	gwong
 鑛	gwong
@@ -9469,40 +9469,40 @@ min_phrase_weight: 100
 䣺	gyun
 䩰	gyun
 䳌	gyun
-倦	gyun
-券	gyun
-券	hyun
-卷	gyun
-卷	kyun
-圈	gyun
-圈	hyun
+倦	gyun	1000
+券	gyun	1000
+券	hyun	1000
+卷	gyun	1000
+卷	kyun	0%
+圈	gyun	0%
+圈	hyun	1000
 埢	gyun
-娟	gyun
+娟	gyun	500
 婘	gyun
 婘	kyun
 帣	gyun
 悁	gyun
 懁	gyun
 懁	hyun
-捐	gyun
-捲	gyun
-涓	gyun
-狷	gyun
+捐	gyun	1000
+捲	gyun	1000
+涓	gyun	500
+狷	gyun	500
 獧	gyun
 琄	gyun
 琄	jyun
 瓹	gyun
-眷	gyun
+眷	gyun	500
 睊	gyun
 睠	gyun
 絭	gyun
-絹	gyun
+絹	gyun	1000
 绢	gyun
 罥	gyun
 菤	gyun
 蠲	gyun
-身	gyun
-身	san
+身	gyun	0%
+身	san	1000
 鄄	gyun
 鞙	gyun
 鞙	jyun
@@ -9512,7 +9512,7 @@ min_phrase_weight: 100
 駽	hyun
 鬳	gyun
 鬳	jin
-鵑	gyun
+鵑	gyun	1000
 鹃	gyun
 劂	gyut
 劂	kyut
@@ -9528,29 +9528,29 @@ min_phrase_weight: 100
 㰺	kwaai
 䪗	haa
 䫗	haa
-下	haa
+下	haa	1000
 厦	haa
 吓	haa
 吓	haak
-哈	haa
-哈	haai
-哈	kaa
-夏	haa
+哈	haa	1000
+哈	haai	0%
+哈	kaa	0%
+夏	haa	1000
 岈	haa
 岈	ngaa
-廈	haa
-暇	haa
-瑕	haa
+廈	haa	1000
+暇	haa	1000
+瑕	haa	500
 芐	haa
 芐	wu
 蕸	haa
 虾	haa
-蝦	haa
+蝦	haa	1000
 赮	haa
-遐	haa
+遐	haa	500
 閜	haa
 閜	ho
-霞	haa
+霞	haa	1000
 颬	haa
 騢	haa
 鰕	haa
@@ -9579,61 +9579,61 @@ min_phrase_weight: 100
 䱺	haai
 叡	haai
 叡	jeoi
-咳	haai
-咳	hoi
-咳	kat
-咳	koi
+咳	haai	0%
+咳	hoi	0%
+咳	kat	1000
+咳	koi	0%
 嗐	haai
 嚡	haai
-孩	haai
-孩	hoi
+孩	haai	1000
+孩	hoi	0%
 嶰	haai
-揩	haai
-械	haai
+揩	haai	500
+械	haai	1000
 澥	haai
 瀣	haai
 獬	haai
 繲	haai
 薤	haai
-蟹	haai
+蟹	haai	1000
 蠏	haai
 觟	haai
 觟	waa
-諧	haai
+諧	haai	1000
 谐	haai
-邂	haai
-鞋	haai
+邂	haai	500
+鞋	haai	1000
 韰	haai
-駭	haai
-駭	hoi
+駭	haai	1000
+駭	hoi	0%
 駴	haai
 骇	haai
-骸	haai
-骸	hoi
+骸	haai	1000
+骸	hoi	0%
 齘	haai
 龤	haai
 𩋘	haai
 𩋧	haai
-克	haak
-克	hak
-刻	haak
-刻	hak
-剋	haak
-剋	hak
-喀	haak
-喀	kaa
-喀	kak
-嚇	haak
-客	haak
+克	haak	200
+克	hak	1000
+刻	haak	200
+刻	hak	1000
+剋	haak	500
+剋	hak	500
+喀	haak	1000
+喀	kaa	0%
+喀	kak	0%
+嚇	haak	1000
+客	haak	1000
 諕	haak
 赩	haak
 赩	sik
-赫	haak
-赫	hak
-黑	haak
-黑	hak
+赫	haak	500
+赫	hak	500
+黑	haak	200
+黑	hak	1000
 喊	haam	1000
-喊	ham
+喊	ham	0%
 㖃	haam
 㖃	haau
 㖤	haam
@@ -9669,44 +9669,44 @@ min_phrase_weight: 100
 䱤	haam
 䲗	haam
 䶟	haam
-函	haam
-咸	haam
-啣	haam
-啣	ham
+函	haam	1000
+咸	haam	1000
+啣	haam	1000
+啣	ham	0%
 嗛	haam
 嗛	him
 嗛	hip
 壏	haam
-嵌	haam
-嵌	ham
+嵌	haam	500
+嵌	ham	500
 撖	haam
 撖	hon
 槛	haam
 槛	laam
-檻	haam
-檻	laam
-涵	haam
+檻	haam	500
+檻	laam	500
+涵	haam	1000
 莰	haam
 莰	ham
 衔	haam
 諴	haam
 豏	haam
-銜	haam
-銜	ham
+銜	haam	1000
+銜	ham	0%
 闞	haam
 闞	ham
 阚	haam
 阚	ham
-陷	haam
-陷	ham
-餡	haam
+陷	haam	1000
+陷	ham	0%
+餡	haam	1000
 馅	haam
 鬫	haam
-鹹	haam
+鹹	haam	1000
 麙	haam
 麙	ngaam
 慳	haan	1000
-慳	han
+慳	han	0%
 㡾	haan
 㯗	haan
 㸧	haan
@@ -9715,16 +9715,16 @@ min_phrase_weight: 100
 僩	haan
 娴	haan
 嫺	haan
-嫻	haan
+嫻	haan	500
 憪	haan
 掔	haan
 撊	haan
 痫	haan
 癇	haan
 瞯	haan
-閑	haan
+閑	haan	500
 闲	haan
-限	haan
+限	haan	1000
 鷳	haan
 鷴	haan
 鹇	haan
@@ -9737,17 +9737,17 @@ min_phrase_weight: 100
 䂔	haang
 䪫	haang
 䰢	haang
-吭	haang
-吭	hong
-坑	haang
+吭	haang	500
+吭	hong	500
+坑	haang	1000
 夯	haang
 夯	hang
 桁	haang
 桁	hang
 桁	hong
-行	haang
-行	hang
-行	hong
+行	haang	501
+行	hang	1000
+行	hong	1000
 誙	haang
 誙	hang
 阬	haang
@@ -9775,24 +9775,24 @@ min_phrase_weight: 100
 䶝	haap
 侠	haap
 侠	hap
-俠	haap
-俠	hap
-匣	haap
-呷	haap
-嗑	haap
-嗑	hap
+俠	haap	0%
+俠	hap	1000
+匣	haap	500
+呷	haap	500
+嗑	haap	500
+嗑	hap	500
 峡	haap
-峽	haap
+峽	haap	1000
 挟	haap
 挟	hip
-挾	haap
-挾	hip
+挾	haap	0%
+挾	hip	1000
 掐	haap
 柙	haap
-狎	haap
+狎	haap	500
 狭	haap
-盒	haap
-盒	hap
+盒	haap	501
+盒	hap	1000
 硖	haap
 祫	haap
 箧	haap
@@ -9816,22 +9816,22 @@ min_phrase_weight: 100
 䳧	haau
 傚	haau
 効	haau
-吼	haau
-吼	hau
-哮	haau
+吼	haau	1000
+吼	hau	501
+哮	haau	500
 嗃	haau
 嗃	hok
 嘐	haau
 墝	haau
-孝	haau
+孝	haau	1000
 尻	haau
-巧	haau
-巧	kiu
+巧	haau	1000
+巧	kiu	501
 恔	haau
-拷	haau
+拷	haau	500
 攷	haau
-效	haau
-敲	haau
+效	haau	1000
+敲	haau	1000
 斆	haau
 栲	haau
 毃	haau
@@ -9840,7 +9840,7 @@ min_phrase_weight: 100
 洨	ngaau
 烋	haau
 烋	jau
-烤	haau
+烤	haau	1000
 熇	haau
 熇	hok
 熇	huk
@@ -9848,7 +9848,7 @@ min_phrase_weight: 100
 痚	haau
 硗	haau
 磽	haau
-考	haau
+考	haau	1000
 薧	haau
 薧	hou
 虓	haau
@@ -9875,27 +9875,27 @@ min_phrase_weight: 100
 䲒	ngai
 傒	hai
 傒	hoi
-兮	hai
+兮	hai	1000
 匸	hai
-奚	hai
+奚	hai	500
 徯	hai
 檕	hai
 盻	hai
 禊	hai
-系	hai
-繫	hai
+系	hai	1000
+繫	hai	1000
 肹	hai
 螇	hai
 謑	hai
 貕	hai
-蹊	hai
+蹊	hai	500
 郋	hai
 閪	hai
 騱	hai
 鼷	hai
 𡚦	hai
-可	hak	1%
-可	ho
+可	hak	0.01
+可	ho	1000
 㦦	hak
 㵺	hak
 㵺	pai
@@ -9927,41 +9927,41 @@ min_phrase_weight: 100
 䨡	ham
 䶃	ham
 凵	ham
-勘	ham
-含	ham
+勘	ham	500
+含	ham	1000
 唅	ham
 唅	ngam
 唅	ngan
-坎	ham
-坩	ham
+坎	ham	500
+坩	ham	500
 埳	ham
-堪	ham
+堪	ham	1000
 墈	ham
 崁	ham
 嵁	ham
 憨	ham
-憾	ham
-戡	ham
+憾	ham	1000
+戡	ham	500
 扻	ham
 扻	zit
-撼	ham
+撼	ham	1000
 欿	ham
 歁	ham
 歁	zam
 焓	ham
 琀	ham
-瞰	ham
+瞰	ham	1000
 矙	ham
-砍	ham
+砍	ham	1000
 磡	ham
-蚶	ham
+蚶	ham	500
 蜭	ham
 谽	ham
 轗	ham
 邯	ham
 邯	hon
-酣	ham
-頷	ham
+酣	ham	1000
+頷	ham	1000
 顄	ham
 顉	ham
 顉	jam
@@ -9978,23 +9978,23 @@ min_phrase_weight: 100
 䦥	kok
 佷	han
 垦	han
-墾	han
-很	han
-恨	han
+墾	han	1000
+很	han	1000
+恨	han	1000
 恳	han
 悭	han
-懇	han
+懇	han	1000
 拫	han
 拫	hang
-狠	han
-痕	han
+狠	han	1000
+痕	han	1000
 絎	han
 絎	hong
 绗	han
 绗	hong
 豤	han
-齦	han
-齦	ngan
+齦	han	500
+齦	ngan	500
 龈	han
 龈	ngan
 㔰	hang
@@ -10009,40 +10009,40 @@ min_phrase_weight: 100
 䓷	hang
 䛭	hang
 䯒	hang
-亨	hang
-亨	paang
-倖	hang
+亨	hang	1000
+亨	paang	0%
+倖	hang	1000
 哼	hang
 哼	hng
 哼	ng
-啃	hang
+啃	hang	1000
 啈	hang
 姮	hang
 婞	hang
-幸	hang
-恆	hang
+幸	hang	1000
+恆	hang	1000
 恒	hang
-悻	hang
+悻	hang	500
 揯	hang
 摼	hang
-杏	hang
+杏	hang	1000
 涬	hang
 牼	hang
 珩	hang
 硁	hang
 硜	hang
-肯	hang
-肯	hoi
+肯	hang	1000
+肯	hoi	0%
 胻	hang
 脝	hang
 茎	hang
 荇	hang
 莕	hang
 蘅	hang
-衡	hang
-衡	waang
+衡	hang	1000
+衡	waang	0%
 踁	hang
-鏗	hang
+鏗	hang	500
 铿	hang
 㛍	hap
 㤲	hap
@@ -10064,50 +10064,50 @@ min_phrase_weight: 100
 匼	hap
 匼	o
 帢	hap
-恰	hap
+恰	hap	1000
 搕	hap
 榼	hap
 欱	hap
 欱	hot
-溘	hap
+溘	hap	500
 烚	hap
 烚	saap
-盍	hap
-瞌	hap
-磕	hap
+盍	hap	500
+瞌	hap	1000
+磕	hap	500
 鉿	hap
 铪	hap
-闔	hap
+闔	hap	500
 阖	hap
 㔠	hat
 㮝	hat
 䎢	hat
-乞	hat
-劾	hat
+乞	hat	1000
+劾	hat	500
 忔	hat
 忔	ngat
 搳	hat
-核	hat
-核	wat
-檄	hat
-瞎	hat
+核	hat	1000
+核	wat	1000
+檄	hat	500
+瞎	hat	1000
 礉	hat
 籺	hat
 舝	hat
 覈	hat
 覡	hat
 觋	hat
-轄	hat
+轄	hat	500
 辖	hat
-迄	hat
-迄	ngat
-閡	hat
-閡	ngoi
+迄	hat	500
+迄	ngat	500
+閡	hat	500
+閡	ngoi	500
 阂	hat
 麧	hat
-黠	hat
-黠	kit
-黠	waat
+黠	hat	500
+黠	kit	500
+黠	waat	500
 齕	hat
 龁	hat
 㗋	hau
@@ -10134,16 +10134,16 @@ min_phrase_weight: 100
 䯌	hau
 䯨	hau
 䯨	kok
-侯	hau
-候	hau
-厚	hau
-口	hau
-后	hau
-喉	hau
+侯	hau	1000
+候	hau	1000
+厚	hau	1000
+口	hau	1000
+后	hau	1000
+喉	hau	1000
 垕	hau
 堠	hau
-後	hau
-猴	hau
+後	hau	1000
+猴	hau	1000
 瘊	hau
 睺	hau
 篌	hau
@@ -10154,7 +10154,7 @@ min_phrase_weight: 100
 茩	hau
 蓲	hau
 蓲	jau
-逅	hau
+逅	hau	500
 郈	hau
 鄇	hau
 銗	hau
@@ -10232,70 +10232,70 @@ min_phrase_weight: 100
 䳢	hei
 䳢	kei
 俙	hei
-僖	hei
+僖	hei	500
 僛	hei
 呬	hei
 唏	hei
-喜	hei
-嗨	hei
-嗨	hoi
-嘻	hei
-嘿	hei
-器	hei
+喜	hei	1000
+嗨	hei	500
+嗨	hoi	500
+嘻	hei	1000
+嘿	hei	1000
+器	hei	1000
 嚱	hei
 囍	hei
 塈	hei
 塈	kei
 娸	hei
 媐	hei
-嬉	hei
-屎	hei
-屎	si
+嬉	hei	1000
+屎	hei	0%
+屎	si	1000
 岂	hei
 巇	hei
-希	hei
+希	hei	1000
 弃	hei
 悕	hei
 憇	hei
-憩	hei
+憩	hei	1000
 戏	hei
 戱	hei
 晞	hei
-曦	hei
-棄	hei
+曦	hei	500
+棄	hei	1000
 榿	hei
 榿	kei
 欷	hei
-欺	hei
+欺	hei	1000
 气	hei
-氣	hei
-汽	hei
+氣	hei	1000
+汽	hei	1000
 浠	hei
 炁	hei
 烯	hei
-熙	hei
-熹	hei
+熙	hei	500
+熹	hei	500
 爔	hei
 牺	hei
-犧	hei
+犧	hei	1000
 狶	hei
 甈	hei
 睎	hei
-禧	hei
-稀	hei
+禧	hei	500
+稀	hei	1000
 羛	hei
 羛	ji
-羲	hei
+羲	hei	1000
 蟢	hei
 諆	hei
 譆	hei
-豈	hei
-豈	hoi
+豈	hei	1000
+豈	hoi	0%
 豨	hei
-起	hei
+起	hei	1000
 醯	hei
-釐	hei
-釐	lei
+釐	hei	0%
+釐	lei	1000
 餼	hei
 饩	hei
 魌	hei
@@ -10304,8 +10304,8 @@ min_phrase_weight: 100
 䂆	hek
 喫	hek
 喫	jaak
-輕	heng
-輕	hing
+輕	heng	0%
+輕	hing	1000
 轻	heng
 轻	hing
 㗾	heoi
@@ -10328,36 +10328,36 @@ min_phrase_weight: 100
 佢	heoi
 佢	keoi	100000
 冔	heoi
-去	heoi
-吁	heoi
+去	heoi	1000
+吁	heoi	500
 呴	heoi
-咻	heoi
-咻	jau
+咻	heoi	500
+咻	jau	500
 喣	heoi
 嘘	heoi
-噓	heoi
+噓	heoi	500
 圩	heoi
 圩	jyu
 圩	wai
-墟	heoi
+墟	heoi	1000
 姁	heoi
 旴	heoi
 昫	heoi
-栩	heoi
+栩	heoi	500
 欨	heoi
 歔	heoi
-煦	heoi
-煦	jyu
+煦	heoi	500
+煦	jyu	500
 盱	heoi
 虚	heoi
-虛	heoi
+虛	heoi	1000
 訏	heoi
-許	heoi
+許	heoi	1000
 詡	heoi
 许	heoi
 诩	heoi
-迂	heoi
-迂	jyu
+迂	heoi	500
+迂	jyu	500
 鄦	heoi
 驉	heoi
 魖	heoi
@@ -10384,17 +10384,17 @@ min_phrase_weight: 100
 忺	him
 慊	him
 慊	hip
-欠	him
-歉	him
-歉	hip
+欠	him	1000
+歉	him	0%
+歉	hip	1000
 猃	him
 獫	him
 玁	him
 芡	him
-謙	him
+謙	him	1000
 谦	him
 险	him
-險	him
+險	him	1000
 㗔	hin
 㧛	hin
 㫫	hin
@@ -10427,8 +10427,8 @@ min_phrase_weight: 100
 岍	hin
 幰	hin
 愆	hin
-憲	hin
-掀	hin
+憲	hin	1000
+掀	hin	1000
 搴	hin
 攐	hin
 攓	hin
@@ -10437,27 +10437,27 @@ min_phrase_weight: 100
 杴	jan
 汧	hin
 牵	hin
-牽	hin
+牽	hin	1000
 献	hin
-獻	hin
+獻	hin	1000
 祅	hin
 縴	hin
 繾	hin
 缱	hin
 蚬	hin
 蜆	hin
-衍	hin
-衍	jin
+衍	hin	1000
+衍	jin	1000
 褰	hin
-譴	hin
+譴	hin	500
 谴	hin
-軒	hin
+軒	hin	500
 轩	hin
-遣	hin
+遣	hin	1000
 韅	hin
 顕	hin
-顯	hin
-騫	hin
+顯	hin	1000
+騫	hin	1000
 骞	hin
 鶱	hin
 㷫	hing	1000
@@ -10468,27 +10468,27 @@ min_phrase_weight: 100
 䋜	hing
 䋯	hing
 䋯	kaai
-兄	hing
+兄	hing	1000
 兴	hing
-卿	hing
+卿	hing	1000
 夐	hing
 庆	hing
-慶	hing
+慶	hing	1000
 敻	hing
 敻	hyun
 氢	hing
-氫	hing
+氫	hing	500
 矎	hing
 矎	hyun
-磬	hing
+磬	hing	500
 綮	hing
 綮	kai
-罄	hing
+罄	hing	500
 胫	hing
-興	hing
+興	hing	1000
 謦	hing
 鑋	hing
-馨	hing
+馨	hing	1000
 㙝	hip
 㢵	hip
 㢵	sip
@@ -10503,22 +10503,22 @@ min_phrase_weight: 100
 劦	hip
 勰	hip
 协	hip
-協	hip
+協	hip	1000
 叶	hip
 嗋	hip
-怯	hip
+怯	hip	1000
 惬	hip
-愜	hip
+愜	hip	500
 拹	hip
 胁	hip
-脅	hip
-歇	hit
+脅	hip	1000
+歇	hit	1000
 猲	hit
 猲	hot
 蝎	hit
 蝎	hot
-蠍	hit
-蠍	kit
+蠍	hit	500
+蠍	kit	500
 㕺	hiu
 㚠	hiu
 㠉	hiu
@@ -10536,19 +10536,19 @@ min_phrase_weight: 100
 哓	hiu
 嘵	hiu
 嚣	hiu
-囂	hiu
+囂	hiu	1000
 晓	hiu
-曉	hiu
+曉	hiu	1000
 枭	hiu
 枵	hiu
-梟	hiu
+梟	hiu	500
 歊	hiu
 獟	hiu
 獢	hiu
 窍	hiu
 窍	kiu
-竅	hiu
-竅	kiu
+竅	hiu	500
+竅	kiu	500
 繑	hiu
 繑	kiu
 膮	hiu
@@ -10557,7 +10557,7 @@ min_phrase_weight: 100
 虈	hiu
 趬	hiu
 跷	hiu
-蹺	hiu
+蹺	hiu	500
 鄡	hiu
 驍	hiu
 骁	hiu
@@ -10575,44 +10575,44 @@ min_phrase_weight: 100
 䏜	ho
 䘔	ho
 䘔	kaa
-何	ho
-呵	ho
+何	ho	1000
+呵	ho	1000
 嗬	ho
-坷	ho
+坷	ho	500
 岢	ho
-河	ho
-苛	ho
-荷	ho
+河	ho	1000
+苛	ho	1000
+荷	ho	1000
 蚵	ho
 訶	ho
 诃	ho
-賀	ho
+賀	ho	1000
 贺	ho
-靴	hoe
+靴	hoe	500
 㗽	hoeng
 㿝	hoeng
 䊑	hoeng
 䬕	hoeng
 乡	hoeng
-享	hoeng
-向	hoeng
+享	hoeng	1000
+向	hoeng	1000
 响	hoeng
-嚮	hoeng
-晌	hoeng
+嚮	hoeng	1000
+晌	hoeng	500
 曏	hoeng
 膷	hoeng
 芗	hoeng
 薌	hoeng
 蠁	hoeng
-鄉	hoeng
+鄉	hoeng	1000
 鄕	hoeng
-響	hoeng
+響	hoeng	1000
 飨	hoeng
-餉	hoeng
+餉	hoeng	1000
 饗	hoeng
 饟	hoeng
 饷	hoeng
-香	hoeng
+香	hoeng	1000
 㚊	hoi
 㝩	hoi
 㤥	hoi
@@ -10623,31 +10623,31 @@ min_phrase_weight: 100
 䁗	hoi
 䇋	hoi
 䇋	waai
-亥	hoi
+亥	hoi	1000
 儗	hoi
 儗	ji
 凯	hoi
-凱	hoi
-凱	ngoi
+凱	hoi	1000
+凱	ngoi	0%
 剀	hoi
-剴	hoi
+剴	hoi	500
 咍	hoi
 垲	hoi
 塏	hoi
-害	hoi
-害	hot
+害	hoi	1000
+害	hot	0%
 嵦	hoi
 开	hoi
 恺	hoi
 愷	hoi
-氦	hoi
-海	hoi
+氦	hoi	500
+海	hoi	1000
 磑	hoi
 磑	wui
 醢	hoi
 鎧	hoi
 铠	hoi
-開	hoi
+開	hoi	1000
 闓	hoi
 闿	hoi
 頦	hoi
@@ -10664,17 +10664,17 @@ min_phrase_weight: 100
 嗀	hok
 壳	hok
 学	hok
-學	hok
+學	hok	1000
 斈	hok
-殼	hok
+殼	hok	1000
 澩	hok
 矐	hok
 矐	kok
 翯	hok
 觷	hok
-貉	hok
-貉	mak
-鶴	hok
+貉	hok	500
+貉	mak	500
+鶴	hok	1000
 鷽	hok
 鸴	hok
 鹤	hok
@@ -10706,31 +10706,31 @@ min_phrase_weight: 100
 䮧	hon
 䳚	hon
 䳚	hot
-侃	hon
-刊	hon
+侃	hon	500
+刊	hon	1000
 刋	hon
 咹	hon
-寒	hon
-悍	hon
+寒	hon	1000
+悍	hon	500
 扞	hon
 捍	hon
-旱	hon
+旱	hon	1000
 暵	hon
 汉	hon
-汗	hon
-汗	hong	0%
+汗	hon	1000
+汗	hong	0
 涆	hon
-漢	hon
-瀚	hon
-焊	hon
+漢	hon	1000
+瀚	hon	500
+焊	hon	500
 熯	hon
 犴	hon
 犴	ngon
 甝	hon
-看	hon
+看	hon	1000
 睅	hon
-罕	hon
-翰	hon
+罕	hon	1000
+翰	hon	500
 蔊	hon
 螒	hon
 衎	hon
@@ -10741,14 +10741,14 @@ min_phrase_weight: 100
 銲	hon
 閈	hon
 闬	hon
-韓	hon
+韓	hon	1000
 韩	hon
 頇	hon
 顸	hon
 馯	hon
 駻	hon
 鶾	hon
-鼾	hon
+鼾	hon	1000
 𫘣	hon
 㑌	hong
 㟟	hong
@@ -10775,33 +10775,33 @@ min_phrase_weight: 100
 䯑	hong
 䲳	hong
 劻	hong
-匡	hong
-巷	hong
-康	hong
+匡	hong	1000
+巷	hong	1000
+康	hong	1000
 恇	hong
-慷	hong
-慷	hung
-慷	kong
-杭	hong
-框	hong
-框	kwaang
+慷	hong	1000
+慷	hung	0%
+慷	kong	0%
+杭	hong	1000
+框	hong	1000
+框	kwaang	1000
 椌	hong
 沆	hong
 洭	hong
 漮	hong
-炕	hong
-炕	kong
-烘	hong
-烘	hung
-眶	hong
-眶	kwaang
+炕	hong	500
+炕	kong	500
+烘	hong	501
+烘	hung	1000
+眶	hong	1000
+眶	kwaang	1000
 穅	hong
 笐	hong
-筐	hong
-筐	kwaang
-糠	hong
-腔	hong
-航	hong
+筐	hong	1000
+筐	kwaang	0%
+糠	hong	500
+腔	hong	1000
+航	hong	1000
 蚢	hong
 衖	hong
 衖	lung
@@ -10809,13 +10809,13 @@ min_phrase_weight: 100
 诓	hong
 迒	hong
 鏮	hong
-項	hong
+項	hong	1000
 頏	hong
 项	hong
 颃	hong
-骯	hong
-骯	ngong
-骯	ong
+骯	hong	501
+骯	ngong	0%
+骯	ong	1000
 𠵉	hong
 𣚺	hong
 㓭	hot
@@ -10828,14 +10828,14 @@ min_phrase_weight: 100
 㿣	hot
 䫘	hot
 䶎	hot
-喝	hot
+喝	hot	1000
 嵑	hot
 嵑	kit
 暍	hot
-曷	hot
+曷	hot	500
 毼	hot
-渴	hot
-褐	hot
+渴	hot	1000
+褐	hot	500
 鞨	hot
 鶡	hot
 鹖	hot
@@ -10861,34 +10861,34 @@ min_phrase_weight: 100
 䪽	hou
 䯫	hou
 号	hou
-嗥	hou
+嗥	hou	500
 嚆	hou
-嚎	hou
-壕	hou
-好	hou
+嚎	hou	500
+壕	hou	500
+好	hou	1000
 昊	hou
 昦	hou
-毫	hou
-浩	hou
+毫	hou	1000
+浩	hou	1000
 淏	hou
 滈	hou
 澔	hou
-濠	hou
+濠	hou	500
 灏	hou
 灝	hou
-犒	hou
+犒	hou	500
 皜	hou
 皞	hou
 秏	hou
-耗	hou
+耗	hou	1000
 茠	hou
 茠	jau
-蒿	hou
+蒿	hou	500
 薃	hou
 薅	hou
-號	hou
-蠔	hou
-豪	hou
+號	hou	1000
+蠔	hou	1000
+豪	hou	1000
 镐	hou
 顥	hou
 颢	hou
@@ -10913,16 +10913,16 @@ min_phrase_weight: 100
 䧼	huk
 勖	huk
 勖	juk
-勗	huk
-勗	juk
-哭	huk
+勗	huk	500
+勗	juk	500
+哭	huk	1000
 嘝	huk
 斛	huk
 槲	huk
 瀫	huk
 縠	huk
 觳	huk
-酷	huk
+酷	huk	1000
 㒑	hung
 㒑	kui
 㒑	wak
@@ -10944,49 +10944,49 @@ min_phrase_weight: 100
 䫹	hung
 䫹	kyun
 䲨	hung
-倥	hung
-兇	hung
-凶	hung
-匈	hung
+倥	hung	500
+兇	hung	1000
+凶	hung	1000
+匈	hung	1000
 吽	hung
 吽	ngau
-哄	hung
+哄	hung	1000
 哅	hung
-孔	hung
-崆	hung
+孔	hung	1000
+崆	hung	500
 忷	hung
 忼	hung
-恐	hung
+恐	hung	1000
 恟	hung
 悾	hung
-控	hung
-汞	hung
+控	hung	1000
+汞	hung	500
 汹	hung
-洪	hung
-洶	hung
+洪	hung	1000
+洶	hung	1000
 澒	hung
 灴	hung
-熊	hung
-穹	hung
-穹	kung
-空	hung
+熊	hung	1000
+穹	hung	0%
+穹	kung	1000
+空	hung	1000
 箜	hung
 篊	hung
 红	hung
 胷	hung
-胸	hung
+胸	hung	1000
 荭	hung
 葒	hung
 蕻	hung
-虹	hung
-訌	hung
+虹	hung	1000
+訌	hung	500
 讧	hung
 谼	hung
 閧	hung
-雄	hung
+雄	hung	1000
 鞚	hung
-鬨	hung
-鴻	hung
+鬨	hung	500
+鴻	hung	1000
 鸿	hung
 黉	hung
 黌	hung
@@ -11003,9 +11003,9 @@ min_phrase_weight: 100
 䳦	kwaan
 儇	hyun
 劝	hyun
-勸	hyun
+勸	hyun	1000
 咺	hyun
-喧	hyun
+喧	hyun	1000
 埙	hyun
 塤	hyun
 壎	hyun
@@ -11021,13 +11021,13 @@ min_phrase_weight: 100
 楥	hyun
 楥	jyun
 楦	hyun
-渲	hyun
-渲	syun
+渲	hyun	1000
+渲	syun	1000
 烜	hyun
 煊	hyun
 煖	hyun
 煖	nyun
-犬	hyun
+犬	hyun	1000
 犭	hyun
 甽	hyun
 甽	zan
@@ -11037,13 +11037,13 @@ min_phrase_weight: 100
 眴	seon
 禢	hyun
 禤	hyun
-絢	hyun
-絢	seon
+絢	hyun	1000
+絢	seon	0%
 綣	hyun
 绚	hyun
 绻	hyun
 翾	hyun
-萱	hyun
+萱	hyun	500
 萲	hyun
 虇	hyun
 蠉	hyun
@@ -11066,11 +11066,11 @@ min_phrase_weight: 100
 狘	hyut
 狘	jyut
 瞲	hyut
-血	hyut
+血	hyut	1000
 廿	jaa	1000
-廿	je
-廿	nim
-也	jaa
+廿	je	500
+廿	nim	500
+也	jaa	1000
 卄	jaa
 卄	je
 吔	jaak
@@ -11094,14 +11094,14 @@ min_phrase_weight: 100
 勩	ji
 抴	jai
 抴	zai
-拽	jai
-拽	jit
-曳	jai
+拽	jai	500
+拽	jit	500
+曳	jai	500
 枍	jai
 枻	jai
 枻	sit
-泄	jai
-泄	sit
+泄	jai	0%
+泄	sit	1000
 洩	jai
 洩	sit
 詍	jai
@@ -11109,7 +11109,7 @@ min_phrase_weight: 100
 跩	jai
 跩	zai
 𠯋	jai
-飲	jam	500%
+飲	jam	5
 㖗	jam
 㖗	zaam
 䅧	jam
@@ -11119,16 +11119,16 @@ min_phrase_weight: 100
 䕃	jam
 䕃	zaam
 乑	jam
-任	jam
+任	jam	1000
 冘	jam
 冘	jau
-吟	jam
-吟	ngam
+吟	jam	1000
+吟	ngam	501
 呥	jam
 呥	jim
 喑	jam
-壬	jam
-妊	jam
+壬	jam	1000
+妊	jam	500
 婬	jam
 崟	jam
 嵚	jam
@@ -11137,35 +11137,35 @@ min_phrase_weight: 100
 廞	jam
 恁	jam
 愔	jam
-欽	jam
+欽	jam	1000
 歆	jam
-淫	jam
+淫	jam	500
 瘖	jam
-簷	jam
-簷	jim
-簷	sim
+簷	jam	200
+簷	jim	1000
+簷	sim	1000
 紝	jam
 纴	jam
 腍	jam
 腍	nam
-荏	jam
+荏	jam	500
 荫	jam
-蔭	jam
+蔭	jam	1000
 衽	jam
 袵	jam
-賃	jam
+賃	jam	1000
 赁	jam
 銋	jam
 鑫	jam
 钦	jam
 阴	jam
-陰	jam
+陰	jam	1000
 隂	jam
 霒	jam
 霠	jam
-霪	jam
-音	jam
-飪	jam
+霪	jam	500
+音	jam	1000
+飪	jam	1000
 饪	jam
 饮	jam
 鵀	jam
@@ -11175,97 +11175,97 @@ min_phrase_weight: 100
 㶏	zaan
 䄄	jan
 䄄	zaan
-人	jan
-仁	jan
-仞	jan
+人	jan	1000
+仁	jan	1000
+仞	jan	500
 仭	jan
 儿	jan
-刃	jan
-印	jan
-印	ngan
+刃	jan	500
+印	jan	1000
+印	ngan	501
 听	jan
 听	teng
 听	ting
-因	jan
+因	jan	1000
 垔	jan
 垽	jan
 垽	ngan
 堙	jan
-夤	jan
-姻	jan
-孕	jan
-寅	jan
+夤	jan	500
+姻	jan	1000
+孕	jan	1000
+寅	jan	1000
 屻	jan
 廴	jan
-引	jan
-忍	jan
+引	jan	1000
+忍	jan	1000
 忻	jan
-恩	jan
-慇	jan
+恩	jan	1000
+慇	jan	500
 憖	jan
 戭	jan
 戭	jin
 昕	jan
 朄	jan
 檃	jan
-欣	jan
+欣	jan	1000
 歅	jan
 殥	jan
-殷	jan
-殷	jin
-氤	jan
+殷	jan	1000
+殷	jin	0%
+氤	jan	500
 洇	jan
-湮	jan
-湮	jin
+湮	jan	500
+湮	jin	500
 濦	jan
 炘	jan
 焮	jan
 牣	jan
 猌	jan
-甄	jan
-甄	zan
+甄	jan	1000
+甄	zan	0%
 瘾	jan
 癊	jan
-癮	jan
+癮	jan	1000
 盺	jan
 禋	jan
-紉	jan
+紉	jan	500
 絪	jan
 縯	jan
 縯	jin
 纫	jan
 肕	jan
 肕	ngan
-胤	jan
+胤	jan	500
 舋	jan
 舋	lang
-茵	jan
+茵	jan	500
 荵	jan
-蚓	jan
+蚓	jan	500
 螾	jan
 衅	jan
 裀	jan
 訒	jan
 訢	jan
-認	jan
-認	jing
+認	jan	0%
+認	jing	1000
 諲	jan
 讔	jan
 讱	jan
-軔	jan
+軔	jan	500
 轫	jan
 酳	jan
-釁	jan
+釁	jan	500
 銦	jan
 铟	jan
 锨	jan
 闉	jan
 陻	jan
 隐	jan
-隱	jan
+隱	jan	1000
 靷	jan
-韌	jan
-韌	ngan
+韌	jan	500
+韌	ngan	500
 韧	jan
 駰	jan
 骃	jan
@@ -11274,12 +11274,12 @@ min_phrase_weight: 100
 㗱	jap
 㗱	zap
 俋	jap
-入	jap
+入	jap	1000
 唈	jap
 悒	jap
 挹	jap
-揖	jap
-泣	jap
+揖	jap	500
+泣	jap	1000
 浥	jap
 湆	jap
 湆	nap
@@ -11288,39 +11288,39 @@ min_phrase_weight: 100
 潝	kap
 熠	jap
 熤	jap
-翕	jap
+翕	jap	500
 裛	jap
-邑	jap
+邑	jap	1000
 㳑	jat
 㳑	zaat
-一	jat
+一	jat	1000
 丨	jat
 丨	kwan
 佚	jat
 佾	jat
 劮	jat
-壹	jat
-壹	jik	0%
+壹	jat	1000
+壹	jik	0
 弌	jat
-掖	jat
-掖	jik
-日	jat
-汨	jat
-汨	mik
+掖	jat	500
+掖	jik	500
+日	jat	1000
+汨	jat	500
+汨	mik	500
 泆	jat
-液	jat
-液	jik
-溢	jat
+液	jat	0%
+液	jik	1000
+溢	jat	1000
 肸	jat
-腋	jat
-腋	jik
-腋	jit
+腋	jat	500
+腋	jik	500
+腋	jit	500
 艗	jat
 艗	jik
 衵	jat
 衵	nik
 轶	jat
-逸	jat
+逸	jat	1000
 鈤	jat
 鎰	jat
 镒	jat
@@ -11336,62 +11336,62 @@ min_phrase_weight: 100
 㳜	zaau
 䋴	jau
 䋴	zaau
-丘	jau
+丘	jau	1000
 丣	jau
-休	jau
+休	jau	1000
 优	jau
-佑	jau
+佑	jau	1000
 侑	jau
-優	jau
+優	jau	1000
 卣	jau
-又	jau
-友	jau
-右	jau
+又	jau	1000
+友	jau	1000
+右	jau	1000
 呦	jau
 嚘	jau
 囮	jau
 囮	ngo
 囿	jau
 坵	jau
-宥	jau
-尤	jau
-幼	jau
-幽	jau
+宥	jau	500
+尤	jau	1000
+幼	jau	1000
+幽	jau	1000
 庥	jau
 庮	jau
 忧	jau
 怞	jau
 怞	zau
 怮	jau
-悠	jau
-憂	jau
+悠	jau	1000
+憂	jau	1000
 懮	jau
-揉	jau
+揉	jau	1000
 攸	jau
 斿	jau
-有	jau
-朽	jau
-朽	nau
-柔	jau
-柚	jau
-柚	zuk
+有	jau	1000
+朽	jau	0%
+朽	nau	1000
+柔	jau	1000
+柚	jau	1000
+柚	zuk	0%
 楢	jau
 楺	jau
 槱	jau
 櫌	jau
 沋	jau
-油	jau
+油	jau	1000
 泑	jau
-游	jau
+游	jau	1000
 煣	jau
-牖	jau
+牖	jau	500
 犹	jau
 狖	jau
-猶	jau
-猷	jau
-由	jau
+猶	jau	1000
+猷	jau	500
+由	jau	1000
 疣	jau
-祐	jau
+祐	jau	500
 禸	jau
 糅	jau
 糅	nau
@@ -11401,107 +11401,107 @@ min_phrase_weight: 100
 纋	jau
 羑	jau
 耰	jau
-莠	jau
+莠	jau	500
 莸	jau
 葇	jau
 蕕	jau
 蘨	jau
-蚯	jau
+蚯	jau	500
 蚰	jau
 蚴	jau
 蝣	jau
 褎	jau
 褎	zau
 訧	jau
-誘	jau
+誘	jau	1000
 诱	jau
 貅	jau
-蹂	jau
+蹂	jau	500
 輮	jau
 輶	jau
 逌	jau
-遊	jau
+遊	jau	1000
 邮	jau
-邱	jau
-郵	jau
+邱	jau	500
+郵	jau	1000
 鄾	jau
-酉	jau
-釉	jau
-鈾	jau
+酉	jau	1000
+釉	jau	500
+鈾	jau	500
 銪	jau
 铀	jau
 铕	jau
-鞣	jau
+鞣	jau	500
 髹	jau
-魷	jau
+魷	jau	1000
 鯈	jau
 鯈	tiu
 鱿	jau
 鵂	jau
 鸺	jau
 麀	jau
-黝	jau
-鼬	jau
+黝	jau	500
+鼬	jau	500
 𠀉	jau
 𤍕	jau
 嘢	je	1000
 㭨	je
-偌	je
-冶	je
+偌	je	500
+冶	je	1000
 喏	je
 埜	je
-夜	je
-射	je
-射	jik
-射	se
-惹	je
+夜	je	1000
+射	je	0%
+射	jik	0%
+射	se	1000
+惹	je	1000
 捓	je
 揶	je
-椰	je
+椰	je	1000
 歋	je
 歋	ji
 渃	je
 渃	joek
 爷	je
-爺	je
+爺	je	1000
 玡	je
-琊	je
-耶	je
-若	je
-若	joek
-野	je
-影	jeng
-影	jing
-贏	jeng
-贏	jing
+琊	je	500
+耶	je	1000
+若	je	0%
+若	joek	1000
+野	je	1000
+影	jeng	0%
+影	jing	1000
+贏	jeng	1000
+贏	jing	1000
 赢	jeng
 赢	jing
-佯	jeoi
-佯	joeng
+佯	jeoi	500
+佯	joeng	500
 擩	jeoi
 擩	jyu
 枘	jeoi
 桵	jeoi
 橤	jeoi
 汭	jeoi
-睿	jeoi
+睿	jeoi	500
 緌	jeoi
 繠	jeoi
 芮	jeoi
-蕊	jeoi
+蕊	jeoi	1000
 蕤	jeoi
 蚋	jeoi
 蜹	jeoi
-裔	jeoi
+裔	jeoi	1000
 銳	jeoi
-鋭	jeoi
+鋭	jeoi	1000
 锐	jeoi
 撋	jeon
 撋	no
 润	jeon
-潤	jeon
+潤	jeon	1000
 膶	jeon
-閏	jeon
+閏	jeon	1000
 闰	jeon
 㖇	ji
 㖇	mei
@@ -11525,69 +11525,69 @@ min_phrase_weight: 100
 䭲	zi
 义	ji
 亄	ji
-二	ji
-以	ji
-以	jyu
+二	ji	1000
+以	ji	1000
+以	jyu	0%
 仪	ji
-伊	ji
+伊	ji	1000
 佁	ji
 佴	ji
 佴	noi
 侇	ji
-依	ji
-倚	ji
+依	ji	1000
+倚	ji	1000
 偯	ji
-儀	ji
-兒	ji
-兒	ngai
+儀	ji	1000
+兒	ji	1000
+兒	ngai	0%
 刵	ji
 劓	ji
 勚	ji
 匜	ji
 医	ji
-台	ji
-台	toi
+台	ji	0%
+台	toi	1000
 吚	ji
 咡	ji
 咡	mai
-咦	ji
+咦	ji	1000
 咿	ji
 唲	ji
 唲	waa
-噫	ji
-圯	ji
-夷	ji
-她	ji
-她	taa
-姨	ji
+噫	ji	1000
+圯	ji	500
+夷	ji	500
+她	ji	0%
+她	taa	1000
+姨	ji	1000
 嫛	ji
-宜	ji
+宜	ji	1000
 宧	ji
 尒	ji
 尔	ji
 崺	ji
 嶷	ji
 嶷	jik
-已	ji
+已	ji	1000
 廙	ji
 异	ji
 弍	ji
-彝	ji
-怡	ji
-意	ji
-懿	ji
+彝	ji	500
+怡	ji	1000
+意	ji	1000
+懿	ji	500
 扆	ji
 拟	ji
-擬	ji
-施	ji
-施	si
-旖	ji
-易	ji
-易	jik
+擬	ji	1000
+施	ji	0%
+施	si	1000
+旖	ji	500
+易	ji	1000
+易	jik	1000
 栘	ji
 栭	ji
 桋	ji
-椅	ji
+椅	ji	1000
 椸	ji
 樲	ji
 欹	ji
@@ -11599,45 +11599,45 @@ min_phrase_weight: 100
 洏	ji
 洟	ji
 洟	tai
-洱	ji
-漪	ji
+洱	ji	500
+漪	ji	500
 潩	ji
-爾	ji
+爾	ji	1000
 狋	ji
 狋	ngan
 猗	ji
 珥	ji
 珥	nei
 瑿	ji
-異	ji
-疑	ji
+異	ji	1000
+疑	ji	1000
 痍	ji
 瘗	ji
 瘞	ji
 瘱	ji
 皑	ji
 皑	ngoi
-皚	ji
-皚	ngoi
+皚	ji	500
+皚	ngoi	500
 眱	ji
-矣	ji
+矣	ji	1000
 祎	ji
 禕	ji
-移	ji
+移	ji	1000
 箷	ji
 簃	ji
-綺	ji
+綺	ji	500
 繄	ji
 绮	ji
 羠	ji
-義	ji
-而	ji
+義	ji	1000
+而	ji	1000
 耏	ji
-耳	ji
+耳	ji	1000
 聏	ji
-肄	ji
-肄	si
-胰	ji
+肄	ji	500
+肄	si	500
+胰	ji	500
 胹	ji
 臑	ji
 臑	jyu
@@ -11648,40 +11648,40 @@ min_phrase_weight: 100
 薏	ji
 薾	ji
 薿	ji
-蛇	ji
-蛇	se
+蛇	ji	0%
+蛇	se	1000
 蛜	ji
 螔	ji
 衈	ji
 衈	nei
-衣	ji
+衣	ji	1000
 衪	ji
 袘	ji
 袲	ji
 觺	ji
 訑	ji
 詒	ji
-誼	ji
-議	ji
+誼	ji	1000
+議	ji	1000
 议	ji
 诒	ji
 谊	ji
 貤	ji
-貳	ji
-貽	ji
+貳	ji	1000
+貽	ji	1000
 贰	ji
 贻	ji
 輀	ji
 轙	ji
 轙	ngai
 迆	ji
-迤	ji
+迤	ji	500
 迩	ji
 迻	ji
-邇	ji
+邇	ji	500
 郼	ji
 酏	ji
-醫	ji
+醫	ji	1000
 鉯	ji
 鉺	ji
 銥	ji
@@ -11695,12 +11695,12 @@ min_phrase_weight: 100
 陑	ji
 陭	ji
 陭	kei
-頤	ji
+頤	ji	500
 颐	ji
-食	ji
-食	sik	500%
-食	zi
-飴	ji
+食	ji	0%
+食	sik	5
+食	zi	0%
+飴	ji	500
 饐	ji
 饴	ji
 駬	ji
@@ -11722,56 +11722,56 @@ min_phrase_weight: 100
 𫍙	ji
 䦧	jik
 䦧	zik
-亦	jik
+亦	jik	1000
 亿	jik
-億	jik
+億	jik	1000
 圛	jik
 垼	jik
 埸	jik
-奕	jik
+奕	jik	500
 峄	jik
 嶧	jik
 帟	jik
-弈	jik
+弈	jik	1000
 弋	jik
-役	jik
+役	jik	1000
 忆	jik
 怿	jik
-憶	jik
+憶	jik	1000
 懌	jik
-抑	jik
+抑	jik	1000
 杙	jik
 檍	jik
 澺	jik
 瀷	jik
 燚	jik
 燡	jik
-疫	jik
-益	jik
-睪	jik
+疫	jik	1000
+益	jik	1000
+睪	jik	500
 繶	jik
-繹	jik
+繹	jik	500
 绎	jik
 翊	jik
-翌	jik
-翼	jik
+翌	jik	1000
+翼	jik	1000
 肊	jik
 膉	jik
 膱	jik
 膱	zik
-臆	jik
+臆	jik	500
 芅	jik
-蜴	jik
+蜴	jik	1000
 蝪	jik
-譯	jik
+譯	jik	1000
 译	jik
-逆	jik
-逆	ngaak
+逆	jik	1000
+逆	ngaak	501
 醳	jik
 醳	sik
 醷	jik
 阋	jik
-驛	jik
+驛	jik	500
 驿	jik
 鬩	jik
 鶂	jik
@@ -11782,7 +11782,7 @@ min_phrase_weight: 100
 鹢	jik
 黓	jik
 黓	jit
-益	jik
+益	jik	1000
 𡄯	jik
 㤿	jim
 䀋	jim
@@ -11790,22 +11790,22 @@ min_phrase_weight: 100
 䀋	zim
 严	jim
 俨	jim
-俺	jim
-儼	jim
-冉	jim
+俺	jim	500
+儼	jim	500
+冉	jim	1000
 剡	jim
 剡	sim
 剦	jim
 厌	jim
 厣	jim
-厭	jim
+厭	jim	1000
 厴	jim
 噞	jim
-嚴	jim
+嚴	jim	1000
 壛	jim
-奄	jim
+奄	jim	500
 姌	jim
-嫌	jim
+嫌	jim	1000
 嬮	jim
 崦	jim
 广	jim
@@ -11814,17 +11814,17 @@ min_phrase_weight: 100
 懨	jim
 扊	jim
 揜	jim
-染	jim
+染	jim	1000
 橪	jim
 檿	jim
 淊	jim
-淹	jim
+淹	jim	1000
 渰	jim
 灩	jim
-炎	jim
-焰	jim
+炎	jim	1000
+焰	jim	1000
 焱	jim
-燄	jim
+燄	jim	500
 爓	jim
 琰	jim
 盐	jim
@@ -11834,7 +11834,7 @@ min_phrase_weight: 100
 艳	jim
 艶	jim
 艷	jim
-苒	jim
+苒	jim	500
 蚎	jim
 蚒	jim
 蚺	jim
@@ -11843,29 +11843,29 @@ min_phrase_weight: 100
 蛅	zim
 裺	jim
 豓	jim
-豔	jim
+豔	jim	1000
 酓	jim
 酽	jim
-醃	jim
-醃	jip
+醃	jim	500
+醃	jip	500
 釅	jim
 閆	jim
 閹	jim
-閻	jim
+閻	jim	500
 闫	jim
 阉	jim
 阎	jim
 隒	jim
 顩	jim
 餍	jim
-饜	jim
+饜	jim	500
 騐	jim
-驗	jim
+驗	jim	1000
 验	jim
-髯	jim
+髯	jim	500
 魇	jim
-魘	jim
-鹽	jim
+魘	jim	500
+鹽	jim	1000
 黡	jim
 黤	jim
 黶	jim
@@ -11887,32 +11887,32 @@ min_phrase_weight: 100
 伭	jin
 伭	jyun
 俔	jin
-偃	jin
+偃	jin	500
 傿	jin
 兖	jin
-兗	jin
+兗	jin	500
 匽	jin
-咽	jin
-咽	jit
-唁	jin
+咽	jin	1000
+咽	jit	1000
+唁	jin	500
 唌	jin
 喭	jin
 喭	ngon
-嚥	jin
-嚥	jit
+嚥	jin	500
+嚥	jit	500
 埏	jin
-堰	jin
-妍	jin
-嫣	jin
+堰	jin	500
+妍	jin	500
+嫣	jin	500
 嬿	jin
-宴	jin
+宴	jin	1000
 岘	jin
 峴	jin
 巘	jin
-延	jin
-弦	jin
-弦	jyun
-彥	jin
+延	jin	1000
+弦	jin	1000
+弦	jyun	200
+彥	jin	500
 彦	jin
 揅	jin
 揅	ngaan
@@ -11921,47 +11921,47 @@ min_phrase_weight: 100
 沇	jin
 沇	wai
 涀	jin
-涎	jin
-演	jin
+涎	jin	500
+演	jin	1000
 烟	jin
 烻	jin
-焉	jin
-然	jin
-煙	jin
-燃	jin
-燕	jin
+焉	jin	1000
+然	jin	1000
+煙	jin	1000
+燃	jin	1000
+燕	jin	1000
 狿	jin
 现	jin
-現	jin
+現	jin	1000
 甗	jin
 睍	jin
-研	jin
-研	ngaan
+研	jin	1000
+研	ngaan	501
 砚	jin
-硯	jin
+硯	jin	500
 筳	jin
 筳	ting
-筵	jin
-絃	jin
+筵	jin	1000
+絃	jin	500
 綖	jin
-胭	jin
+胭	jin	500
 臙	jin
-舷	jin
+舷	jin	500
 苋	jin
 莚	jin
 莧	jin
-菸	jin
+菸	jin	500
 蔫	jin
 蚿	jin
 蜒	jin
 蝘	jin
-言	jin
-諺	jin
+言	jin	1000
+諺	jin	500
 讌	jin
 讞	jin
 谚	jin
 谳	jin
-賢	jin
+賢	jin	1000
 贤	jin
 躽	jin
 躽	zin
@@ -11975,11 +11975,11 @@ min_phrase_weight: 100
 鋧	jin
 驠	jin
 鰋	jin
-鴛	jin
-鴛	jyun
+鴛	jin	200
+鴛	jyun	1000
 鶠	jin
 鷰	jin
-鼴	jin
+鼴	jin	500
 鼹	jin
 齞	jin
 齴	jin
@@ -11996,62 +11996,62 @@ min_phrase_weight: 100
 䊔	zing
 䣐	jing
 䣐	zing
-仍	jing
+仍	jing	1000
 侀	jing
 偀	jing
-凝	jing
-凝	king
-刑	jing
-型	jing
+凝	jing	1000
+凝	king	501
+刑	jing	1000
+型	jing	1000
 塋	jing
 娙	jing
 婴	jing
 媵	jing
 嫈	jing
-嬰	jing
-嬴	jing
+嬰	jing	1000
+嬴	jing	500
 嶸	jing
 嶸	wing
 应	jing
-形	jing
-應	jing
-扔	jing
-扔	wing
+形	jing	1000
+應	jing	1000
+扔	jing	1000
+扔	wing	0%
 撄	jing
 攖	jing
-映	jing
+映	jing	1000
 桜	jing
-楹	jing
+楹	jing	500
 樱	jing
-櫻	jing
+櫻	jing	1000
 滎	jing
 滢	jing
 潆	jing
 濴	jing
 瀅	jing
-瀛	jing
+瀛	jing	500
 瀠	jing
 瀯	jing
 瀴	jing
 熒	jing
-營	jing
-瑛	jing
-瑩	jing
+營	jing	1000
+瑛	jing	500
+瑩	jing	1000
 璎	jing
 瓔	jing
 瘿	jing
 癭	jing
-盈	jing
+盈	jing	1000
 硎	jing
 礽	jing
 籯	jing
-縈	jing
-纓	jing
+縈	jing	500
+纓	jing	500
 缨	jing
-膺	jing
+膺	jing	500
 艿	jing
 艿	naai
-英	jing
+英	jing	1000
 茔	jing
 荥	jing
 荧	jing
@@ -12062,13 +12062,13 @@ min_phrase_weight: 100
 蓥	jing
 蘡	jing
 蝇	jing
-螢	jing
-蠅	jing
+螢	jing	1000
+蠅	jing	1000
 謍	jing
 认	jing
 賏	jing
-迎	jing
-邢	jing
+迎	jing	1000
+邢	jing	500
 鉶	jing
 鎣	jing
 铏	jing
@@ -12077,26 +12077,26 @@ min_phrase_weight: 100
 陾	jing
 霙	jing
 韺	jing
-鷹	jing
-鸚	jing
+鷹	jing	1000
+鸚	jing	500
 鹦	jing
 鹰	jing
 业	jip
 偞	jip
-嘩	jip
-嘩	waa
-孽	jip
-孽	jit
+嘩	jip	0%
+嘩	waa	1000
+孽	jip	500
+孽	jit	500
 嶪	jip
 擫	jip
 晔	jip
 曄	jip
-業	jip
+業	jip	1000
 殗	jip
 烨	jip
 燁	jip
-葉	jip
-葉	sip
+葉	jip	1000
+葉	sip	0%
 蠥	jip
 蠥	jit
 邺	jip
@@ -12104,8 +12104,8 @@ min_phrase_weight: 100
 闑	jip
 闑	jit
 靥	jip
-靨	jip
-頁	jip
+靨	jip	500
+頁	jip	1000
 页	jip
 饁	jip
 馌	jip
@@ -12114,7 +12114,7 @@ min_phrase_weight: 100
 㗁	zit
 啮	jit
 啮	ngat
-噎	jit
+噎	jit	500
 嚙	jit
 嚙	ngat
 嚙	ngit
@@ -12130,7 +12130,7 @@ min_phrase_weight: 100
 槷	jit
 櫱	jit
 热	jit
-熱	jit
+熱	jit	1000
 糱	jit
 臬	jit
 臬	nip
@@ -12140,8 +12140,8 @@ min_phrase_weight: 100
 蘗	jit
 蘗	paak
 蠮	jit
-謁	jit
-謁	kit
+謁	jit	500
+謁	kit	500
 钀	jit
 齧	jit
 齧	ngaat
@@ -12157,17 +12157,17 @@ min_phrase_weight: 100
 䬙	jiu
 䬙	ziu
 么	jiu
-么	mo	0%
+么	mo	0
 偠	jiu
 傜	jiu
-吆	jiu
+吆	jiu	500
 喓	jiu
 喓	oe
 垚	jiu
-堯	jiu
-夭	jiu
-妖	jiu
-姚	jiu
+堯	jiu	1000
+夭	jiu	1000
+妖	jiu	1000
+姚	jiu	500
 娆	jiu
 媱	jiu
 嬈	jiu
@@ -12176,18 +12176,18 @@ min_phrase_weight: 100
 尧	jiu
 峣	jiu
 嶢	jiu
-幺	jiu
+幺	jiu	500
 徭	jiu
 愮	jiu
 愰	jiu
 扰	jiu
 抭	jiu
-搖	jiu
+搖	jiu	1000
 摇	jiu
-擾	jiu
+擾	jiu	1000
 曜	jiu
-杳	jiu
-杳	miu
+杳	jiu	500
+杳	miu	500
 榣	jiu
 橈	jiu
 橈	naau
@@ -12198,61 +12198,61 @@ min_phrase_weight: 100
 燿	jiu
 猺	jiu
 珧	jiu
-瑤	jiu
+瑤	jiu	1000
 瑶	jiu
 眑	jiu
-祆	jiu
+祆	jiu	500
 穾	jiu
 窅	jiu
-窈	jiu
-窈	miu
+窈	jiu	500
+窈	miu	500
 窑	jiu
 窔	jiu
-窯	jiu
+窯	jiu	500
 窰	jiu
 筄	jiu
-繞	jiu
+繞	jiu	1000
 绕	jiu
-耀	jiu
-腰	jiu
-舀	jiu
+耀	jiu	1000
+腰	jiu	1000
+舀	jiu	500
 荛	jiu
 葽	jiu
 蕘	jiu
 蛲	jiu
-蟯	jiu
-蟯	naau
+蟯	jiu	500
+蟯	naau	500
 襓	jiu
-要	jiu
-謠	jiu
+要	jiu	1000
+謠	jiu	1000
 谣	jiu
 軺	jiu
 轺	jiu
-遙	jiu
+遙	jiu	1000
 遥	jiu
 遶	jiu
-邀	jiu
-陶	jiu
-陶	tou
+邀	jiu	1000
+陶	jiu	0%
+陶	tou	1000
 颻	jiu
 飖	jiu
-饒	jiu
+饒	jiu	1000
 饶	jiu
 騕	jiu
 鰩	jiu
 鳐	jiu
-鷂	jiu
+鷂	jiu	500
 鷕	jiu
 鹞	jiu
 𨍳	jiu
 哟	jo
-唷	jo
-喲	jo
+唷	jo	500
+喲	jo	1000
 㜰	joek
 㜰	zoek
-弱	joek
-曰	joek
-曰	jyut
+弱	joek	1000
+曰	joek	1000
+曰	jyut	0%
 楉	joek
 汋	joek
 汋	soek
@@ -12260,40 +12260,40 @@ min_phrase_weight: 100
 瀹	joek
 爚	joek
 疟	joek
-瘧	joek
+瘧	joek	500
 礿	joek
 禴	joek
 箬	joek
 篛	joek
 籥	joek
-籲	joek
-籲	jyu
-約	joek
+籲	joek	0%
+籲	jyu	1000
+約	joek	1000
 约	joek
 药	joek
 葯	joek
 蒻	joek
 薬	joek
-藥	joek
+藥	joek	1000
 蘥	joek
-虐	joek
+虐	joek	1000
 謔	joek
 谑	joek
 跃	joek
 跃	tik
-躍	joek
-躍	tik
+躍	joek	1000
+躍	tik	0%
 鄀	joek
 鈅	joek
-鑰	joek
+鑰	joek	1000
 钥	joek
 龠	joek
 䄃	joeng
 䄃	zoeng
 䬬	joeng
 䬬	zoeng
-仰	joeng
-仰	ngong
+仰	joeng	1000
+仰	ngong	501
 佒	joeng
 儴	joeng
 养	joeng
@@ -12301,71 +12301,71 @@ min_phrase_weight: 100
 勷	soeng
 卬	joeng
 卬	ngong
-嚷	joeng
+嚷	joeng	1000
 坱	joeng
 垟	joeng
 埌	joeng
 埌	long
 壌	joeng
-壤	joeng
-央	joeng
+壤	joeng	1000
+央	joeng	1000
 姎	joeng
 徉	joeng
-怏	joeng
-恙	joeng
+怏	joeng	500
+恙	joeng	500
 扬	joeng
 抰	joeng
-揚	joeng
-攘	joeng
+揚	joeng	1000
+攘	joeng	500
 旸	joeng
 昜	joeng
 暘	joeng
 杨	joeng
 柍	joeng
 样	joeng
-楊	joeng
-樣	joeng
-殃	joeng
-氧	joeng
-泱	joeng
-洋	joeng
-漾	joeng
+楊	joeng	1000
+樣	joeng	1000
+殃	joeng	500
+氧	joeng	1000
+泱	joeng	500
+洋	joeng	1000
+漾	joeng	1000
 瀁	joeng
 瀼	joeng
 炀	joeng
-烊	joeng
-煬	joeng
+烊	joeng	500
+煬	joeng	500
 獽	joeng
 疡	joeng
 痒	joeng
-瘍	joeng
-癢	joeng
+瘍	joeng	500
+癢	joeng	1000
 禓	joeng
 禳	joeng
-秧	joeng
+秧	joeng	1000
 穰	joeng
-羊	joeng
+羊	joeng	1000
 羕	joeng
 蘘	joeng
 蛘	joeng
 蠰	joeng
-讓	joeng
+讓	joeng	1000
 让	joeng
 躟	joeng
 躟	nong
 酿	joeng
-釀	joeng
+釀	joeng	1000
 鉠	joeng
 鍚	joeng
 钖	joeng
 阳	joeng
-陽	joeng
-鞅	joeng
-颺	joeng
+陽	joeng	1000
+鞅	joeng	500
+颺	joeng	500
 飏	joeng
-養	joeng
+養	joeng	1000
 鬤	joeng
-鴦	joeng
+鴦	joeng	1000
 鸉	joeng
 鸯	joeng
 䏁	joi
@@ -12374,42 +12374,42 @@ min_phrase_weight: 100
 㣃	juk
 㣃	zuk
 儥	juk
-噢	juk
-噢	jyu
-噢	ou
+噢	juk	0%
+噢	jyu	0%
+噢	ou	200
 堉	juk
 媷	juk
 宍	juk
-峪	juk
-峪	jyu
+峪	juk	500
+峪	jyu	500
 彧	juk
-慾	juk
-旭	juk
+慾	juk	1000
+旭	juk	500
 昱	juk
-欲	juk
-毓	juk
-沃	juk
-浴	juk
+欲	juk	1000
+毓	juk	500
+沃	juk	1000
+浴	juk	1000
 淯	juk
 溽	juk
-澳	juk
-澳	ou
-煜	juk
+澳	juk	0%
+澳	ou	1000
+煜	juk	500
 燠	juk
 狱	juk
-獄	juk
-玉	juk
+獄	juk	1000
+玉	juk	1000
 縟	juk
 缛	juk
-肉	juk
-育	juk
+肉	juk	1000
+育	juk	1000
 蓐	juk
 薁	juk
-褥	juk
-辱	juk
+褥	juk	1000
+辱	juk	1000
 逳	juk
-郁	juk
-郁	jyu
+郁	juk	1000
+郁	jyu	0%
 鄏	juk
 鈺	juk
 鋈	juk
@@ -12427,78 +12427,78 @@ min_phrase_weight: 100
 㣑	zung
 䇯	jung
 䇯	zung
-佣	jung
-俑	jung
+佣	jung	1000
+俑	jung	500
 傛	jung
-傭	jung
+傭	jung	1000
 冗	jung
-勇	jung
+勇	jung	1000
 喁	jung
 喁	jyu
 嗈	jung
-嗡	jung
+嗡	jung	1000
 噰	jung
 塕	jung
 墉	jung
-壅	jung
-宂	jung
-容	jung
+壅	jung	500
+宂	jung	500
+容	jung	1000
 嵱	jung
-庸	jung
+庸	jung	1000
 廱	jung
-恿	jung
+恿	jung	500
 慂	jung
 慵	jung
-戎	jung
+戎	jung	500
 拥	jung
-擁	jung
-擁	ung
-榕	jung
+擁	jung	1000
+擁	ung	0%
+榕	jung	1000
 毧	jung
 氄	jung
-湧	jung
-溶	jung
+湧	jung	1000
+溶	jung	1000
 滃	jung
 滽	jung
 澭	jung
-濃	jung
-濃	nung
+濃	jung	0%
+濃	nung	1000
 瀜	jung
 灉	jung
-熔	jung
+熔	jung	1000
 狨	jung
 瑢	jung
-用	jung
-甬	jung
+用	jung	1000
+甬	jung	500
 痈	jung
 癰	jung
-絨	jung
+絨	jung	1000
 绒	jung
 羢	jung
-翁	jung
+翁	jung	1000
 肜	jung
-臃	jung
+臃	jung	500
 茙	jung
-茸	jung
-蓉	jung
+茸	jung	500
+蓉	jung	500
 蓊	jung
 蕹	jung
 蕹	ngung
 蕹	ung
-蛹	jung
+蛹	jung	500
 螉	jung
-融	jung
+融	jung	1000
 螎	jung
 踊	jung
-踴	jung
-邕	jung
+踴	jung	1000
+邕	jung	500
 鄘	jung
 鄘	tong
-鎔	jung
+鎔	jung	500
 鏞	jung
 镕	jung
 镛	jung
-雍	jung
+雍	jung	500
 雝	jung
 顒	jung
 颙	jung
@@ -12522,48 +12522,48 @@ min_phrase_weight: 100
 䰻	jyu
 䰻	zyu
 与	jyu
-乳	jyu
-予	jyu
-于	jyu
+乳	jyu	1000
+予	jyu	1000
+于	jyu	1000
 伃	jyu
 伛	jyu
-余	jyu
+余	jyu	1000
 俁	jyu
-俞	jyu
+俞	jyu	500
 俣	jyu
 傴	jyu
-儒	jyu
+儒	jyu	1000
 兪	jyu
-喻	jyu
+喻	jyu	1000
 噳	jyu
 噳	koek
-嚅	jyu
+嚅	jyu	500
 圄	jyu
 圉	jyu
-女	jyu
-女	neoi
-如	jyu
-妤	jyu
+女	jyu	0%
+女	neoi	1000
+如	jyu	1000
+妤	jyu	500
 妪	jyu
-娛	jyu
+娛	jyu	1000
 娱	jyu
-嫗	jyu
+嫗	jyu	1000
 嬬	jyu
-孺	jyu
-宇	jyu
-寓	jyu
+孺	jyu	500
+宇	jyu	1000
+寓	jyu	1000
 屿	jyu
 屿	zeoi
 嵎	jyu
-嶼	jyu
-嶼	zeoi
+嶼	jyu	0%
+嶼	zeoi	1000
 帤	jyu
-庾	jyu
-御	jyu
-御	ngaa
-愈	jyu
-愉	jyu
-愚	jyu
+庾	jyu	500
+御	jyu	1000
+御	ngaa	0%
+愈	jyu	1000
+愉	jyu	1000
+愚	jyu	1000
 扜	jyu
 扵	jyu
 挐	jyu
@@ -12572,63 +12572,63 @@ min_phrase_weight: 100
 揄	jyu
 敔	jyu
 斞	jyu
-於	jyu
-於	wu
+於	jyu	1000
+於	wu	0%
 旟	jyu
 杅	jyu
 棜	jyu
 楰	jyu
-榆	jyu
+榆	jyu	500
 欤	jyu
 歈	jyu
-歟	jyu
+歟	jyu	500
 毹	jyu
 毹	syu
-汝	jyu
+汝	jyu	1000
 洳	jyu
-淤	jyu
+淤	jyu	1000
 渔	jyu
-渝	jyu
+渝	jyu	500
 湡	jyu
 滪	jyu
-漁	jyu
+漁	jyu	1000
 澦	jyu
-濡	jyu
-濡	nyun
+濡	jyu	500
+濡	nyun	500
 牏	jyu
 牏	tau
 狳	jyu
 玗	jyu
 瑀	jyu
-瑜	jyu
+瑜	jyu	500
 璵	jyu
 畬	jyu
 畬	se
 瘉	jyu
 瘐	jyu
-癒	jyu
-盂	jyu
+癒	jyu	1000
+盂	jyu	500
 睮	jyu
 礜	jyu
-禦	jyu
-禹	jyu
+禦	jyu	1000
+禹	jyu	500
 禺	jyu
 窬	jyu
 窳	jyu
-竽	jyu
+竽	jyu	500
 籹	jyu
 紆	jyu
 纡	jyu
 羭	jyu
-羽	jyu
+羽	jyu	1000
 腴	jyu
-臾	jyu
+臾	jyu	500
 舁	jyu
 舆	jyu
-與	jyu
+與	jyu	1000
 艅	jyu
-茹	jyu
-萸	jyu
+茹	jyu	500
+萸	jyu	1000
 蒘	jyu
 蓣	jyu
 蕍	jyu
@@ -12638,38 +12638,38 @@ min_phrase_weight: 100
 藇	jyu
 藇	zeoi
 蘌	jyu
-虞	jyu
+虞	jyu	500
 蝓	jyu
 蝡	jyu
 蝡	jyun
-蠕	jyu
-蠕	jyun
+蠕	jyu	500
+蠕	jyun	500
 衧	jyu
 袽	jyu
-裕	jyu
+裕	jyu	1000
 褕	jyu
 襦	jyu
-覦	jyu
+覦	jyu	500
 觎	jyu
 誉	jyu
-語	jyu
+語	jyu	1000
 諛	jyu
-諭	jyu
+諭	jyu	1000
 謣	jyu
-譽	jyu
+譽	jyu	1000
 语	jyu
 谀	jyu
 谕	jyu
-豫	jyu
+豫	jyu	1000
 貐	jyu
 踰	jyu
-輿	jyu
+輿	jyu	1000
 轝	jyu
-逾	jyu
-遇	jyu
+逾	jyu	1000
+遇	jyu	1000
 邘	jyu
 鄅	jyu
-酗	jyu
+酗	jyu	500
 醧	jyu
 醹	jyu
 釪	jyu
@@ -12681,25 +12681,25 @@ min_phrase_weight: 100
 陓	jyu
 陓	wu
 隃	jyu
-隅	jyu
-雨	jyu
+隅	jyu	500
+雨	jyu	1000
 雩	jyu
-預	jyu
+預	jyu	1000
 预	jyu
 飫	jyu
-餘	jyu
+餘	jyu	1000
 饇	jyu
 饫	jyu
 馀	jyu
-馭	jyu
+馭	jyu	500
 驭	jyu
-魚	jyu
+魚	jyu	1000
 鱼	jyu
 鴽	jyu
 鸆	jyu
 鸒	jyu
 麌	jyu
-齬	jyu
+齬	jyu	500
 齵	jyu
 龉	jyu
 龥	jyu
@@ -12714,20 +12714,20 @@ min_phrase_weight: 100
 䡱	zyun
 䲮	jyun
 䲮	zyun
-丸	jyun
+丸	jyun	1000
 倇	jyun
-元	jyun
-冤	jyun
+元	jyun	1000
+冤	jyun	1000
 刓	jyun
-原	jyun
+原	jyun	1000
 县	jyun
 员	jyun
-員	jyun
-員	wan
+員	jyun	1000
+員	wan	0%
 园	jyun
 圆	jyun
-園	jyun
-圓	jyun
+園	jyun	1000
+圓	jyun	1000
 圜	jyun
 圜	waan
 垸	jyun
@@ -12736,27 +12736,27 @@ min_phrase_weight: 100
 夗	jyun
 奫	jyun
 奫	wan
-婉	jyun
-媛	jyun
-媛	wun
+婉	jyun	1000
+媛	jyun	500
+媛	wun	500
 嫄	jyun
-完	jyun
-宛	jyun
+完	jyun	1000
+宛	jyun	1000
 寃	jyun
 岏	jyun
-怨	jyun
+怨	jyun	1000
 悬	jyun
-惋	jyun
-惋	wun
+惋	jyun	1000
+惋	wun	0%
 惌	jyun
-愿	jyun
-懸	jyun
+愿	jyun	500
+懸	jyun	1000
 抏	jyun
 抏	waan
 抏	wun
 掾	jyun
-援	jyun
-援	wun
+援	jyun	1000
+援	wun	1000
 昡	jyun
 晼	jyun
 杬	jyun
@@ -12765,23 +12765,23 @@ min_phrase_weight: 100
 橼	jyun
 櫞	jyun
 汍	jyun
-沅	jyun
-沿	jyun
+沅	jyun	500
+沿	jyun	1000
 泫	jyun
 洹	jyun
 洹	wun
-淵	jyun
+淵	jyun	1000
 渊	jyun
 湲	jyun
 湲	wun
-源	jyun
-炫	jyun
+源	jyun	1000
+炫	jyun	1000
 烷	jyun
-爰	jyun
-爰	wun
+爰	jyun	500
+爰	wun	500
 猨	jyun
-猿	jyun
-玄	jyun
+猿	jyun	1000
+玄	jyun	500
 琬	jyun
 瑗	jyun
 瓀	jyun
@@ -12789,13 +12789,13 @@ min_phrase_weight: 100
 盷	jyun
 盷	tin
 眢	jyun
-眩	jyun
+眩	jyun	500
 睕	jyun
 睕	waan
 礝	jyun
 紈	jyun
-緣	jyun
-縣	jyun
+緣	jyun	1000
+縣	jyun	1000
 繯	jyun
 繯	waan
 纨	jyun
@@ -12805,7 +12805,7 @@ min_phrase_weight: 100
 肙	jyun
 芄	jyun
 芫	jyun
-苑	jyun
+苑	jyun	500
 菀	jyun
 葾	jyun
 蒝	jyun
@@ -12813,39 +12813,39 @@ min_phrase_weight: 100
 薳	wai
 蚖	jyun
 蜎	jyun
-蜿	jyun
+蜿	jyun	1000
 蝝	jyun
 蝯	jyun
 螈	jyun
 衒	jyun
-袁	jyun
+袁	jyun	500
 褑	jyun
 豲	jyun
 豲	wun
 踠	jyun
-軟	jyun
+軟	jyun	1000
 輭	jyun
 輲	jyun
 輲	syun
-轅	jyun
+轅	jyun	500
 软	jyun
 辕	jyun
 远	jyun
-遠	jyun
+遠	jyun	1000
 邍	jyun
 邧	jyun
 鈆	jyun
 鉉	jyun
-鉛	jyun
+鉛	jyun	1000
 铅	jyun
 铉	jyun
-阮	jyun
-院	jyun
-隕	jyun
-隕	wan
-願	jyun
+阮	jyun	500
+院	jyun	1000
+隕	jyun	500
+隕	wan	500
+願	jyun	1000
 騵	jyun
-鳶	jyun
+鳶	jyun	500
 鵷	jyun
 鶢	jyun
 鸢	jyun
@@ -12855,39 +12855,39 @@ min_phrase_weight: 100
 鼋	jyun
 鼘	jyun
 䮑	jyut
-乙	jyut
+乙	jyut	1000
 刖	jyut
 哕	jyut
 噦	jyut
 噦	wai
 悅	jyut
-悦	jyut
+悦	jyut	1000
 戉	jyut
 抈	jyut
-月	jyut
+月	jyut	1000
 樾	jyut
 泧	jyut
 泧	kut
 泧	kwut
 爇	jyut
 玥	jyut
-穴	jyut
+穴	jyut	1000
 粤	jyut
-粵	jyut
-聿	jyut
-聿	leot
-聿	wat
-說	jyut	0%
+粵	jyut	1000
+聿	jyut	500
+聿	leot	500
+聿	wat	500
+說	jyut	0
 說	seoi
 說	syut
-越	jyut
+越	jyut	1000
 軏	jyut
 釔	jyut
 鉞	jyut
 钇	jyut
 钺	jyut
 閱	jyut
-閲	jyut
+閲	jyut	1000
 阅	jyut
 鳦	jyut
 𫐄	jyut
@@ -12898,8 +12898,8 @@ min_phrase_weight: 100
 䯊	kaa
 䯊	o
 佧	kaa
-卡	kaa
-卡	kaat
+卡	kaa	1000
+卡	kaat	1000
 咔	kaa
 擖	kaa
 擖	kat
@@ -12947,9 +12947,9 @@ min_phrase_weight: 100
 䉚	ngaa
 䎋	kaau
 䳹	kaau
-銬	kaau
+銬	kaau	500
 铐	kaau
-靠	kaau
+靠	kaau	1000
 㒅	kai
 㡁	kai
 㡁	kwaa
@@ -12960,23 +12960,23 @@ min_phrase_weight: 100
 䭬	kai
 启	kai
 啓	kai
-啟	kai
-契	kai
-契	kit
-契	sit
+啟	kai	1000
+契	kai	1000
+契	kit	0%
+契	sit	0%
 嵇	kai
 嵠	kai
 愒	kai
 愒	koi
 栔	kai
 棨	kai
-溪	kai
+溪	kai	1000
 瘈	kai
 瘈	zai
 瘛	kai
 磎	kai
-稽	kai
-谿	kai
+稽	kai	1000
+谿	kai	500
 鸂	kai
 揢	kak
 𠸉	kak
@@ -12985,28 +12985,28 @@ min_phrase_weight: 100
 䔷	kam
 䥅	kam
 䥆	kam
-噙	kam
+噙	kam	500
 妗	kam
 捦	kam
-擒	kam
+擒	kam	1000
 檎	kam
-琴	kam
-禽	kam
+琴	kam	1000
+禽	kam	1000
 芩	kam
 蠄	kam
 衾	kam
-襟	kam
+襟	kam	1000
 靲	kam
 𠸐	kam
 𠹸	kam
 𢫏	kam
 㘦	kan
-勤	kan
+勤	kan	1000
 慬	kan
 懃	kan
 懄	kan
 斳	kan
-芹	kan
+芹	kan	1000
 掯	kang
 裉	kang
 𠼰	kang
@@ -13015,18 +13015,18 @@ min_phrase_weight: 100
 㬛	kap
 㲸	kap
 伋	kap
-吸	kap
-吸	ngap
-圾	kap
-圾	saap
+吸	kap	1000
+吸	ngap	0%
+圾	kap	0%
+圾	saap	1000
 扱	kap
 歙	kap
 歙	sip
-汲	kap
+汲	kap	1000
 盵	kap
 笈	kap
-級	kap
-給	kap
+級	kap	1000
+給	kap	1000
 级	kap
 给	kap
 鈒	kap
@@ -13045,43 +13045,43 @@ min_phrase_weight: 100
 䟵	kau
 䣇	kau
 䤛	kau
-佝	kau
-佝	keoi
+佝	kau	500
+佝	keoi	500
 俅	kau
 厹	kau
-叩	kau
+叩	kau	500
 叴	kau
-寇	kau
+寇	kau	500
 巯	kau
 巰	kau
 彄	kau
 怐	kau
 怐	ngau
-扣	kau
+扣	kau	1000
 抠	kau
 摳	kau
 桕	kau
 梂	kau
 毬	kau
-求	kau
+求	kau	1000
 滱	kau
 犰	kau
-球	kau
+球	kau	1000
 璆	kau
 筘	kau
 簆	kau
 絿	kau
 缑	kau
-臼	kau
-舅	kau
+臼	kau	1000
+舅	kau	1000
 艽	kau
 芤	kau
 蔲	kau
 蔻	kau
 虬	kau
-虯	kau
+虯	kau	500
 蛷	kau
-裘	kau
+裘	kau	500
 觓	kau
 觩	kau
 訄	kau
@@ -13089,13 +13089,13 @@ min_phrase_weight: 100
 赇	kau
 逑	kau
 釚	kau
-釦	kau
+釦	kau	500
 銶	kau
 鷇	kau
 鼽	kau
-瘸	ke
+瘸	ke	500
 𡲢	ke
-企	kei	500%
+企	kei	5
 㞿	kei
 㟓	kei
 㟚	kei
@@ -13120,39 +13120,39 @@ min_phrase_weight: 100
 䵭	ze
 䶞	kei
 亓	kei
-俟	kei
-俟	zi
-冀	kei
+俟	kei	0%
+俟	zi	1000
+冀	kei	1000
 圻	kei
 圻	ngan
 埼	kei
-岐	kei
-崎	kei
+岐	kei	500
+崎	kei	1000
 懻	kei
 攲	kei
 旂	kei
-旗	kei
-暨	kei
-枝	kei
-枝	zi
+旗	kei	1000
+暨	kei	500
+枝	kei	0%
+枝	zi	1000
 桤	kei
 棊	kei
-棋	kei
-歧	kei
-淇	kei
-琦	kei
-琪	kei
+棋	kei	1000
+歧	kei	1000
+淇	kei	1000
+琦	kei	500
+琪	kei	500
 疧	kei
 碁	kei
 碕	kei
-祁	kei
-祇	kei
-祇	zi
-祈	kei
-祺	kei
+祁	kei	500
+祇	kei	500
+祇	zi	500
+祈	kei	1000
+祺	kei	500
 竒	kei
 綦	kei
-耆	kei
+耆	kei	500
 肵	kei
 臮	kei
 芪	kei
@@ -13169,7 +13169,7 @@ min_phrase_weight: 100
 颀	kei
 騏	kei
 騹	kei
-驥	kei
+驥	kei	500
 骐	kei
 骑	kei
 骥	kei
@@ -13179,15 +13179,15 @@ min_phrase_weight: 100
 鮨	ngai
 鮨	zi
 鯕	kei
-鰭	kei
+鰭	kei	1000
 鳍	kei
-麒	kei
+麒	kei	500
 𨀣	kei
 㘌	kek
 乪	kek
 剧	kek
-劇	kek
-屐	kek
+劇	kek	1000
+屐	kek	500
 𢲈	kek
 𢲈	kik
 㜹	keoi
@@ -13211,17 +13211,17 @@ min_phrase_weight: 100
 䮃	keoi
 䵶	keoi
 佉	keoi
-劬	keoi
+劬	keoi	500
 呿	keoi
 岖	keoi
-嶇	keoi
+嶇	keoi	1000
 懅	keoi
-拒	keoi
-拘	keoi
+拒	keoi	1000
+拘	keoi	1000
 斪	keoi
 朐	keoi
 氍	keoi
-渠	keoi
+渠	keoi	1000
 灈	keoi
 璩	keoi
 痀	keoi
@@ -13238,16 +13238,16 @@ min_phrase_weight: 100
 蕖	keoi
 蘧	keoi
 蟝	keoi
-衢	keoi
+衢	keoi	500
 袪	keoi
 跔	keoi
 躣	keoi
 躯	keoi
-軀	keoi
+軀	keoi	1000
 軥	keoi
 阹	keoi
-駒	keoi
-驅	keoi
+駒	keoi	500
+驅	keoi	1000
 驱	keoi
 驹	keoi
 鮈	keoi
@@ -13258,19 +13258,19 @@ min_phrase_weight: 100
 䈤	kim
 岒	kim
 拑	kim
-箝	kim
-鈐	kim
-鉗	kim
+箝	kim	500
+鈐	kim	500
+鉗	kim	1000
 钤	kim
 钳	kim
-黔	kim
+黔	kim	500
 黚	kim
 㨜	kin
 㩮	kin
 䖍	kin
 掮	kin
 揵	kin
-虔	kin
+虔	kin	1000
 鰬	kin
 㒌	king
 㔀	king
@@ -13285,24 +13285,24 @@ min_phrase_weight: 100
 䔛	loek
 䵞	king
 倾	king
-傾	king
+傾	king	1000
 勍	king
 墘	king
 廎	king
 惸	king
-擎	king
+擎	king	1000
 檠	king
 焭	king
 煢	king
 琼	king
-瓊	king
+瓊	king	500
 睘	king
 瞏	king
 茕	king
 藑	king
-頃	king
+頃	king	1000
 顷	king
-鯨	king
+鯨	king	1000
 鲸	king
 黥	king
 𢐧	king
@@ -13312,9 +13312,9 @@ min_phrase_weight: 100
 㼤	kit
 䅥	kit
 劼	kit
-孑	kit
-挈	kit
-揭	kit
+孑	kit	500
+挈	kit	500
+揭	kit	1000
 朅	kit
 楬	kit
 碣	kit
@@ -13323,10 +13323,10 @@ min_phrase_weight: 100
 纈	lit
 缬	kit
 缬	lit
-羯	kit
-訐	kit
+羯	kit	500
+訐	kit	500
 讦	kit
-鍥	kit
+鍥	kit	500
 锲	kit
 㚁	kiu
 㝯	kiu
@@ -13336,16 +13336,16 @@ min_phrase_weight: 100
 䱁	kiu
 乔	kiu
 侨	kiu
-僑	kiu
-喬	kiu
+僑	kiu	1000
+喬	kiu	1000
 嘺	kiu
 桥	kiu
-橋	kiu
+橋	kiu	1000
 皛	kiu
 皛	miu
 礄	kiu
 翘	kiu
-翹	kiu
+翹	kiu	500
 荍	kiu
 荞	kiu
 蕎	kiu
@@ -13361,7 +13361,7 @@ min_phrase_weight: 100
 㾡	koek
 䐘	koek
 却	koek
-卻	koek
+卻	koek	1000
 臄	koek
 㩖	koeng
 嵹	koeng
@@ -13377,16 +13377,16 @@ min_phrase_weight: 100
 㧉	koi
 䏗	koi
 䏗	kui
-丐	koi
+丐	koi	1000
 忾	koi
-愾	koi
-慨	koi
+愾	koi	500
+慨	koi	1000
 戤	koi
-概	koi
+概	koi	1000
 槪	koi
-溉	koi
+溉	koi	1000
 漑	koi
-鈣	koi
+鈣	koi	1000
 钙	koi
 㤩	kok
 㩁	kok
@@ -13399,36 +13399,36 @@ min_phrase_weight: 100
 䶅	kok
 䶅	lok
 塙	kok
-壑	kok
-恪	kok
+壑	kok	500
+恪	kok	500
 悫	kok
 愘	kok
 愨	kok
 慤	kok
 搉	kok
-榷	kok
-涸	kok
+榷	kok	500
+涸	kok	500
 确	kok
-確	kok
+確	kok	1000
 碻	kok
 礐	kok
 㢜	kong
 㰠	kong
 䊯	kong
 䊯	kwong
-伉	kong
+伉	kong	500
 匟	kong
 夼	kong
 夼	kwaang
 夼	kwong
 懭	kong
 懭	kwong
-抗	kong
+抗	kong	1000
 爌	kong
 爌	kwong
 犺	kong
-狂	kong
-狂	kwong
+狂	kong	0%
+狂	kwong	1000
 矿	kong
 邟	kong
 鈧	kong
@@ -13437,8 +13437,8 @@ min_phrase_weight: 100
 闶	kong
 鵟	kong
 軲	ku
-會	kui	1%
-會	wui	99%
+會	kui	0.01
+會	wui	0.99
 㱮	kui
 㷐	kui
 㷐	waai
@@ -13454,7 +13454,7 @@ min_phrase_weight: 100
 䭝	kui
 䯤	kui
 侩	kui
-儈	kui
+儈	kui	500
 刽	kui
 廥	kui
 廥	kwui
@@ -13462,21 +13462,21 @@ min_phrase_weight: 100
 憒	kui
 旝	kui
 桧	kui
-檜	kui
+檜	kui	500
 浍	kui
 溃	kui
-潰	kui
+潰	kui	1000
 澮	kui
 狯	kui
 獪	kui
 繢	kui
-繪	kui
+繪	kui	1000
 绘	kui
 缋	kui
 聩	kui
 聵	kui
 脍	kui
-膾	kui
+膾	kui	500
 荟	kui
 荟	wai
 荟	wui
@@ -13490,7 +13490,7 @@ min_phrase_weight: 100
 㖆	kuk
 㻃	kuk
 䢗	kuk
-曲	kuk
+曲	kuk	1000
 蛐	kuk
 㑋	kung
 㤟	kung
@@ -13503,7 +13503,7 @@ min_phrase_weight: 100
 䠻	kung
 匑	kung
 穷	kung
-窮	kung
+窮	kung	1000
 竆	kung
 笻	kung
 筇	kung
@@ -13522,13 +13522,13 @@ min_phrase_weight: 100
 䯺	kut
 佸	kut
 佸	wut
-括	kut
+括	kut	1000
 栝	kut
 濊	kut
 濊	wai
 筈	kut
 聒	kut
-豁	kut
+豁	kut	500
 适	kut
 适	sik
 髺	kut
@@ -13539,13 +13539,13 @@ min_phrase_weight: 100
 䋀	kwaa
 䯞	kwaa
 侉	kwaa
-垮	kwaa
-夸	kwaa
+垮	kwaa	1000
+夸	kwaa	500
 姱	kwaa
 胯	kwaa
 荂	kwaa
-誇	kwaa
-跨	kwaa
+誇	kwaa	1000
+跨	kwaa	1000
 銙	kwaa
 骻	kwaa
 㛻	kwaai
@@ -13597,32 +13597,32 @@ min_phrase_weight: 100
 巂	kwai
 巂	seoi
 巋	kwai
-愧	kwai
+愧	kwai	1000
 戣	kwai
-揆	kwai
+揆	kwai	500
 携	kwai
-攜	kwai
+攜	kwai	1000
 暌	kwai
 槻	kwai
 槼	kwai
 犪	kwai
-畦	kwai
-盔	kwai
+畦	kwai	500
+盔	kwai	500
 眭	kwai
 眭	seoi
-睽	kwai
+睽	kwai	500
 瞡	kwai
 窥	kwai
-窺	kwai
+窺	kwai	500
 聧	kwai
-葵	kwai
+葵	kwai	1000
 蠵	kwai
-規	kwai
+規	kwai	1000
 规	kwai
 觿	kwai
 跬	kwai
 蹞	kwai
-逵	kwai
+逵	kwai	500
 酅	kwai
 鑴	kwai
 闚	kwai
@@ -13639,9 +13639,9 @@ min_phrase_weight: 100
 㪊	kwan
 㿏	kwan
 䖵	kwan
-困	kwan
+困	kwan	1000
 囷	kwan
-坤	kwan
+坤	kwan	1000
 堃	kwan
 壸	kwan
 壼	kwan
@@ -13649,23 +13649,23 @@ min_phrase_weight: 100
 峮	kwan
 悃	kwan
 捃	kwan
-捆	kwan
+捆	kwan	1000
 攗	kwan
 攗	mei
 梱	kwan
 猑	kwan
-睏	kwan
+睏	kwan	500
 碅	kwan
 稇	kwan
 稛	kwan
-窘	kwan
+窘	kwan	500
 箘	kwan
-綑	kwan
-羣	kwan
+綑	kwan	500
+羣	kwan	1000
 群	kwan
-菌	kwan
+菌	kwan	1000
 菎	kwan
-裙	kwan
+裙	kwan	1000
 閫	kwan
 阃	kwan
 騉	kwan
@@ -13681,10 +13681,10 @@ min_phrase_weight: 100
 䵃	kwong
 䵃	wong
 圹	kwong
-壙	kwong
+壙	kwong	500
 扩	kwong
 旷	kwong
-曠	kwong
+曠	kwong	1000
 纊	kwong
 纩	kwong
 邝	kwong
@@ -13693,9 +13693,9 @@ min_phrase_weight: 100
 䠰	kyun
 巏	kyun
 惓	kyun
-拳	kyun
+拳	kyun	1000
 权	kyun
-權	kyun
+權	kyun	1000
 蜷	kyun
 蠸	kyun
 踡	kyun
@@ -13724,29 +13724,29 @@ min_phrase_weight: 100
 䮹	waai
 亅	kyut
 决	kyut
-厥	kyut
+厥	kyut	500
 噘	kyut
-孓	kyut
-抉	kyut
+孓	kyut	500
+抉	kyut	500
 撅	kyut
-決	kyut
-獗	kyut
+決	kyut	1000
+獗	kyut	500
 玦	kyut
-缺	kyut
+缺	kyut	1000
 芵	kyut
 蒛	kyut
-蕨	kyut
+蕨	kyut	500
 蟨	kyut
 觖	kyut
 觼	kyut
-訣	kyut
-譎	kyut
+訣	kyut	1000
+譎	kyut	500
 诀	kyut
 谲	kyut
 趹	kyut
 鈌	kyut
 鐍	kyut
-闋	kyut
+闋	kyut	500
 闕	kyut
 阕	kyut
 阙	kyut
@@ -13761,12 +13761,12 @@ min_phrase_weight: 100
 㙈	laa
 㙤	laa
 䖃	laa
-啦	laa
+啦	laa	1000
 嘑	laa
 嚹	laa
-拉	laa
-拉	laai
-拉	laap
+拉	laa	0%
+拉	laai	1000
+拉	laap	0%
 揦	laa
 砬	laa
 砬	laap
@@ -13799,17 +13799,17 @@ min_phrase_weight: 100
 攋	laai
 濑	laai
 癞	laai
-癩	laai
+癩	laai	500
 籁	laai
-籟	laai
-舐	laai
-舐	lem
-舐	lim
-舐	saai
-落	laai
-落	lok
+籟	laai	500
+舐	laai	500
+舐	lem	500
+舐	lim	500
+舐	saai	500
+落	laai	0%
+落	lok	1000
 藾	laai
-賴	laai
+賴	laai	1000
 赖	laai
 酹	laai
 酹	lyut
@@ -13820,14 +13820,14 @@ min_phrase_weight: 100
 㖀	laak
 㖀	lak
 㖀	leot
-勒	laak
-勒	lak
+勒	laak	200
+勒	lak	1000
 嘞	laak
 嘞	lak	1000
 砳	laak
 砳	lak
-肋	laak
-肋	lak
+肋	laak	200
+肋	lak	1000
 𨊛	laak
 㜮	laam
 㞩	laam
@@ -13847,34 +13847,34 @@ min_phrase_weight: 100
 䫐	laau
 䰐	laam
 嚂	laam
-婪	laam
+婪	laam	500
 岚	laam
-嵐	laam
+嵐	laam	500
 惏	laam
 揽	laam
 擥	laam
-攬	laam
+攬	laam	1000
 榄	laam
-欖	laam
+欖	laam	1000
 滥	laam
 漤	laam
-濫	laam
+濫	laam	1000
 灠	laam
 爁	laam
 爦	laam
 礛	laam
 箖	laam
 篮	laam
-籃	laam
-纜	laam
+籃	laam	1000
+纜	laam	1000
 缆	laam
 舰	laam
-艦	laam
+艦	laam	1000
 蓝	laam
-藍	laam
+藍	laam	1000
 褴	laam
-襤	laam
-覽	laam
+襤	laam	500
+覽	laam	1000
 览	laam
 轞	laam
 𨅏	laam
@@ -13891,30 +13891,30 @@ min_phrase_weight: 100
 囒	laan
 嬾	laan
 懒	laan
-懶	laan
+懶	laan	1000
 拦	laan
-攔	laan
+攔	laan	1000
 斓	laan
 斕	laan
 栏	laan
-欄	laan
+欄	laan	1000
 澜	laan
-瀾	laan
+瀾	laan	500
 灡	laan
 烂	laan
-爛	laan
+爛	laan	1000
 籣	laan
 糷	laan
-蘭	laan
+蘭	laan	1000
 襴	laan
 讕	laan
 谰	laan
 鑭	laan
 镧	laan
-闌	laan
+闌	laan	1000
 阑	laan
 𢦂	laan
-冷	laang
+冷	laang	1000
 唥	laang
 唥	lang
 㧜	laap
@@ -13925,20 +13925,20 @@ min_phrase_weight: 100
 䃳	laap
 䗶	laap
 䶘	laap
-垃	laap
+垃	laap	1000
 妠	laap
 妠	naap
 擸	laap
 擸	lip
-立	laap
-立	lap
+立	laap	1000
+立	lap	1000
 翋	laap
 腊	laap
 腊	sik
 臈	laap
-臘	laap
-臘	lip
-蠟	laap
+臘	laap	1000
+臘	lip	200
+蠟	laap	1000
 邋	laap
 邋	laat
 鑞	laap
@@ -13950,14 +13950,14 @@ min_phrase_weight: 100
 㻝	laat
 䱫	laat
 䶛	laat
-列	laat
-列	lit
-剌	laat
+列	laat	501
+列	lit	1000
+剌	laat	500
 楋	laat
 瘌	laat
 辢	laat
-辣	laat
-辣	lat
+辣	laat	1000
+辣	lat	0%
 迾	laat
 迾	lit
 鬎	laat
@@ -13989,8 +13989,8 @@ min_phrase_weight: 100
 䱾	laau
 捞	laau
 捞	lou
-撈	laau
-撈	lou
+撈	laau	1000
+撈	lou	1000
 嚟	lai	10000
 嚟	lei
 㒧	lai
@@ -14020,25 +14020,25 @@ min_phrase_weight: 100
 䴡	lai
 䵩	lai
 丽	lai
-來	lai
-來	loi
-例	lai
+來	lai	501
+來	loi	1000
+例	lai	1000
 俪	lai
-儷	lai
+儷	lai	500
 剺	lai
 剺	lei
 劙	lai
 劙	lei
 励	lai
-勵	lai
+勵	lai	1000
 厉	lai
-厲	lai
+厲	lai	1000
 囄	lai
 囄	lei
 悷	lai
-捩	lai
-捩	lit
-捩	leoi
+捩	lai	0%
+捩	lit	1000
+捩	leoi	0%
 攦	lai
 攭	lai
 栵	lai
@@ -14046,28 +14046,28 @@ min_phrase_weight: 100
 樏	lai
 樏	leoi
 欐	lai
-澧	lai
+澧	lai	500
 濿	lai
-犁	lai
+犁	lai	1000
 犂	lai
 疠	lai
-癘	lai
+癘	lai	500
 矋	lai
 矖	lai
 砅	lai
 砺	lai
-礪	lai
+礪	lai	500
 礼	lai
-禮	lai
+禮	lai	1000
 粝	lai
 糲	lai
-荔	lai
+荔	lai	1000
 蔾	lai
 藜	lai
 藜	lei
 蛎	lai
-蠡	lai
-蠣	lai
+蠡	lai	500
+蠣	lai	500
 豊	lai
 迣	lai
 迣	lit
@@ -14075,8 +14075,8 @@ min_phrase_weight: 100
 醴	lai
 鱧	lai
 鳢	lai
-麗	lai
-黎	lai
+麗	lai	1000
+黎	lai	1000
 黧	lai
 𡂖	lai
 𡅏	lai
@@ -14120,25 +14120,25 @@ min_phrase_weight: 100
 䕲	lam
 临	lam
 凛	lam
-凜	lam
+凜	lam	500
 啉	lam
 壈	lam
 廩	lam
 廪	lam
-懍	lam
+懍	lam	500
 懔	lam
-林	lam
+林	lam	1000
 檁	lam
 檩	lam
-淋	lam
-琳	lam
-痳	lam
-痳	maa
+淋	lam	1000
+琳	lam	1000
+痳	lam	500
+痳	maa	500
 罧	lam
 罧	sam
-臨	lam
+臨	lam	1000
 菻	lam
-霖	lam
+霖	lam	500
 𡒄	lam
 𠹹	lan
 𠹹	leon
@@ -14158,9 +14158,9 @@ min_phrase_weight: 100
 䤚	lei
 䲞	lap
 搚	lap
-笠	lap
-粒	lap
-粒	nap
+笠	lap	500
+粒	lap	200
+粒	nap	1000
 苙	lap
 镴	lap
 鴗	lap
@@ -14169,7 +14169,7 @@ min_phrase_weight: 100
 䀳	lat
 䏀	lat
 䏀	lit
-甩	lat
+甩	lat	1000
 𢫫	lat
 㐬	lau
 㔷	lau
@@ -14190,13 +14190,13 @@ min_phrase_weight: 100
 偻	lau
 僂	lau
 刘	lau
-劉	lau
+劉	lau	1000
 喽	lau
-嘍	lau
+嘍	lau	500
 嚠	lau
 塿	lau
 娄	lau
-婁	lau
+婁	lau	500
 嵝	lau
 嶁	lau
 廇	lau
@@ -14204,41 +14204,41 @@ min_phrase_weight: 100
 慺	lau
 懰	lau
 搂	lau
-摟	lau
+摟	lau	1000
 旈	lau
 旒	lau
-柳	lau
+柳	lau	1000
 楼	lau
-榴	lau
-樓	lau
+榴	lau	1000
+樓	lau	1000
 橊	lau
-流	lau
+流	lau	1000
 浏	lau
-溜	lau
-溜	liu
+溜	lau	1000
+溜	liu	501
 漊	lau
 漊	lou
-漏	lau
+漏	lau	1000
 漻	lau
 漻	liu
-瀏	lau
-琉	lau
+瀏	lau	1000
+琉	lau	500
 瑠	lau
 璢	lau
-留	lau
+留	lau	1000
 畱	lau
 瘘	lau
-瘤	lau
+瘤	lau	1000
 瘺	lau
 瘻	lau
 癅	lau
 瞜	lau
-硫	lau
+硫	lau	500
 篓	lau
-簍	lau
+簍	lau	500
 綹	lau
-縷	lau
-縷	leoi
+縷	lau	500
+縷	leoi	500
 绺	lau
 罶	lau
 翏	lau
@@ -14252,10 +14252,10 @@ min_phrase_weight: 100
 蒌	lau
 蔞	lau
 蝼	lau
-螻	lau
+螻	lau	500
 蟉	lau
-褸	lau
-褸	leoi
+褸	lau	1000
+褸	leoi	0%
 謱	lau
 謱	leoi
 謱	lou
@@ -14268,31 +14268,31 @@ min_phrase_weight: 100
 镂	lau
 镏	lau
 镠	lau
-陋	lau
+陋	lau	1000
 霤	lau
-露	lau
-露	lou
+露	lau	0%
+露	lou	1000
 鞻	lau
 飀	lau
 飂	lau
 飂	liu
 飗	lau
-餾	lau
+餾	lau	500
 馏	lau
 騮	lau
 骝	lau
 髅	lau
-髏	lau
+髏	lau	500
 鰡	lau
 鶹	lau
 鷚	lau
 鹠	lau
 鹨	lau
 𤠑	lau
-咧	le
-哩	le
-哩	lei
-哩	li
+咧	le	500
+哩	le	1000
+哩	lei	1000
+哩	li	0%
 褦	le
 褦	naai
 褦	nang
@@ -14323,67 +14323,67 @@ min_phrase_weight: 100
 䧉	lei
 䱘	lei
 䴻	lei
-俐	lei
-俚	lei
-利	lei
+俐	lei	1000
+俚	lei	500
+利	lei	1000
 厘	lei
-吏	lei
+吏	lei	1000
 唎	lei
 唎	li
-喱	lei
-妳	lei
-妳	naai
-妳	nei
-娌	lei
+喱	lei	1000
+妳	lei	500
+妳	naai	500
+妳	nei	500
+娌	lei	500
 嫠	lei
 孋	lei
-履	lei
-履	leoi
+履	lei	1000
+履	leoi	0%
 峛	lei
-李	lei
-梨	lei
+李	lei	1000
+梨	lei	1000
 梩	lei
 棃	lei
 樆	lei
 氂	lei
 氂	moi
-浬	lei
+浬	lei	500
 浰	lei
 浰	lin
 涖	lei
-漓	lei
+漓	lei	500
 漦	lei
 灕	lei
-犛	lei
-狸	lei
+犛	lei	500
+狸	lei	1000
 猁	lei
 猕	lei
 猕	mei
 獼	lei
 獼	mei
 獼	nei
-理	lei
+理	lei	1000
 琍	lei
-璃	lei
+璃	lei	1000
 瓈	lei
-痢	lei
+痢	lei	500
 离	lei
 离	sit
 筣	lei
 篱	lei
-籬	lei
+籬	lei	1000
 縭	lei
 缡	lei
-罹	lei
+罹	lei	1000
 脷	lei
 莅	lei
-莉	lei
-蒞	lei
+莉	lei	500
+蒞	lei	500
 蓠	lei
 蘺	lei
 蜊	lei
-裏	lei
-裏	leoi
+裏	lei	0%
+裏	leoi	1000
 裡	lei
 裡	leoi
 褵	lei
@@ -14391,19 +14391,19 @@ min_phrase_weight: 100
 謧	lei
 貍	lei
 逦	lei
-邐	lei
+邐	lei	500
 醨	lei
-里	lei
+里	lei	1000
 鋰	lei
 锂	lei
-離	lei
-霾	lei
-霾	maai
-霾	mai
-驪	lei
+離	lei	1000
+霾	lei	500
+霾	maai	500
+霾	mai	500
+驪	lei	500
 骊	lei
 鬁	lei
-鯉	lei
+鯉	lei	1000
 鱺	lei
 鲡	lei
 鲤	lei
@@ -14423,14 +14423,14 @@ min_phrase_weight: 100
 䈊	liu
 僆	leng
 僆	lin
-嶺	leng
-嶺	ling
-靈	leng
-靈	ling
+嶺	leng	200
+嶺	ling	1000
+靈	leng	501
+靈	ling	1000
 靓	leng
 靓	zing
-領	leng
-領	ling
+領	leng	501
+領	ling	1000
 鮻	leng
 鯪	leng
 鯪	ling
@@ -14470,48 +14470,48 @@ min_phrase_weight: 100
 䯁	leoi
 䴎	leoi
 侣	leoi
-侶	leoi
-儡	leoi
+侶	leoi	1000
+儡	leoi	500
 儢	leoi
 儽	leoi
 勴	leoi
 吕	leoi
-呂	leoi
-唳	leoi
+呂	leoi	500
+唳	leoi	500
 垒	leoi
-壘	leoi
-壘	leot
-嫘	leoi
+壘	leoi	1000
+壘	leot	0%
+嫘	leoi	500
 屡	leoi
-屢	leoi
+屢	leoi	1000
 惀	leoi
 惀	leon
-慮	leoi
-戾	leoi
-擂	leoi
+慮	leoi	1000
+戾	leoi	500
+擂	leoi	1000
 攂	leoi
-旅	leoi
+旅	leoi	1000
 梠	leoi
 榈	leoi
 檑	leoi
 櫐	leoi
 櫑	leoi
-櫚	leoi
+櫚	leoi	500
 欙	leoi
 氀	leoi
 沴	leoi
 泪	leoi
-淚	leoi
+淚	leoi	1000
 滤	leoi
 漯	leoi
 漯	lok
 漯	taap
-濾	leoi
+濾	leoi	1000
 灅	leoi
 畾	leoi
 癗	leoi
 盭	leoi
-磊	leoi
+磊	leoi	500
 磥	leoi
 礌	leoi
 礧	leoi
@@ -14520,21 +14520,21 @@ min_phrase_weight: 100
 稆	leoi
 穭	leoi
 类	leoi
-累	leoi
+累	leoi	1000
 絫	leoi
-縲	leoi
+縲	leoi	500
 纇	leoi
 纍	leoi
 缕	leoi
 缧	leoi
 罍	leoi
-羸	leoi
-耒	leoi
-耒	loi
+羸	leoi	500
+耒	leoi	500
+耒	loi	500
 膂	leoi
 蔂	leoi
 蔂	lo
-蕾	leoi
+蕾	leoi	1000
 藘	leoi
 藟	leoi
 蘱	leoi
@@ -14548,17 +14548,17 @@ min_phrase_weight: 100
 誄	loi
 轠	leoi
 郘	leoi
-鋁	leoi
-鐳	leoi
+鋁	leoi	1000
+鐳	leoi	1000
 鑢	leoi
 铝	leoi
 镭	leoi
-閭	leoi
+閭	leoi	500
 闾	leoi
-雷	leoi
-類	leoi
-驢	leoi
-驢	lou
+雷	leoi	1000
+類	leoi	1000
+驢	leoi	1000
+驢	lou	1000
 驴	leoi
 驴	lou
 鸓	leoi
@@ -14586,56 +14586,56 @@ min_phrase_weight: 100
 䮼	leon
 仑	leon
 伦	leon
-侖	leon
-倫	leon
-卵	leon
-卵	lo
-吝	leon
+侖	leon	500
+倫	leon	1000
+卵	leon	1000
+卵	lo	0%
+吝	leon	1000
 噒	leon
 囵	leon
 圇	leon
 崘	leon
-崙	leon
+崙	leon	500
 嶙	leon
 抡	leon
-掄	leon
+掄	leon	500
 橉	leon
 沦	leon
-淪	leon
+淪	leon	1000
 潾	leon
-燐	leon
+燐	leon	500
 璘	leon
 甐	leon
 疄	leon
 瞵	leon
-磷	leon
+磷	leon	500
 粦	leon
 粼	leon
-紊	leon
-紊	man
+紊	leon	0%
+紊	man	1000
 膦	leon
 菕	leon
 蔺	leon
-藺	leon
-論	leon
+藺	leon	1000
+論	leon	1000
 论	leon
 蹸	leon
 躏	leon
-躪	leon
-輪	leon
-轔	leon
+躪	leon	500
+輪	leon	1000
+轔	leon	500
 轮	leon
 辚	leon
-遴	leon
+遴	leon	500
 邻	leon
-鄰	leon
+鄰	leon	1000
 鏻	leon
 閵	leon
 隣	leon
 驎	leon
-鱗	leon
+鱗	leon	1000
 鳞	leon
-麟	leon
+麟	leon	500
 㧒	leot
 㧒	waat
 㮚	leot
@@ -14654,13 +14654,13 @@ min_phrase_weight: 100
 噊	leot
 噊	wat
 嵂	leot
-律	leot
-慄	leot
+律	leot	1000
+慄	leot	500
 搮	leot
-栗	leot
+栗	leot	500
 溧	leot
-率	leot
-率	seot
+率	leot	1000
+率	seot	1000
 瑮	leot
 硉	leot
 篥	leot
@@ -14698,7 +14698,7 @@ min_phrase_weight: 100
 䮥	lik
 䰛	lik
 䰜	lik
-力	lik
+力	lik	1000
 历	lik
 厤	lik
 呖	lik
@@ -14706,21 +14706,21 @@ min_phrase_weight: 100
 坜	lik
 擽	lik
 擽	loek
-曆	lik
+曆	lik	1000
 枥	lik
 栎	lik
 櫟	lik
 櫪	lik
 歴	lik
-歷	lik
+歷	lik	1000
 沥	lik
-瀝	lik
-爍	lik
-爍	soek
+瀝	lik	1000
+爍	lik	0%
+爍	soek	1000
 瓅	lik
 皪	lik
 磿	lik
-礫	lik
+礫	lik	500
 芀	lik
 芀	siu
 芀	tiu
@@ -14736,9 +14736,9 @@ min_phrase_weight: 100
 郦	lik
 酈	lik
 雳	lik
-靂	lik
-令	lim	0%
-令	ling
+靂	lik	500
+令	lim	0
+令	ling	1000
 㝺	lim
 㡘	lim
 㪘	lim
@@ -14755,25 +14755,25 @@ min_phrase_weight: 100
 䨬	lim
 䭑	lim
 奁	lim
-奩	lim
-帘	lim
-廉	lim
+奩	lim	500
+帘	lim	500
+廉	lim	1000
 敛	lim
-斂	lim
+斂	lim	500
 歛	lim
 殓	lim
-殮	lim
+殮	lim	500
 溓	lim
 潋	lim
 澰	lim
-濂	lim
+濂	lim	500
 瀲	lim
 磏	lim
-簾	lim
+簾	lim	1000
 羷	lim
 脸	lim
 臁	lim
-臉	lim
+臉	lim	1000
 蔹	lim
 蘞	lim
 蠊	lim
@@ -14783,7 +14783,7 @@ min_phrase_weight: 100
 襜	zim
 襝	lim
 鎌	lim
-鐮	lim
+鐮	lim	500
 镰	lim
 鬑	lim
 𢅏	lim
@@ -14798,35 +14798,35 @@ min_phrase_weight: 100
 嗹	lin
 怜	lin
 怜	ling
-憐	lin
+憐	lin	1000
 摙	lin
 撵	lin
-攆	lin
+攆	lin	500
 梿	lin
 楝	lin
 槤	lin
 涟	lin
 湅	lin
-漣	lin
+漣	lin	500
 炼	lin
-煉	lin
+煉	lin	1000
 琏	lin
 璉	lin
-練	lin
+練	lin	1000
 练	lin
 莲	lin
-蓮	lin
+蓮	lin	1000
 裢	lin
 褳	lin
 謰	lin
-輦	lin
+輦	lin	500
 辇	lin
 连	lin
-連	lin
-鍊	lin
-鏈	lin
+連	lin	1000
+鍊	lin	500
+鏈	lin	1000
 链	lin
-鰱	lin
+鰱	lin	500
 鲢	lin
 㖫	ling
 㡵	ling
@@ -14865,25 +14865,25 @@ min_phrase_weight: 100
 䴇	ling
 䴒	ling
 䴫	ling
-伶	ling
-凌	ling
-另	ling
+伶	ling	1000
+凌	ling	1000
+另	ling	1000
 呤	ling
 囹	ling
 堎	ling
 夌	ling
 岭	ling
 崚	ling
-愣	ling
+愣	ling	1000
 拎	ling
-擰	ling
-擰	ning
+擰	ling	501
+擰	ning	1000
 柃	ling
 棂	ling
 棱	ling
-楞	ling
-檸	ling
-檸	ning
+楞	ling	500
+檸	ling	501
+檸	ning	1000
 櫺	ling
 欞	ling
 泠	ling
@@ -14891,21 +14891,21 @@ min_phrase_weight: 100
 灵	ling
 炩	ling
 狑	ling
-玲	ling
+玲	ling	500
 瓴	ling
 睖	ling
 稑	ling
 稑	luk
-稜	ling
+稜	ling	500
 笭	ling
-綾	ling
+綾	ling	500
 绫	ling
-羚	ling
-翎	ling
-聆	ling
+羚	ling	500
+翎	ling	500
+聆	ling	1000
 舲	ling
-苓	ling
-菱	ling
+苓	ling	500
+菱	ling	1000
 蔆	ling
 薐	ling
 蘦	ling
@@ -14915,17 +14915,17 @@ min_phrase_weight: 100
 輘	ling
 酃	ling
 醽	ling
-鈴	ling
+鈴	ling	1000
 铃	ling
-陵	ling
-零	ling
+陵	ling	1000
+零	ling	1000
 霝	ling
 领	ling
 鲮	ling
 鳹	ling
 鴒	ling
 鸰	ling
-齡	ling
+齡	ling	1000
 龄	ling
 𫐉	ling
 㯿	lip
@@ -14937,7 +14937,7 @@ min_phrase_weight: 100
 巤	lip
 犣	lip
 猎	lip
-獵	lip
+獵	lip	1000
 躐	lip
 鬣	lip
 𤢪	lip
@@ -14949,13 +14949,13 @@ min_phrase_weight: 100
 䅀	lit
 䮋	lit
 䴕	lit
-冽	lit
+冽	lit	500
 洌	lit
-烈	lit
+烈	lit	1000
 綟	lit
 茢	lit
 蛚	lit
-裂	lit
+裂	lit	1000
 趔	lit
 颲	lit
 鮤	lit
@@ -14977,40 +14977,40 @@ min_phrase_weight: 100
 䢧	liu
 䨅	liu
 䩍	liu
-了	liu
-僚	liu
-嘹	liu
+了	liu	1000
+僚	liu	500
+嘹	liu	1000
 嫽	liu
-寥	liu
-寮	liu
+寥	liu	1000
+寮	liu	500
 尥	liu
 屪	liu
 嵺	liu
 嶚	liu
-廖	liu
+廖	liu	500
 憀	liu
 憭	liu
 撂	liu
-撩	liu
+撩	liu	500
 敹	liu
-料	liu
+料	liu	1000
 暸	liu
 橑	liu
 橑	lou
-潦	liu
-潦	lou
+潦	liu	1000
+潦	lou	1000
 炓	liu
 炓	tau
-燎	liu
+燎	liu	500
 獠	liu
 獠	lou
 疗	liu
-療	liu
-瞭	liu
+療	liu	1000
+瞭	liu	1000
 簝	liu
-繚	liu
+繚	liu	1000
 缭	liu
-聊	liu
+聊	liu	1000
 膋	liu
 膫	liu
 蓼	liu
@@ -15020,7 +15020,7 @@ min_phrase_weight: 100
 蹘	liu
 蹘	mau
 辽	liu
-遼	liu
+遼	liu	1000
 鄝	liu
 釕	liu
 鐐	liu
@@ -15047,30 +15047,30 @@ min_phrase_weight: 100
 椤	lo
 欏	lo
 猡	lo
-玀	lo
+玀	lo	500
 瘰	lo
 砢	lo
 箩	lo
-籮	lo
+籮	lo	1000
 罗	lo
-羅	lo
+羅	lo	1000
 脶	lo
 腡	lo
 臝	lo
 萝	lo
 蓏	lo
-蘿	lo
-螺	lo
+蘿	lo	1000
+螺	lo	1000
 蠃	lo
-裸	lo
+裸	lo	1000
 覶	lo
 躶	lo
 逻	lo
-邏	lo
-鑼	lo
+邏	lo	1000
+鑼	lo	1000
 锣	lo
 饠	lo
-騾	lo
+騾	lo	1000
 驘	lo
 骡	lo
 鸁	lo
@@ -15085,8 +15085,8 @@ min_phrase_weight: 100
 㨼	loek
 䂮	loek
 䌎	loek
-掠	loek
-略	loek
+掠	loek	1000
+略	loek	1000
 畧	loek
 㒳	loeng
 㔝	loeng
@@ -15102,40 +15102,40 @@ min_phrase_weight: 100
 䭪	loeng
 両	loeng
 两	loeng
-亮	loeng
+亮	loeng	1000
 俍	loeng
 俩	loeng
-倆	loeng
-兩	loeng
+倆	loeng	1000
+兩	loeng	1000
 凉	loeng
 唡	loeng
 啢	loeng
 喨	loeng
 悢	loeng
 悢	long
-梁	loeng
+梁	loeng	1000
 椋	loeng
-樑	loeng
-涼	loeng
+樑	loeng	1000
+涼	loeng	1000
 粮	loeng
-粱	loeng
-糧	loeng
+粱	loeng	1000
+糧	loeng	1000
 緉	loeng
-良	loeng
+良	loeng	1000
 莨	loeng
 莨	long
 蜋	loeng
 蜋	long
 裲	loeng
-諒	loeng
+諒	loeng	1000
 谅	loeng
 踉	loeng
 踉	long
-輛	loeng
+輛	loeng	1000
 輬	loeng
 辆	loeng
 辌	loeng
-量	loeng
+量	loeng	1000
 魉	loeng
 魎	loeng
 㚓	loi
@@ -15157,9 +15157,9 @@ min_phrase_weight: 100
 涞	loi
 淶	loi
 睐	loi
-睞	loi
+睞	loi	500
 莱	loi
-萊	loi
+萊	loi	500
 诔	loi
 賚	loi
 赉	loi
@@ -15187,20 +15187,20 @@ min_phrase_weight: 100
 䌴	lok
 乐	lok
 乐	ngok
-樂	lok
-樂	ngaau
-樂	ngok
-洛	lok
-烙	lok
-犖	lok
+樂	lok	1000
+樂	ngaau	200
+樂	ngok	1000
+洛	lok	1000
+烙	lok	500
+犖	lok	500
 珞	lok
-絡	lok
+絡	lok	1000
 络	lok
 荦	lok
-酪	lok
-酪	lou
+酪	lok	1000
+酪	lou	1000
 雒	lok
-駱	lok
+駱	lok	1000
 骆	lok
 𡀩	lok
 㓪	long
@@ -15221,30 +15221,30 @@ min_phrase_weight: 100
 啷	long
 塱	long
 崀	long
-廊	long
+廊	long	1000
 晾	long
-朗	long
+朗	long	1000
 桹	long
-榔	long
-浪	long
+榔	long	500
+浪	long	1000
 烺	long
-狼	long
-琅	long
-瑯	long
+狼	long	1000
+琅	long	500
+瑯	long	1000
 硠	long
 稂	long
 筤	long
 蒗	long
 蓢	long
-螂	long
-郎	long
+螂	long	1000
+郎	long	1000
 郞	long
 鋃	long
 鎯	long
 锒	long
 閬	long
 阆	long
-廊	long
+廊	long	1000
 𠺘	long
 𠻴	long
 𢲲	long
@@ -15278,28 +15278,28 @@ min_phrase_weight: 100
 䵏	lou
 僗	lou
 劳	lou
-勞	lou
+勞	lou	1000
 卢	lou
 卤	lou
 唠	lou
-嘮	lou
+嘮	lou	500
 噜	lou
-嚕	lou
+嚕	lou	500
 垆	lou
 壚	lou
-姥	lou
-姥	mou
+姥	lou	1000
+姥	mou	0%
 嫪	lou
 庐	lou
-廬	lou
+廬	lou	1000
 恅	lou
 掳	lou
-擄	lou
+擄	lou	1000
 擼	lou
 栌	lou
 栳	lou
 橹	lou
-櫓	lou
+櫓	lou	500
 櫨	lou
 氇	lou
 氌	lou
@@ -15311,23 +15311,23 @@ min_phrase_weight: 100
 澇	lou
 瀘	lou
 炉	lou
-爐	lou
-牢	lou
+爐	lou	1000
+牢	lou	1000
 狫	lou
 玈	lou
 璐	lou
 痨	lou
-癆	lou
-盧	lou
+癆	lou	500
+盧	lou	500
 磠	lou
 簩	lou
 簬	lou
 籚	lou
 纑	lou
 罏	lou
-老	lou
+老	lou	1000
 胪	lou
-臚	lou
+臚	lou	500
 舻	lou
 艣	lou
 艪	lou
@@ -15335,14 +15335,14 @@ min_phrase_weight: 100
 芦	lou
 蓾	lou
 蕗	lou
-蘆	lou
+蘆	lou	1000
 虏	lou
-虜	lou
+虜	lou	1000
 蟧	lou
 蠦	lou
-賂	lou
+賂	lou	1000
 赂	lou
-路	lou
+路	lou	1000
 輅	lou
 轑	lou
 轤	lou
@@ -15355,19 +15355,19 @@ min_phrase_weight: 100
 鑪	lou
 铑	lou
 铹	lou
-顱	lou
+顱	lou	1000
 颅	lou
-魯	lou
-鱸	lou
+魯	lou	1000
+鱸	lou	500
 鲁	lou
 鲈	lou
-鷺	lou
+鷺	lou	500
 鸕	lou
 鸬	lou
 鹭	lou
-鹵	lou
+鹵	lou	500
 黸	lou
-虜	lou
+虜	lou	1000
 𡀔	lou
 𢲸	lou
 㓐	luk
@@ -15397,13 +15397,13 @@ min_phrase_weight: 100
 䱚	luk
 䴪	luk
 僇	luk
-六	luk
+六	luk	1000
 坴	luk
 彔	luk
 录	luk
-戮	luk
+戮	luk	500
 摝	luk
-氯	luk
+氯	luk	500
 淥	luk
 渌	luk
 漉	luk
@@ -15412,15 +15412,15 @@ min_phrase_weight: 100
 甪	luk
 盝	luk
 睩	luk
-碌	luk
+碌	luk	1000
 磟	luk
-祿	luk
+祿	luk	500
 禄	luk
 穋	luk
 箓	luk
 簏	luk
 籙	luk
-綠	luk
+綠	luk	1000
 绿	luk
 菉	luk
 觻	luk
@@ -15429,14 +15429,14 @@ min_phrase_weight: 100
 辘	luk
 逯	luk
 醁	luk
-錄	luk
+錄	luk	1000
 錴	luk
 陆	luk
-陸	luk
+陸	luk	1000
 騄	luk
 鯥	luk
-鹿	luk
-麓	luk
+鹿	luk	1000
+麓	luk	1000
 𢮑	luk
 𤊒	luk
 窿	lung	1000
@@ -15462,37 +15462,37 @@ min_phrase_weight: 100
 儱	lung
 咙	lung
 哢	lung
-嚨	lung
+嚨	lung	1000
 垄	lung
-壟	lung
+壟	lung	500
 巃	lung
-弄	lung
-弄	nung
+弄	lung	1000
+弄	nung	200
 徿	lung
 拢	lung
-攏	lung
+攏	lung	500
 昽	lung
 曨	lung
-朧	lung
+朧	lung	1000
 栊	lung
 櫳	lung
 泷	lung
 瀧	lung
 瀧	soeng
 珑	lung
-瓏	lung
+瓏	lung	500
 癃	lung
 眬	lung
-矓	lung
+矓	lung	500
 砻	lung
 礱	lung
 竉	lung
 竜	lung
 笼	lung
 篢	lung
-籠	lung
+籠	lung	1000
 聋	lung
-聾	lung
+聾	lung	1000
 胧	lung
 茏	lung
 蘢	lung
@@ -15501,9 +15501,9 @@ min_phrase_weight: 100
 躘	lung
 鑨	lung
 陇	lung
-隆	lung
-隴	lung
-龍	lung
+隆	lung	1000
+隴	lung	500
+龍	lung	1000
 龙	lung
 𢙱	lung
 𤮨	lung
@@ -15520,18 +15520,18 @@ min_phrase_weight: 100
 䖂	lyun
 䜌	lyun
 乱	lyun
-亂	lyun
+亂	lyun	1000
 圞	lyun
 娈	lyun
 孌	lyun
 孪	lyun
-孿	lyun
+孿	lyun	500
 峦	lyun
-巒	lyun
+巒	lyun	1000
 恋	lyun
-戀	lyun
+戀	lyun	1000
 挛	lyun
-攣	lyun
+攣	lyun	1000
 栾	lyun
 欒	lyun
 滦	lyun
@@ -15539,14 +15539,14 @@ min_phrase_weight: 100
 癵	lyun
 羉	lyun
 联	lyun
-聯	lyun
+聯	lyun	1000
 脔	lyun
 臠	lyun
 薍	lyun
 薍	waan
 銮	lyun
-鑾	lyun
-鸞	lyun
+鑾	lyun	500
+鸞	lyun	500
 鸾	lyun
 𪢮	lyun
 㭞	lyut
@@ -15555,7 +15555,7 @@ min_phrase_weight: 100
 㸹	lyut
 㽟	lyut
 䤣	lyut
-劣	lyut
+劣	lyut	1000
 哷	lyut
 埒	lyut
 挘	lyut
@@ -15565,7 +15565,7 @@ min_phrase_weight: 100
 鋝	lyut
 锊	lyut
 唔	m	100000
-唔	ng
+唔	ng	1000
 呒	m
 呣	m
 㐷	maa
@@ -15588,38 +15588,38 @@ min_phrase_weight: 100
 䵢	mui
 傌	maa
 吗	maa
-嗎	maa
-嘛	maa
+嗎	maa	1000
+嘛	maa	1000
 嚜	maa
 嚜	maak
 嚜	mak
 妈	maa
-媽	maa
+媽	maa	1000
 嫲	maa
-嬤	maa
+嬤	maa	500
 嬷	maa
 孖	maa
 榪	maa
 玛	maa
-瑪	maa
+瑪	maa	1000
 痲	maa
 码	maa
-碼	maa
+碼	maa	1000
 祃	maa
 禡	maa
-罵	maa
+罵	maa	1000
 蔴	maa
 蚂	maa
-螞	maa
-蟆	maa
+螞	maa	1000
+蟆	maa	500
 鎷	maa
-馬	maa
+馬	maa	1000
 駡	maa
 马	maa
 骂	maa
-麻	maa
-麼	maa
-麼	mo
+麻	maa	1000
+麼	maa	0%
+麼	mo	1000
 㜆	maai
 㜥	maai
 㝥	maai
@@ -15637,12 +15637,12 @@ min_phrase_weight: 100
 劢	maai
 勱	maai
 卖	maai
-埋	maai
+埋	maai	1000
 薶	maai
-買	maai
-賣	maai
+買	maai	1000
+賣	maai	1000
 迈	maai
-邁	maai
+邁	maai	1000
 𠹺	maai
 䁇	maak
 䁇	maat
@@ -15655,9 +15655,9 @@ min_phrase_weight: 100
 䮬	maak
 䳮	maak
 䳮	maat
-擘	maak
-麥	maak
-麥	mak
+擘	maak	500
+麥	maak	0%
+麥	mak	1000
 㗃	maan
 㗈	maan
 㝰	maan
@@ -15683,56 +15683,56 @@ min_phrase_weight: 100
 卍	maan
 墁	maan
 姏	maan
-娩	maan
-娩	min
+娩	maan	500
+娩	min	500
 嫚	maan
-幔	maan
-慢	maan
+幔	maan	500
+慢	maan	1000
 摱	maan
-晚	maan
-曼	maan
+晚	maan	1000
+曼	maan	1000
 槾	maan
-漫	maan
+漫	maan	1000
 熳	maan
 矕	maan
 縵	maan
 缦	maan
 脕	maan
-萬	maan
-蔓	maan
+萬	maan	1000
+蔓	maan	1000
 蛮	maan
-蠻	maan
+蠻	maan	1000
 謾	maan
 谩	maan
 鄤	maan
 鏝	maan
 镘	maan
-饅	maan
+饅	maan	1000
 馒	maan
 鬘	maan
-鰻	maan
+鰻	maan	500
 鳗	maan
 𢶯	maan
 𢺳	maan
 䁅	maang
 䁅	mang
 䇇	maang
-孟	maang
+孟	maang	1000
 掹	maang
 掹	mang
-氓	maang
-氓	man
-氓	mong
-猛	maang
-盲	maang
+氓	maang	0%
+氓	man	1000
+氓	mong	1000
+猛	maang	1000
+盲	maang	1000
 盳	maang
 盳	mong
 艋	maang
 莔	maang
-蜢	maang
+蜢	maang	500
 鄳	maang
 鄳	mong
-錳	maang
+錳	maang	500
 锰	maang
 鯭	maang
 䀛	maat
@@ -15742,10 +15742,10 @@ min_phrase_weight: 100
 䊅	maat
 䊅	ming
 䠚	maat
-抹	maat
-抹	mut
-襪	maat
-襪	mat
+抹	maat	501
+抹	mut	1000
+襪	maat	0%
+襪	mat	1000
 㚹	maau
 㚹	mau
 㮘	maau
@@ -15761,24 +15761,24 @@ min_phrase_weight: 100
 䤊	maau
 䤊	zung
 䫉	maau
-卯	maau
+卯	maau	1000
 媌	maau
 昴	maau
 泖	maau
-牡	maau
-牡	mau
+牡	maau	1000
+牡	mau	0%
 猫	maau
-矛	maau
-茅	maau
+矛	maau	1000
+茅	maau	1000
 茆	maau
 蝥	maau
 蟊	maau
-貌	maau
-貓	maau
-貓	miu
+貌	maau	1000
+貓	maau	1000
+貓	miu	0%
 鉚	maau
-錨	maau
-錨	naau
+錨	maau	500
+錨	naau	500
 铆	maau
 锚	maau
 锚	naau
@@ -15791,24 +15791,24 @@ min_phrase_weight: 100
 䨪	mai
 䨪	mo
 䱊	mai
-弭	mai
-弭	mei
+弭	mai	500
+弭	mei	500
 敉	mai
 敉	mei
 渳	mai
 眯	mai
 眯	mei
 眯	mi
-瞇	mai
-瞇	mei
-瞇	mi
-米	mai
+瞇	mai	500
+瞇	mei	500
+瞇	mi	500
+米	mai	1000
 蛑	mai
 蛑	mau
-袂	mai
-謎	mai
+袂	mai	500
+謎	mai	1000
 谜	mai
-迷	mai
+迷	mai	1000
 醚	mai
 銤	mai
 麛	mai
@@ -15818,15 +15818,15 @@ min_phrase_weight: 100
 䁿	mak
 䘑	mak
 䮮	mak
-冒	mak
-冒	mou
+冒	mak	0%
+冒	mou	1000
 唛	mak
 嘜	mak
-墨	mak
+墨	mak	1000
 癦	mak
 眽	mak
 纆	mak
-脈	mak
+脈	mak	1000
 脉	mak
 蓦	mak
 衇	mak
@@ -15838,12 +15838,12 @@ min_phrase_weight: 100
 貊	mak
 貘	mak
 貘	mok
-陌	mak
+陌	mak	1000
 霡	mak
 霢	mak
-驀	mak
+驀	mak	500
 麦	mak
-默	mak
+默	mak	1000
 黙	mak
 𦢓	mak
 𩜠	mam
@@ -15880,29 +15880,29 @@ min_phrase_weight: 100
 伩	man
 伩	seon
 僶	man
-免	man
-免	min
-刎	man
+免	man	0%
+免	min	1000
+刎	man	500
 勄	man
-吻	man
+吻	man	1000
 呅	man
 呡	man
-問	man
-岷	man
+問	man	1000
+岷	man	500
 忞	man
 怋	man
 悯	man
 愍	man
-憫	man
+憫	man	500
 抆	man
-抿	man
+抿	man	500
 敃	man
-敏	man
-文	man
+敏	man	1000
+文	man	1000
 旻	man
 旼	man
 暋	man
-民	man
+民	man	1000
 汶	man
 泯	man
 渑	man
@@ -15911,31 +15911,31 @@ min_phrase_weight: 100
 澠	man
 澠	sing
 炆	man
-玟	man
+玟	man	500
 珉	man
 璺	man
 甿	man
 甿	mong
 笢	man
-紋	man
+紋	man	1000
 絻	man
 纹	man
 罠	man
-聞	man
+聞	man	1000
 肳	man
 脗	man
 芠	man
 苠	man
-蚊	man
-閔	man
-閩	man
+蚊	man	1000
+閔	man	1000
+閩	man	500
 閿	man
 问	man
 闵	man
 闻	man
 闽	man
 阌	man
-雯	man
+雯	man	500
 魰	man
 鰵	man
 鰶	man
@@ -15957,14 +15957,14 @@ min_phrase_weight: 100
 忟	mang
 擝	mang
 甍	mang
-盟	mang
-萌	mang
+盟	mang	1000
+萌	mang	1000
 𠵼	mang
 𢛴	mang
 𤷪	mang
 乜	mat	10000
 乜	me	10000
-乜	mi	0%
+乜	mi	0
 乜	ne
 㫘	mat
 㳴	mat
@@ -15975,15 +15975,15 @@ min_phrase_weight: 100
 䍪	mat
 䛑	mat
 䤉	mat
-勿	mat
+勿	mat	1000
 嘧	mat
-密	mat
+密	mat	1000
 沕	mat
 沕	mei
 滵	mat
-物	mat
+物	mat	1000
 蔤	mat
-蜜	mat
+蜜	mat	1000
 蟔	mat
 袜	mat
 謐	mat
@@ -16005,25 +16005,25 @@ min_phrase_weight: 100
 厶	si
 哞	mau
 懋	mau
-某	mau
+某	mau	1000
 楙	mau
-牟	mau
-畝	mau
-眸	mau
+牟	mau	500
+畝	mau	1000
+眸	mau	500
 睯	mau
 瞀	mau
-繆	mau
-繆	miu
-繆	muk
+繆	mau	500
+繆	miu	500
+繆	muk	500
 缪	mau
 缪	miu
-茂	mau
+茂	mau	1000
 袤	mau
-謀	mau
-謬	mau
+謀	mau	1000
+謬	mau	1000
 谋	mau
 谬	mau
-貿	mau
+貿	mau	1000
 贸	mau
 鄮	mau
 鍪	mau
@@ -16036,8 +16036,8 @@ min_phrase_weight: 100
 咩	me	1000
 哶	me
 孭	me
-歪	me
-歪	waai
+歪	me	501
+歪	waai	1000
 羋	me
 芈	me
 𡥼	me
@@ -16073,23 +16073,23 @@ min_phrase_weight: 100
 亹	mei
 亹	mun
 冞	mei
-味	mei
+味	mei	1000
 堳	mei
 堳	mui
-娓	mei
-媚	mei
+娓	mei	500
+媚	mei	1000
 媺	mei
-寐	mei
-尾	mei
+寐	mei	500
+尾	mei	1000
 屘	mei
 嵋	mei
 弥	mei
 弥	nei
-彌	mei
-彌	nei
-微	mei
+彌	mei	1000
+彌	nei	1000
+微	mei	1000
 攠	mei
-未	mei
+未	mei	1000
 楣	mei
 沬	mei
 沬	mui
@@ -16099,37 +16099,37 @@ min_phrase_weight: 100
 溦	mei
 濔	mei
 濔	nei
-瀰	mei
-瀰	nei
+瀰	mei	1000
+瀰	nei	1000
 煝	mei
 爢	mei
-眉	mei
+眉	mei	1000
 睸	mei
-糜	mei
+糜	mei	500
 縻	mei
-美	mei
+美	mei	1000
 羙	mei
 艉	mei
 菋	mei
 葞	mei
-薇	mei
+薇	mei	500
 蘼	mei
 蝞	mei
 郿	mei
 醾	mei
-鎂	mei
+鎂	mei	500
 镁	mei
-靡	mei
-魅	mei
-魅	mui
+靡	mei	500
+魅	mei	1000
+魅	mui	0%
 鮇	mei
-麋	mei
-黴	mei
+麋	mei	500
+黴	mei	500
 𧋦	mei
-名	meng
-名	ming
-命	meng
-命	ming
+名	meng	501
+名	ming	1000
+命	meng	501
+命	ming	1000
 㨠	mik
 㵋	mik
 䌐	mik
@@ -16145,7 +16145,7 @@ min_phrase_weight: 100
 糸	mik
 糸	si
 羃	mik
-覓	mik
+覓	mik	1000
 觅	mik
 鼏	mik
 㒙	min
@@ -16167,31 +16167,31 @@ min_phrase_weight: 100
 䰓	min
 丏	min
 偭	min
-冕	min
-勉	min
+冕	min	1000
+勉	min	1000
 勔	min
 媔	min
 宀	min
 愐	min
-棉	min
+棉	min	1000
 櫋	min
 沔	min
 湎	min
 眄	min
-眠	min
+眠	min	1000
 矊	min
-綿	min
+綿	min	1000
 緜	min
-緬	min
+緬	min	1000
 绵	min
 缅	min
 腼	min
 腼	tin
-面	min
-靦	min
-靦	tin
+面	min	1000
+靦	min	500
+靦	tin	500
 鮸	min
-麪	min
+麪	min	1000
 麵	min
 㝠	ming
 㟰	ming
@@ -16200,24 +16200,24 @@ min_phrase_weight: 100
 䆨	ming
 䆩	ming
 䳟	ming
-冥	ming
+冥	ming	500
 嫇	ming
-明	ming
+明	ming	1000
 暝	ming
 榠	ming
 洺	ming
 溟	ming
-皿	ming
+皿	ming	1000
 眳	ming
-瞑	ming
-茗	ming
+瞑	ming	500
+茗	ming	500
 蓂	ming
-螟	ming
+螟	ming	500
 鄍	ming
-酩	ming
-銘	ming
+酩	ming	500
+銘	ming	500
 铭	ming
-鳴	ming
+鳴	ming	1000
 鸣	ming
 𠱷	ming
 㒝	mit
@@ -16227,11 +16227,11 @@ min_phrase_weight: 100
 䘊	mit
 䩏	mit
 搣	mit
-滅	mit
+滅	mit	1000
 灭	mit
 烕	mit
-篾	mit
-蔑	mit
+篾	mit	500
+蔑	mit	500
 蠛	mit
 衊	mit
 㑤	miu
@@ -16249,22 +16249,22 @@ min_phrase_weight: 100
 䚺	zaau
 䚺	ziu
 喵	miu
-妙	miu
+妙	miu	1000
 庙	miu
-廟	miu
-描	miu
+廟	miu	1000
+描	miu	1000
 杪	miu
 淼	miu
-渺	miu
+渺	miu	1000
 玅	miu
 眇	miu
-瞄	miu
-秒	miu
+瞄	miu	1000
+秒	miu	1000
 緲	miu
 缈	miu
 苖	miu
-苗	miu
-藐	miu
+苗	miu	1000
+藐	miu	500
 邈	miu
 邈	mok
 𠴕	miu
@@ -16276,16 +16276,16 @@ min_phrase_weight: 100
 嚤	mo
 塺	mo
 塺	mui
-摩	mo
-摸	mo
-摸	mok
+摩	mo	1000
+摸	mo	1000
+摸	mok	0%
 擵	mo
-磨	mo
+磨	mo	1000
 藦	mo
-蘑	mo
+蘑	mo	1000
 饃	mo
 馍	mo
-魔	mo
+魔	mo	1000
 麽	mo
 牦	moi
 㱳	mok
@@ -16297,16 +16297,16 @@ min_phrase_weight: 100
 㿺	pok
 䒬	mok
 嗼	mok
-寞	mok
-幕	mok
+寞	mok	1000
+幕	mok	1000
 幙	mok
-漠	mok
+漠	mok	1000
 瘼	mok
 瞙	mok
-膜	mok
-膜	mou
-莫	mok
-莫	mou
+膜	mok	1000
+膜	mou	0%
+莫	mok	1000
+莫	mou	0%
 鄚	mok
 鏌	mok
 镆	mok
@@ -16327,22 +16327,22 @@ min_phrase_weight: 100
 䗈	mong
 䥰	mong
 䵨	mong
-亡	mong
-亡	mou
+亡	mong	1000
+亡	mou	0%
 兦	mong
 厖	mong
 厖	pong
 哤	mong
-妄	mong
+妄	mong	500
 尨	mong
 尨	mung
 尨	pong
 庬	mong
 庬	pong
-忘	mong
-忙	mong
-惘	mong
-望	mong
+忘	mong	1000
+忙	mong	1000
+惘	mong	500
+望	mong	1000
 朢	mong
 杗	mong
 杧	mong
@@ -16352,18 +16352,18 @@ min_phrase_weight: 100
 牻	mong
 狵	mong
 硭	mong
-網	mong
+網	mong	1000
 网	mong
-罔	mong
-芒	mong
-茫	mong
+罔	mong	1000
+芒	mong	1000
+茫	mong	1000
 茻	mong
-莽	mong
+莽	mong	1000
 菵	mong
 蘉	mong
 虻	mong
 蝱	mong
-蟒	mong
+蟒	mong	500
 輞	mong
 辋	mong
 邙	mong
@@ -16404,68 +16404,68 @@ min_phrase_weight: 100
 䱯	mou
 䳇	mou
 䳱	mou
-侮	mou
+侮	mou	1000
 务	mou
-務	mou
-募	mou
-墓	mou
+務	mou	1000
+募	mou	1000
+墓	mou	1000
 妩	mou
-姆	mou
+姆	mou	1000
 婺	mou
 媢	mou
 嫫	mou
-嫵	mou
-巫	mou
-帽	mou
+嫵	mou	500
+巫	mou	1000
+帽	mou	1000
 庑	mou
 廡	mou
 怃	mou
-慕	mou
+慕	mou	1000
 憮	mou
-戊	mou
-拇	mou
-摹	mou
+戊	mou	1000
+拇	mou	1000
+摹	mou	500
 旄	mou
 无	mou
-暮	mou
+暮	mou	1000
 楘	mou
 楘	muk
-模	mou
+模	mou	1000
 橆	mou
-武	mou
-毋	mou
-母	mou
-毛	mou
+武	mou	1000
+毋	mou	1000
+母	mou	1000
+毛	mou	1000
 毷	mou
 潕	mou
-無	mou
+無	mou	1000
 珷	mou
-瑁	mou
-瑁	mui
+瑁	mou	500
+瑁	mui	500
 甒	mou
 眊	mou
 砪	mou
 碔	mou
-糢	mou
+糢	mou	500
 耄	mou
-舞	mou
+舞	mou	1000
 芜	mou
 芼	mou
-蕪	mou
+蕪	mou	1000
 蝐	mou
 蝐	mui
-誣	mou
-謨	mou
+誣	mou	1000
+謨	mou	500
 诬	mou
 谟	mou
 酕	mou
 鉧	mou
 雾	mou
-霧	mou
-騖	mou
+霧	mou	1000
+騖	mou	500
 骛	mou
-髦	mou
-鵡	mou
+髦	mou	1000
+鵡	mou	500
 鶩	mou
 鹉	mou
 鹜	mou
@@ -16474,26 +16474,26 @@ min_phrase_weight: 100
 䆀	mui
 䊈	mui
 䍙	mui
-妹	mui
-媒	mui
+妹	mui	1000
+媒	mui	1000
 挴	mui
-昧	mui
-枚	mui
-梅	mui
-每	mui
+昧	mui	500
+枚	mui	1000
+梅	mui	1000
+每	mui	1000
 浼	mui
-煤	mui
+煤	mui	1000
 燘	mui
-玫	mui
+玫	mui	1000
 眛	mui
 禖	mui
 脢	mui
 腜	mui
 苺	mui
-莓	mui
+莓	mui	1000
 酶	mui
 鋂	mui
-霉	mui
+霉	mui	1000
 韎	mui
 𠵈	mui
 𡈎	mui
@@ -16506,13 +16506,13 @@ min_phrase_weight: 100
 䊾	muk
 䑵	muk
 坶	muk
-木	muk
+木	muk	1000
 毣	muk
-沐	muk
-牧	muk
-目	muk
-睦	muk
-穆	muk
+沐	muk	1000
+牧	muk	1000
+目	muk	1000
+睦	muk	1000
+穆	muk	1000
 苜	muk
 鉬	muk
 钼	muk
@@ -16526,29 +16526,29 @@ min_phrase_weight: 100
 䊡	mun
 䐽	mun
 们	mun
-們	mun
+們	mun	1000
 悗	mun
-悶	mun
+悶	mun	1000
 懑	mun
-懣	mun
+懣	mun	500
 扪	mun
-捫	mun
+捫	mun	500
 樠	mun
 满	mun
-滿	mun
+滿	mun	1000
 焖	mun
-燜	mun
+燜	mun	500
 璊	mun
 瞒	mun
-瞞	mun
+瞞	mun	1000
 穈	mun
 虋	mun
 蹒	mun
-蹣	mun
-蹣	pun
+蹣	mun	500
+蹣	pun	500
 鍆	mun
 钔	mun
-門	mun
+門	mun	1000
 门	mun
 闷	mun
 顢	mun
@@ -16575,22 +16575,22 @@ min_phrase_weight: 100
 䴿	mung
 䵆	mung
 儚	mung
-夢	mung
+夢	mung	1000
 幪	mung
 懜	mung
 懞	mung
-懵	mung
+懵	mung	500
 曚	mung
-朦	mung
+朦	mung	1000
 梦	mung
-檬	mung
+檬	mung	1000
 氋	mung
-濛	mung
+濛	mung	500
 瞢	mung
-矇	mung
+矇	mung	500
 礞	mung
 艨	mung
-蒙	mung
+蒙	mung	1000
 蠓	mung
 鄸	mung
 霥	mung
@@ -16603,16 +16603,16 @@ min_phrase_weight: 100
 䬴	mut
 䴲	mut
 妺	mut
-末	mut
+末	mut	1000
 歾	mut
-歿	mut
+歿	mut	500
 殁	mut
-沒	mut
+沒	mut	1000
 没	mut
-沫	mut
+沫	mut	1000
 瀎	mut
-秣	mut
-茉	mut
+秣	mut	500
+茉	mut	500
 靺	mut
 𠰌	mut
 𧻙	mut
@@ -16636,29 +16636,29 @@ min_phrase_weight: 100
 䛕	zyu
 䬁	naa
 䬁	zyu
-哪	naa
-娜	naa
-娜	no
+哪	naa	1000
+娜	naa	500
+娜	no	500
 拏	naa
-拿	naa
+拿	naa	1000
 詉	naa
 𠸎	naa
 𤶸	naa
 𤸻	naa
 𪐀	naa
-乃	naai
-乃	oi
-奶	naai
+乃	naai	1000
+乃	oi	0%
+奶	naai	1000
 嬭	naai
-氖	naai
+氖	naai	500
 疓	naai
-迺	naai
+迺	naai	500
 釢	naai
 鼐	naai
 𠮨	naai
 䄒	naam
-南	naam
-喃	naam
+南	naam	1000
+喃	naam	1000
 囝	naam
 囝	zai
 囝	zoi
@@ -16666,11 +16666,11 @@ min_phrase_weight: 100
 揇	naam
 枏	naam
 柟	naam
-楠	naam
+楠	naam	500
 淰	naam
 淰	nam
 淰	sam
-男	naam
+男	naam	1000
 腩	naam
 蝻	naam
 諵	naam
@@ -16681,9 +16681,9 @@ min_phrase_weight: 100
 嶩	naan
 嶩	naau
 戁	naan
-赧	naan
+赧	naan	500
 难	naan
-難	naan
+難	naan	1000
 𢺋	naan
 𧕴	naan
 㴰	naang
@@ -16691,19 +16691,19 @@ min_phrase_weight: 100
 䘅	naang
 䯮	naang
 䯮	nai
-內	naap
-內	noi
-吶	naap
-吶	nat
-吶	neot
+內	naap	0%
+內	noi	1000
+吶	naap	1000
+吶	nat	0%
+吶	neot	0%
 呐	naap
 呐	neot
-納	naap
+納	naap	1000
 纳	naap
 衲	naap
 軜	naap
-鈉	naap
-鈉	naat
+鈉	naap	500
+鈉	naat	500
 钠	naap
 魶	naap
 捺	naat
@@ -16719,12 +16719,12 @@ min_phrase_weight: 100
 䏔	naau
 䰰	naau
 䰰	zyu
-呶	naau
+呶	naau	500
 夒	naau
 峱	naau
 怓	naau
 挠	naau
-撓	naau
+撓	naau	1000
 桡	naau
 淖	naau
 猱	naau
@@ -16732,11 +16732,11 @@ min_phrase_weight: 100
 獶	nou
 獿	naau
 譊	naau
-鐃	naau
+鐃	naau	500
 铙	naau
 閙	naau
 闹	naau
-鬧	naau
+鬧	naau	1000
 𥑪	naau
 𫍢	naau
 㚷	nai
@@ -16745,8 +16745,8 @@ min_phrase_weight: 100
 䍲	ngaai
 坭	nai
 抳	nai
-泥	nai
-泥	nei
+泥	nai	1000
+泥	nei	0%
 臡	nai
 苨	nai
 苨	nei
@@ -16758,7 +16758,7 @@ min_phrase_weight: 100
 焾	nam
 煁	nam
 煁	sam
-稔	nam
+稔	nam	500
 𡀝	nam
 𥈶	nam
 𥻚	nam
@@ -16767,13 +16767,13 @@ min_phrase_weight: 100
 㫱	nan
 㬮	nan
 䕼	nan
-撚	nan
-撚	nin
+撚	nan	500
+撚	nin	500
 㨢	nang
 㨢	pei
 坉	nang
 坉	tyun
-能	nang
+能	nang	1000
 㕕	nap
 㕕	wan
 㖠	nap
@@ -16790,8 +16790,8 @@ min_phrase_weight: 100
 嫐	nat
 肭	nat
 肭	neot
-訥	nat
-訥	neot
+訥	nat	500
+訥	neot	500
 讷	nat
 讷	neot
 㑱	nau
@@ -16800,26 +16800,26 @@ min_phrase_weight: 100
 㺀	nau
 䅦	nau
 䴃	nau
-妞	nau
+妞	nau	500
 嬲	nau
 嬲	niu
 忸	nau
 忸	nuk
-扭	nau
+扭	nau	1000
 檽	nau
 狃	nau
 獳	nau
-紐	nau
+紐	nau	1000
 纽	nau
 耨	nau
-膩	nau
-膩	nei
-鈕	nau
+膩	nau	0%
+膩	nei	1000
+鈕	nau	1000
 鎒	nau
 钮	nau
-呢	ne
-呢	nei
-呢	ni
+呢	ne	1000
+呢	nei	501
+呢	ni	501
 㛅	nei
 㞾	nei
 㟜	nei
@@ -16842,14 +16842,14 @@ min_phrase_weight: 100
 䝚	nei
 䣵	nei
 䥸	nei
-你	nei
-妮	nei
+你	nei	1000
+妮	nei	500
 婗	nei
 婗	ngai
-尼	nei
+尼	nei	1000
 怩	nei
-您	nei
-旎	nei
+您	nei	1000
+旎	nei	500
 柅	nei
 檷	nei
 毦	nei
@@ -16861,7 +16861,7 @@ min_phrase_weight: 100
 腻	nei
 鈮	nei
 铌	nei
-餌	nei
+餌	nei	500
 饵	nei
 𨉖	nei
 𨉖	ni
@@ -16872,8 +16872,8 @@ min_phrase_weight: 100
 腇	neoi
 釹	neoi
 钕	neoi
-餒	neoi
-餒	noi
+餒	neoi	1000
+餒	noi	0%
 㕯	neot
 䎪	neot
 䭆	neot
@@ -16890,24 +16890,24 @@ min_phrase_weight: 100
 䓊	ng
 䦜	ng
 䮏	ng
-五	ng
+五	ng	1000
 仵	ng
-伍	ng
+伍	ng	1000
 俉	ng
-午	ng
-吳	ng
+午	ng	1000
+吳	ng	1000
 吴	ng
-吾	ng
+吾	ng	1000
 啎	ng
-嗯	ng
-寤	ng
+嗯	ng	1000
+寤	ng	500
 峿	ng
 忢	ng
 忤	ng
 悞	ng
-悟	ng
-晤	ng
-梧	ng
+悟	ng	1000
+晤	ng	1000
+梧	ng	500
 浯	ng
 焐	ng
 牾	ng
@@ -16915,8 +16915,8 @@ min_phrase_weight: 100
 痦	ng
 蘁	ng
 蘁	ngok
-蜈	ng
-誤	ng
+蜈	ng	1000
+誤	ng	1000
 误	ng
 迕	ng
 遻	ng
@@ -16939,17 +16939,17 @@ min_phrase_weight: 100
 庌	ngaa
 枒	ngaa
 桠	ngaa
-牙	ngaa
+牙	ngaa	1000
 犽	ngaa
-瓦	ngaa
-疋	ngaa
-疋	pat
-疋	so
+瓦	ngaa	1000
+疋	ngaa	0%
+疋	pat	1000
+疋	so	0%
 砑	ngaa
-芽	ngaa
+芽	ngaa	1000
 蚜	ngaa
-衙	ngaa
-訝	ngaa
+衙	ngaa	500
+訝	ngaa	1000
 讶	ngaa
 迓	ngaa
 齾	ngaa
@@ -16972,30 +16972,30 @@ min_phrase_weight: 100
 䣀	ngaai
 䫥	ngaai
 乂	ngaai
-刈	ngaai
+刈	ngaai	500
 厓	ngaai
 啀	ngaai
 堐	ngaai
-崖	ngaai
-捱	ngaai
-涯	ngaai
+崖	ngaai	1000
+捱	ngaai	1000
+涯	ngaai	1000
 睚	ngaai
-艾	ngaai
+艾	ngaai	1000
 峉	ngaak
 詻	ngaak
 頟	ngaak
-額	ngaak
+額	ngaak	1000
 额	ngaak
 𠱘	ngaak
 𠸺	ngaak
 𧦠	ngaak
 啱	ngaam	1000
 喦	ngaam
-岩	ngaam
+岩	ngaam	500
 嵒	ngaam
 巌	ngaam
-巖	ngaam
-癌	ngaam
+巖	ngaam	1000
+癌	ngaam	1000
 碞	ngaam
 黬	ngaam
 㙬	ngaan
@@ -17007,15 +17007,15 @@ min_phrase_weight: 100
 䇵	zi
 䴦	ngaan
 䴦	ngai
-眼	ngaan
+眼	ngaan	1000
 虤	ngaan
 贗	ngaan
 贗	ngan
-雁	ngaan
-顏	ngaan
+雁	ngaan	1000
+顏	ngaan	1000
 颜	ngaan
 鴈	ngaan
-硬	ngaang
+硬	ngaang	1000
 擪	ngaap
 㐳	ngaat
 㞕	ngaat
@@ -17031,13 +17031,13 @@ min_phrase_weight: 100
 䗤	ngaau
 䗤	zung
 䬲	ngaau
-咬	ngaau
+咬	ngaau	1000
 崤	ngaau
 挍	ngaau
 殽	ngaau
-淆	ngaau
-爻	ngaau
-肴	ngaau
+淆	ngaau	1000
+爻	ngaau	500
+肴	ngaau	500
 餚	ngaau
 齩	ngaau
 𠴳	ngaau
@@ -17050,54 +17050,54 @@ min_phrase_weight: 100
 䢃	ngai
 䭳	ngai
 伪	ngai
-倪	ngai
-偽	ngai
+倪	ngai	500
+偽	ngai	1000
 僞	ngai
-危	ngai
+危	ngai	1000
 呓	ngai
 噅	ngai
-囈	ngai
+囈	ngai	500
 埶	ngai
 埶	zap
 堄	ngai
 寱	ngai
 嵬	ngai
-巍	ngai
+巍	ngai	500
 掜	ngai
 掜	nip
-桅	ngai
-桅	wai
+桅	ngai	500
+桅	wai	500
 槸	ngai
 檥	ngai
-毅	ngai
+毅	ngai	1000
 犩	ngai
 猊	ngai
-睨	ngai
+睨	ngai	500
 礒	ngai
-羿	ngai
+羿	ngai	1000
 舣	ngai
 艤	ngai
 艺	ngai
 蓺	ngai
 藙	ngai
-藝	ngai
+藝	ngai	1000
 蚁	ngai
-蛾	ngai
-蛾	ngo
+蛾	ngai	500
+蛾	ngo	500
 蜺	ngai
 螘	ngai
-蟻	ngai
+蟻	ngai	1000
 襼	ngai
-詣	ngai
+詣	ngai	1000
 诣	ngai
 輗	ngai
 郳	ngai
 隗	ngai
 隗	wai
-霓	ngai
+霓	ngai	1000
 頠	ngai
 顗	ngai
-魏	ngai
+魏	ngai	1000
 鮠	ngai
 鮠	wai
 鯢	ngai
@@ -17123,13 +17123,13 @@ min_phrase_weight: 100
 䮗	ngon
 嚚	ngan
 圁	ngan
-垠	ngan
+垠	ngan	500
 奀	ngan
 狺	ngan
 誾	ngan
 赝	ngan
 鄞	ngan
-銀	ngan
+銀	ngan	1000
 银	ngan
 齗	ngan
 龂	ngan
@@ -17137,9 +17137,9 @@ min_phrase_weight: 100
 㟁	ngon
 䤝	ngang
 砐	ngap
-兀	ngat
+兀	ngat	500
 卼	ngat
-屹	ngat
+屹	ngat	1000
 屼	ngat
 杌	ngat
 汔	ngat
@@ -17157,12 +17157,12 @@ min_phrase_weight: 100
 䉰	ngau
 䋂	ngau
 䶧	ngau
-偶	ngau
-牛	ngau
+偶	ngau	1000
+牛	ngau	1000
 耦	ngau
 腢	ngau
 蕅	ngau
-藕	ngau
+藕	ngau	500
 騳	ngau
 㓟	ngo
 㓟	pai
@@ -17174,46 +17174,46 @@ min_phrase_weight: 100
 䖸	ngo
 䳗	ngo
 䳘	ngo
-俄	ngo
-卧	ngo
+俄	ngo	1000
+卧	ngo	1000
 吪	ngo
-哦	ngo
-哦	o
-娥	ngo
-峨	ngo
+哦	ngo	1000
+哦	o	501
+娥	ngo	1000
+峨	ngo	500
 峩	ngo
-我	ngo
+我	ngo	1000
 涐	ngo
 睋	ngo
 硪	ngo
 臥	ngo
 莪	ngo
-訛	ngo
+訛	ngo	500
 誐	ngo
 譌	ngo
 讹	ngo
 鋨	ngo
 锇	ngo
-餓	ngo
+餓	ngo	1000
 饿	ngo
-鵝	ngo
+鵝	ngo	1000
 鵞	ngo
 鹅	ngo
 𠹷	ngo
 㕌	ngoi
 㕌	zak
-外	ngoi
-外	oi
-愛	ngoi
-愛	oi
-氨	ngoi
-氨	on
+外	ngoi	1000
+外	oi	0%
+愛	ngoi	0%
+愛	oi	1000
+氨	ngoi	500
+氨	on	500
 爱	ngoi
 爱	oi
-璦	ngoi
-璦	oi
+璦	ngoi	500
+璦	oi	500
 碍	ngoi
-礙	ngoi
+礙	ngoi	1000
 騃	ngoi
 𫘤	ngoi
 㓵	ngok
@@ -17229,30 +17229,30 @@ min_phrase_weight: 100
 咢	ngok
 噁	ngok
 噁	ok
-噩	ngok
+噩	ngok	500
 堮	ngok
-岳	ngok
+岳	ngok	1000
 崿	ngok
-嶽	ngok
+嶽	ngok	1000
 恶	ngok
 恶	ok
 恶	wu
-惡	ngok
-惡	ok
-惡	wu
-愕	ngok
+惡	ngok	0%
+惡	ok	1000
+惡	wu	1000
+愕	ngok	500
 櫮	ngok
 腭	ngok
-萼	ngok
+萼	ngok	500
 諤	ngok
 谔	ngok
-鄂	ngok
+鄂	ngok	500
 鍔	ngok
 锷	ngok
-顎	ngok
+顎	ngok	500
 颚	ngok
 鰐	ngok
-鱷	ngok
+鱷	ngok	1000
 鳄	ngok
 鶚	ngok
 鸑	ngok
@@ -17261,11 +17261,11 @@ min_phrase_weight: 100
 𩓥	ngok
 㸩	ngon
 䯃	ngon
-安	ngon
-安	on
-岸	ngon
-案	ngon
-案	on
+安	ngon	0%
+安	on	1000
+岸	ngon	1000
+案	ngon	0%
+案	on	1000
 胺	ngon
 胺	on
 銨	ngon
@@ -17282,7 +17282,7 @@ min_phrase_weight: 100
 戅	ngong
 戆	ngong
 戆	zong
-昂	ngong
+昂	ngong	1000
 㜜	ngou
 㟼	ngou
 㠂	ngou
@@ -17292,8 +17292,8 @@ min_phrase_weight: 100
 䫨	ngou
 䮯	ngou
 䵅	ngou
-傲	ngou
-嗷	ngou
+傲	ngou	1000
+嗷	ngou	500
 奡	ngou
 嶴	ngou
 嶴	ou
@@ -17301,38 +17301,38 @@ min_phrase_weight: 100
 摮	ngou
 擙	ngou
 擙	ou
-敖	ngou
+敖	ngou	1000
 滶	ngou
-熬	ngou
+熬	ngou	1000
 爊	ngou
 爊	ou
 獒	ngou
 璈	ngou
 磝	ngou
-翱	ngou
+翱	ngou	500
 翺	ngou
-聱	ngou
+聱	ngou	500
 芺	ngou
 芺	ou
 螯	ngou
 謷	ngou
-遨	ngou
+遨	ngou	500
 鏊	ngou
-鏖	ngou
-鏖	ou
+鏖	ngou	500
+鏖	ou	500
 隞	ngou
 驁	ngou
 骜	ngou
 鰲	ngou
 鳌	ngou
 鷔	ngou
-鼇	ngou
+鼇	ngou	500
 𢳆	ngou
 𦪈	ngou
 剭	nguk
 剭	uk
-屋	nguk
-屋	uk
+屋	nguk	0%
+屋	uk	1000
 𡃵	ngung
 𢫨	ngung
 𢶜	ngung
@@ -17342,16 +17342,16 @@ min_phrase_weight: 100
 䘌	nik
 䵑	nik
 䵒	nik
-匿	nik
+匿	nik	500
 嫟	nik
 惄	nik
-慝	nik
-慝	tik
+慝	nik	500
+慝	tik	500
 搦	nik
 昵	nik
 暱	nik
-溺	nik
-溺	niu
+溺	nik	1000
+溺	niu	0%
 疒	nik
 砾	nik
 𣘗	nik
@@ -17368,35 +17368,35 @@ min_phrase_weight: 100
 䬯	nim
 䵿	nim
 䵿	tip
-唸	nim
-念	nim
-拈	nim
-拈	nin
-捻	nim
-捻	nip
+唸	nim	1000
+念	nim	1000
+拈	nim	500
+拈	nin	500
+捻	nim	500
+捻	nip	500
 棯	nim
 粘	nim
 粘	zim
 蹨	nim
 鯰	nim
 鲶	nim
-黏	nim
-黏	zim
+黏	nim	1000
+黏	zim	0%
 㞋	nin
 㮟	nin
 䄭	nin
 䄭	zin
 䄹	nin
 姩	nin
-年	nin
+年	nin	1000
 涊	nin
-碾	nin
+碾	nin	500
 脌	nin
 跈	nin
 蹍	nin
 蹍	zin
-輾	nin
-輾	zin
+輾	nin	0%
+輾	zin	1000
 𢆡	nin
 㣷	ning
 㲌	ning
@@ -17405,19 +17405,19 @@ min_phrase_weight: 100
 䔭	ning
 䗿	ning
 䭢	ning
-佞	ning
+佞	ning	500
 儜	ning
 咛	ning
-嚀	ning
+嚀	ning	500
 寍	ning
 寗	ning
-寧	ning
+寧	ning	1000
 拧	ning
 柠	ning
 泞	ning
-濘	ning
+濘	ning	1000
 狞	ning
-獰	ning
+獰	ning	500
 甯	ning
 聍	ning
 聹	ning
@@ -17450,20 +17450,20 @@ min_phrase_weight: 100
 䯀	wai
 䯅	nip
 䳖	nip
-捏	nip
+捏	nip	1000
 揑	nip
-攝	nip
-攝	sip
+攝	nip	0%
+攝	sip	1000
 敜	nip
 涅	nip
 湼	nip
 聂	nip
-聶	nip
+聶	nip	500
 苶	nip
 踂	nip
 蹑	nip
-躡	nip
-鎳	nip
+躡	nip	500
+鎳	nip	500
 鑷	nip
 镊	nip
 镍	nip
@@ -17482,15 +17482,15 @@ min_phrase_weight: 100
 䙚	niu
 䮍	niu
 嫋	niu
-嬝	niu
-尿	niu
-尿	seoi
+嬝	niu	500
+尿	niu	1000
+尿	seoi	0%
 茑	niu
 蔦	niu
 袅	niu
-裊	niu
+裊	niu	500
 褭	niu
-鳥	niu
+鳥	niu	1000
 鸟	niu
 㐡	no
 㡅	no
@@ -17500,15 +17500,15 @@ min_phrase_weight: 100
 傩	no
 儺	no
 愞	no
-懦	no
+懦	no	1000
 懧	no
-挪	no
+挪	no	1000
 挼	no
 捼	no
 稬	no
-糯	no
+糯	no	1000
 𥻟	no
-娘	noeng
+娘	noeng	1000
 孃	noeng
 㨅	noi
 㮈	noi
@@ -17519,18 +17519,18 @@ min_phrase_weight: 100
 䱞	noi
 倷	noi
 内	noi
-奈	noi
+奈	noi	1000
 柰	noi
 氝	noi
-耐	noi
+耐	noi	1000
 錼	noi
 餧	noi
 餧	wai
 馁	noi
-諾	nok
+諾	nok	1000
 诺	nok
 㶞	nong
-囊	nong
+囊	nong	1000
 囔	nong
 擃	nong
 攮	nong
@@ -17552,23 +17552,23 @@ min_phrase_weight: 100
 䜀	nou
 䜧	nou
 伮	nou
-努	nou
-奴	nou
+努	nou	1000
+奴	nou	1000
 孥	nou
-帑	nou
-帑	tong
-弩	nou
-怒	nou
+帑	nou	500
+帑	tong	500
+弩	nou	500
+怒	nou	1000
 恼	nou
 悩	nou
-惱	nou
-瑙	nou
+惱	nou	1000
+瑙	nou	1000
 砮	nou
 碯	nou
 笯	nou
 脑	nou
-腦	nou
-駑	nou
+腦	nou	1000
+駑	nou	500
 驽	nou
 䘐	nuk
 䚼	nuk
@@ -17582,27 +17582,27 @@ min_phrase_weight: 100
 䢉	nung
 䵜	nung
 侬	nung
-儂	nung
+儂	nung	500
 农	nung
 哝	nung
-噥	nung
+噥	nung	500
 浓	nung
 燶	nung
 秾	nung
 穠	nung
 脓	nung
-膿	nung
+膿	nung	500
 襛	nung
 譨	nung
-農	nung
+農	nung	1000
 醲	nung
 𪒬	nung
 䎡	nyun
 䞂	nyun
 䞂	zyun
 媆	nyun
-嫩	nyun
-暖	nyun
+嫩	nyun	1000
+暖	nyun	1000
 渜	nyun
 餪	nyun
 𡞾	nyun
@@ -17611,13 +17611,13 @@ min_phrase_weight: 100
 䋪	o
 嚄	o
 嚄	wok
-婀	o
+婀	o	500
 屙	o
-柯	o
+柯	o	500
 珂	o
 疴	o
 痾	o
-軻	o
+軻	o	500
 轲	o
 钶	o
 㗒	oi
@@ -17626,23 +17626,23 @@ min_phrase_weight: 100
 䨠	oi
 䨠	piu
 僾	oi
-哀	oi
+哀	oi	1000
 嗳	oi
-噯	oi
+噯	oi	500
 壒	oi
 嫒	oi
 嬡	oi
 暧	oi
-曖	oi
+曖	oi	500
 毐	oi
 瑷	oi
 瞹	oi
 蔼	oi
 薆	oi
-藹	oi
+藹	oi	1000
 鑀	oi
 霭	oi
-靄	oi
+靄	oi	500
 靉	oi
 垩	ok
 堊	ok
@@ -17651,19 +17651,19 @@ min_phrase_weight: 100
 䅁	on
 䢿	on
 䬶	on
-按	on
+按	on	1000
 摁	on
 桉	on
-盎	on
-盎	ong
+盎	on	1000
+盎	ong	1000
 铵	on
 鞌	on
-鞍	on
+鞍	on	1000
 㼜	ong
 䱀	ong
 䱀	zoeng
-甕	ong
-甕	ung
+甕	ong	500
+甕	ung	500
 罋	ong
 罋	ung
 軮	ong
@@ -17683,14 +17683,14 @@ min_phrase_weight: 100
 䴠	ziu
 墺	ou
 奥	ou
-奧	ou
+奧	ou	1000
 媪	ou
-媼	ou
-媼	wan
+媼	ou	500
+媼	wan	500
 岙	ou
-懊	ou
+懊	ou	1000
 袄	ou
-襖	ou
+襖	ou	500
 鏕	ou
 镺	ou
 𥜌	ou
@@ -17698,17 +17698,17 @@ min_phrase_weight: 100
 䎬	paa
 䎱	paa
 帊	paa
-帕	paa
-帕	paak
-怕	paa
-扒	paa
+帕	paa	0%
+帕	paak	1000
+怕	paa	1000
+扒	paa	1000
 掱	paa
-杷	paa
-爬	paa
-琶	paa
+杷	paa	500
+爬	paa	1000
+琶	paa	1000
 筢	paa
-耙	paa
-趴	paa
+耙	paa	500
+趴	paa	1000
 跁	paa
 𦘩	paa
 㭛	paai
@@ -17717,11 +17717,11 @@ min_phrase_weight: 100
 䰦	paai
 䰦	pei
 䱝	paai
-俳	paai
-排	paai
+俳	paai	500
+排	paai	1000
 棑	paai
-派	paai
-牌	paai
+派	paai	1000
+牌	paai	1000
 篺	paai
 簰	paai
 蒎	paai
@@ -17734,9 +17734,9 @@ min_phrase_weight: 100
 䪖	paak
 䪖	pak
 䪖	pok
-啪	paak
-拍	paak
-珀	paak
+啪	paak	1000
+拍	paak	1000
+珀	paak	500
 㐴	paan
 㰋	paan
 㰋	pei
@@ -17744,9 +17744,9 @@ min_phrase_weight: 100
 䤨	paan
 䤨	pik
 䤨	wan
-扳	paan
-攀	paan
-盼	paan
+扳	paan	500
+攀	paan	1000
+盼	paan	1000
 眅	paan
 袢	paan
 襻	paan
@@ -17757,32 +17757,32 @@ min_phrase_weight: 100
 倗	pang
 匉	paang
 匉	ping
-彭	paang
-彭	pang
+彭	paang	500
+彭	pang	500
 恲	paang
 憉	paang
-抨	paang
-抨	ping
-棒	paang
-棚	paang
+抨	paang	500
+抨	ping	500
+棒	paang	1000
+棚	paang	1000
 泙	paang
 泙	ping
 淜	paang
 淜	pang
 淜	ping
 漰	paang
-澎	paang
-烹	paang
-硼	paang
-硼	pang
+澎	paang	1000
+烹	paang	1000
+硼	paang	500
+硼	pang	500
 磞	paang
 磞	pang
-膨	paang
+膨	paang	1000
 蟚	paang
 蟛	paang
 軯	paang
 輣	paang
-鵬	paang
+鵬	paang	500
 鹏	paang
 𢴒	paang
 𢵓	paang
@@ -17794,33 +17794,33 @@ min_phrase_weight: 100
 䠙	pong
 䬌	paau
 䶌	paau
-刨	paau
-匏	paau
-咆	paau
+刨	paau	1000
+匏	paau	500
+咆	paau	500
 奅	paau
-庖	paau
+庖	paau	500
 抛	paau
-拋	paau
-泡	paau
-泡	pou
+拋	paau	1000
+泡	paau	1000
+泡	pou	1000
 炰	paau
 疱	paau
-皰	paau
+皰	paau	500
 礟	paau
 礮	paau
 脬	paau
 趵	paau
-跑	paau
-鉋	paau
+跑	paau	1000
+鉋	paau	500
 鑤	paau
 铇	paau
 飑	paau
 䪹	pai
 䪹	pei
 䪹	pui
-批	pai
+批	pai	1000
 睤	pai
-睥	pai
+睥	pai	500
 磇	pai
 錍	pai
 𠜱	pai
@@ -17840,15 +17840,15 @@ min_phrase_weight: 100
 喷	pan
 嚬	pan
 嫔	pan
-牝	pan
+牝	pan	500
 玭	pan
 矉	pan
-蘋	pan
-蘋	ping
-貧	pan
+蘋	pan	0%
+蘋	ping	1000
+貧	pan	1000
 贫	pan
-頻	pan
-顰	pan
+頻	pan	1000
+顰	pan	500
 频	pan
 颦	pan
 㠮	pang
@@ -17862,9 +17862,9 @@ min_phrase_weight: 100
 䰷	pang
 䰷	pau
 凭	pang
-朋	pang
+朋	pang	1000
 𠗦	pang
-匹	pat
+匹	pat	1000
 鴄	pat
 㚿	pau
 㬓	pau
@@ -17896,46 +17896,46 @@ min_phrase_weight: 100
 䮒	pou
 䯱	pei
 䲹	pei
-丕	pei
-仳	pei
+丕	pei	500
+仳	pei	500
 伾	pei
-呸	pei
+呸	pei	500
 嚭	pei
 圮	pei
 埤	pei
 堛	pei
 堛	pik
-婢	pei
+婢	pei	1000
 嬖	pei
-屁	pei
+屁	pei	1000
 帔	pei
 庀	pei
-披	pei
-枇	pei
-毗	pei
+披	pei	1000
+枇	pei	500
+毗	pei	500
 毘	pei
 淠	pei
 濞	pei
 狉	pei
-琵	pei
-疲	pei
-痞	pei
-皮	pei
+琵	pei	1000
+疲	pei	1000
+痞	pei	500
+皮	pei	1000
 砒	pei
 秠	pei
 粃	pei
-紕	pei
+紕	pei	500
 纰	pei
 翍	pei
-脾	pei
+脾	pei	1000
 苤	pei
 蚍	pei
 蜱	pei
-譬	pei
+譬	pei	1000
 貔	pei
 邳	pei
 郫	pei
-鄙	pei
+鄙	pei	1000
 鈚	pei
 鈹	pei
 铍	pei
@@ -17944,32 +17944,32 @@ min_phrase_weight: 100
 駓	pei
 髬	pei
 魾	pei
-鼙	pei
+鼙	pei	500
 𨈚	pei
 𨉉	pei
 䌟	pek
-劈	pek
-劈	pik
+劈	pek	1000
+劈	pik	0%
 噼	pek
 噼	pet
 呯	peng
-平	peng
-平	ping
-瓶	peng
-瓶	ping
+平	peng	501
+平	ping	1000
+瓶	peng	0%
+瓶	ping	1000
 𠝭	peng
 𣖕	peng
 𩩍	peng
 䑀	pik
 䴙	pik
-僻	pik
+僻	pik	1000
 擗	pik
 澼	pik
 甓	pik
-癖	pik
+癖	pik	500
 釽	pik
-闢	pik
-霹	pik
+闢	pik	1000
+霹	pik	500
 鷿	pik
 㓲	pin
 㛹	pin
@@ -17980,25 +17980,25 @@ min_phrase_weight: 100
 䏒	pin
 䡢	pin
 䮁	pin
-偏	pin
+偏	pin	1000
 媥	pin
 徧	pin
 楄	pin
 楩	pin
-片	pin
-篇	pin
-編	pin
+片	pin	1000
+篇	pin	1000
+編	pin	1000
 緶	pin
 缏	pin
 编	pin
-翩	pin
+翩	pin	1000
 諞	pin
 谝	pin
 跰	pin
 蹁	pin
-駢	pin
-駢	ping
-騙	pin
+駢	pin	500
+駢	ping	500
+騙	pin	1000
 骈	pin
 骗	pin
 骿	pin
@@ -18012,26 +18012,26 @@ min_phrase_weight: 100
 䶄	ping
 伻	ping
 俜	ping
-坪	ping
-姘	ping
+坪	ping	1000
+姘	ping	500
 娉	ping
 帡	ping
 帲	ping
 怦	ping
-拚	ping
-拚	pun
-拼	ping
+拚	ping	0%
+拚	pun	1000
+拼	ping	1000
 枰	ping
 洴	ping
 甹	ping
-砰	ping
+砰	ping	1000
 竮	ping
 缾	ping
-聘	ping
+聘	ping	1000
 苹	ping
 荓	ping
-萍	ping
-評	ping
+萍	ping	1000
+評	ping	1000
 评	ping
 軿	ping
 郱	ping
@@ -18043,10 +18043,10 @@ min_phrase_weight: 100
 嫳	pit
 徶	pit
 撆	pit
-撇	pit
+撇	pit	500
 氕	pit
 潎	pit
-瞥	pit
+瞥	pit	500
 𢠳	pit
 㯱	piu
 㲏	piu
@@ -18059,20 +18059,20 @@ min_phrase_weight: 100
 䕯	piu
 䴩	piu
 僄	piu
-剽	piu
+剽	piu	500
 嘌	piu
-嫖	piu
+嫖	piu	500
 彯	piu
 慓	piu
 摽	piu
-朴	piu
-朴	po
-朴	pok
+朴	piu	500
+朴	po	500
+朴	pok	500
 殍	piu
-漂	piu
-瓢	piu
+漂	piu	1000
+瓢	piu	500
 皫	piu
-瞟	piu
+瞟	piu	500
 篻	piu
 縹	piu
 缥	piu
@@ -18080,32 +18080,32 @@ min_phrase_weight: 100
 螵	piu
 醥	piu
 顠	piu
-飄	piu
+飄	piu	1000
 飘	piu
-驃	piu
+驃	piu	500
 骠	piu
-鰾	piu
+鰾	piu	500
 鳔	piu
-叵	po
-婆	po
+叵	po	500
+婆	po	1000
 媻	po
 媻	pun
 尀	po
 樖	po
 皤	po
-破	po
+破	po	1000
 笸	po
-頗	po
+頗	po	1000
 颇	po
 䄸	pok
 䇚	pok
 䪙	pok
-噗	pok
+噗	pok	500
 墣	pok
 扑	pok
-撲	pok
+撲	pok	1000
 璞	pok
-粕	pok
+粕	pok	500
 蒪	pok
 釙	pok
 钋	pok
@@ -18123,44 +18123,44 @@ min_phrase_weight: 100
 䮾	pong
 嗙	pong
 庞	pong
-徬	pong
-旁	pong
-滂	pong
+徬	pong	500
+旁	pong	1000
+滂	pong	500
 篣	pong
 耪	pong
 肨	pong
 艕	pong
-蚌	pong
-螃	pong
-謗	pong
+蚌	pong	500
+螃	pong	500
+謗	pong	500
 谤	pong
 逄	pong
 雱	pong
 霶	pong
 龎	pong
-龐	pong
+龐	pong	1000
 䈬	pou
 䈻	pou
 䔕	pou
 䩣	pou
 䩣	tou
 䲕	pou
-匍	pou
-普	pou
+匍	pou	500
+普	pou	1000
 氆	pou
-浦	pou
-溥	pou
+浦	pou	500
+溥	pou	500
 舖	pou
-菩	pou
-葡	pou
+菩	pou	1000
+葡	pou	1000
 蒱	pou
-蒲	pou
+蒲	pou	1000
 袌	pou
-袍	pou
-譜	pou
+袍	pou	1000
+譜	pou	1000
 谱	pou
 酺	pou
-鋪	pou
+鋪	pou	1000
 鐠	pou
 铺	pou
 镨	pou
@@ -18172,35 +18172,35 @@ min_phrase_weight: 100
 㳈	pui
 㾦	pui
 䫊	pui
-佩	pui
-倍	pui
-坏	pui
+佩	pui	1000
+倍	pui	1000
+坏	pui	500
 坯	pui
-培	pui
-徘	pui
+培	pui	1000
+徘	pui	1000
 旆	pui
 昢	pui
 柸	pui
 毰	pui
-沛	pui
-珮	pui
+沛	pui	1000
+珮	pui	500
 琲	pui
 碚	pui
 肧	pui
-胚	pui
+胚	pui	1000
 衃	pui
-裴	pui
-賠	pui
+裴	pui	500
+賠	pui	1000
 赔	pui
-配	pui
+配	pui	1000
 醅	pui
-陪	pui
+陪	pui	1000
 霈	pui
 㢖	pun
 㩯	pun
 䆺	pun
 䰔	pun
-判	pun
+判	pun	1000
 幋	pun
 槃	pun
 沜	pun
@@ -18208,11 +18208,11 @@ min_phrase_weight: 100
 洀	pun
 洀	zau
 湓	pun
-潘	pun
-盆	pun
+潘	pun	500
+盆	pun	1000
 盘	pun
-盤	pun
-磐	pun
+盤	pun	1000
+磐	pun	500
 磻	pun
 縏	pun
 胓	pun
@@ -18225,17 +18225,17 @@ min_phrase_weight: 100
 䋽	pung
 掽	pung
 椪	pung
-碰	pung
-篷	pung
+碰	pung	1000
+篷	pung	500
 芃	pung
-踫	pung
+踫	pung	500
 髼	pung
 㔇	put
 㗶	put
 㧊	put
 䥽	put
 泼	put
-潑	put
+潑	put	1000
 酦	put
 醱	put
 鏺	put
@@ -18246,27 +18246,27 @@ min_phrase_weight: 100
 㲚	tim
 㸺	saa
 䩖	saa
-卅	saa
+卅	saa	500
 唦	saa
-啥	saa
-沙	saa
+啥	saa	1000
+沙	saa	1000
 洒	saa
 洒	sai
 洒	sin
-灑	saa
+灑	saa	1000
 猀	saa
 痧	saa
-砂	saa
-紗	saa
+砂	saa	1000
+紗	saa	1000
 纱	saa
-耍	saa
-莎	saa
-莎	so
-裟	saa
+耍	saa	1000
+莎	saa	500
+莎	so	500
+裟	saa	500
 逤	saa
 逤	so
 魦	saa
-鯊	saa
+鯊	saa	1000
 鲨	saa
 𧋊	saa
 㩄	saai	1000
@@ -18285,16 +18285,16 @@ min_phrase_weight: 100
 咶	si
 嘥	saai
 屣	saai
-徙	saai
+徙	saai	1000
 晒	saai
-曬	saai
+曬	saai	1000
 枲	saai
 枲	sai
-殺	saai
-殺	saat
+殺	saai	0%
+殺	saat	1000
 漇	saai
 玺	saai
-璽	saai
+璽	saai	500
 縰	saai
 纚	saai
 舓	saai
@@ -18308,9 +18308,9 @@ min_phrase_weight: 100
 𫍰	saai
 𫍰	si
 梀	saak
-索	saak
-索	sok
-索	suk
+索	saak	1000
+索	sok	1000
+索	suk	0%
 𢱢	saak
 㓄	saam
 㓄	zaam
@@ -18330,7 +18330,7 @@ min_phrase_weight: 100
 䏹	zin
 䥠	saam
 䥠	zaam
-三	saam
+三	saam	1000
 仨	saam
 叁	saam
 幓	saam
@@ -18341,9 +18341,9 @@ min_phrase_weight: 100
 穇	saam
 糁	saam
 糝	saam
-芟	saam
+芟	saam	500
 蔪	saam
-衫	saam
+衫	saam	1000
 釤	saam
 釤	sin
 鏒	saam
@@ -18378,38 +18378,38 @@ min_phrase_weight: 100
 䰠	saan
 䴮	saan
 伞	saan
-傘	saan
+傘	saan	1000
 删	saan
-刪	saan
-姍	saan
+刪	saan	1000
+姍	saan	500
 姗	saan
-山	saan
-拴	saan
+山	saan	1000
+拴	saan	500
 挻	saan
-散	saan
-栓	saan
+散	saan	1000
+栓	saan	500
 氙	saan
 氙	sin
 氥	saan
 氥	sai
 氥	sin
-汕	saan
-涮	saan
-潸	saan
-潺	saan
-珊	saan
-疝	saan
-篡	saan
+汕	saan	500
+涮	saan	500
+潸	saan	500
+潺	saan	500
+珊	saan	1000
+疝	saan	500
+篡	saan	500
 粣	saan
 糤	saan
 繖	saan
 膻	saan
 膻	zin
-舢	saan
-訕	saan
+舢	saan	500
+訕	saan	500
 讪	saan
-跚	saan
-閂	saan
+跚	saan	500
+閂	saan	1000
 闩	saan
 饊	saan
 㗂	saang
@@ -18428,20 +18428,20 @@ min_phrase_weight: 100
 䴤	sang
 渻	saang
 渻	sing
-牲	saang
-牲	sang
+牲	saang	0%
+牲	sang	1000
 琤	saang
 琤	zaang
 琤	zang
-生	saang
-生	sang
-甥	saang
-甥	sang
-省	saang
-省	sing
+生	saang	501
+生	sang	1000
+甥	saang	0%
+甥	sang	1000
+省	saang	1000
+省	sing	1000
 眚	saang
-笙	saang
-笙	sang
+笙	saang	0%
+笙	sang	1000
 胜	saang
 胜	sing
 㒊	saap
@@ -18472,10 +18472,10 @@ min_phrase_weight: 100
 趿	taat
 鉔	saap
 霋	saap
-霎	saap
-霎	sap
+霎	saap	500
+霎	sap	500
 靸	saap
-颯	saap
+颯	saap	500
 飒	saap
 馺	saap
 𢶍	saap
@@ -18483,13 +18483,13 @@ min_phrase_weight: 100
 䊛	saat
 䶡	saat
 摋	saat
-撒	saat
+撒	saat	1000
 杀	saat
 樧	saat
-煞	saat
+煞	saat	1000
 萨	saat
 蔱	saat
-薩	saat
+薩	saat	1000
 鎩	saat
 铩	saat
 閷	saat
@@ -18519,14 +18519,14 @@ min_phrase_weight: 100
 䭉	seoi
 䭭	saau
 䭭	sou
-哨	saau
+哨	saau	1000
 弰	saau
-捎	saau
+捎	saau	500
 旓	saau
-梢	saau
+梢	saau	1000
 潲	saau
 潲	sau
-稍	saau
+稍	saau	1000
 筲	saau
 艄	saau
 莦	saau
@@ -18549,41 +18549,41 @@ min_phrase_weight: 100
 䤱	sai
 䵘	sai
 䵘	sam
-世	sai
-使	sai
-使	si
+世	sai	1000
+使	sai	501
+使	si	1000
 势	sai
-勢	sai
-嘶	sai
-嘶	si
-噬	sai
+勢	sai	1000
+嘶	sai	500
+嘶	si	500
+噬	sai	500
 壻	sai
-婿	sai
+婿	sai	1000
 恓	sai
 樨	sai
-洗	sai
+洗	sai	1000
 澨	sai
-犀	sai
+犀	sai	1000
 硒	sai
 筛	sai
 筮	sai
-篩	sai
+篩	sai	1000
 簁	sai
 簁	si
 簭	sai
 粞	sai
-細	sai
+細	sai	1000
 细	sai
 舾	sai
 茜	sai
 茜	sin
-西	sai
-誓	sai
+西	sai	1000
+誓	sai	1000
 貰	sai
 贳	sai
-逝	sai
+逝	sai	1000
 遾	sai
-駛	sai
+駛	sai	1000
 驶	sai
 𠀍	sai
 𩢲	sai
@@ -18612,33 +18612,33 @@ min_phrase_weight: 100
 䊏	sam
 䲋	sam
 䵇	sam
-什	sam
-什	sap
-什	zaap
+什	sam	1000
+什	sap	0%
+什	zaap	200
 伈	sam
 婶	sam
-嬸	sam
+嬸	sam	1000
 审	sam
-審	sam
-岑	sam
-心	sam
-忱	sam
+審	sam	1000
+岑	sam	500
+心	sam	1000
+忱	sam	1000
 愖	sam
 梣	sam
-森	sam
+森	sam	1000
 椹	sam
 椹	zam
 槮	sam
-沁	sam
+沁	sam	500
 涔	sam
-深	sam
+深	sam	1000
 渖	sam
 渗	sam
-滲	sam
-瀋	sam
+滲	sam	1000
+瀋	sam	1000
 琛	sam
-甚	sam
-甚	sap
+甚	sam	1000
+甚	sap	0%
 瞫	sam
 綝	sam
 芯	sam
@@ -18670,43 +18670,43 @@ min_phrase_weight: 100
 䫅	tam
 䫩	san
 䯂	san
-伸	san
+伸	san	1000
 侁	san
 兟	san
-呻	san
-娠	san
-娠	zan
+呻	san	1000
+娠	san	500
+娠	zan	500
 宸	san
 屾	san
 愼	san
-慎	san
-新	san
-晨	san
+慎	san	1000
+新	san	1000
+晨	san	1000
 桭	san
 氠	san
 燊	san
 珅	san
 甡	san
-申	san
+申	san	1000
 砷	san
-神	san
+神	san	1000
 祳	san
-紳	san
+紳	san	1000
 绅	san
 肾	san
 胂	san
 胂	seon
 脤	san
-腎	san
-臣	san
-莘	san
-薪	san
-蜃	san
+腎	san	1000
+臣	san	1000
+莘	san	500
+薪	san	1000
+蜃	san	500
 詵	san
 诜	san
-辛	san
-辰	san
-鋅	san
+辛	san	1000
+辰	san	1000
+鋅	san	500
 锌	san
 駪	san
 鷐	san
@@ -18716,8 +18716,8 @@ min_phrase_weight: 100
 㼳	zip
 䚇	sang
 䚇	sing
-僧	sang
-僧	zang
+僧	sang	0%
+僧	zang	1000
 擤	sang
 狌	sang
 狌	sing
@@ -18729,32 +18729,32 @@ min_phrase_weight: 100
 䬃	sap
 䬃	seon
 䬃	sou
-十	sap
+十	sap	1000
 咂	sap
 咂	zaap
-拾	sap
+拾	sap	1000
 涩	sap
 湿	sap
 溼	sap
 澁	sap
-濕	sap
+濕	sap	1000
 譅	sap
 㒎	sat
 㻎	sat
 㻭	sat
 䣛	sat
-失	sat
+失	sat	1000
 实	sat
-室	sat
+室	sat	1000
 寔	sat
-實	sat
+實	sat	1000
 湜	sat
 湜	zik
-瑟	sat
+瑟	sat	1000
 璱	sat
-膝	sat
-虱	sat
-蝨	sat
+膝	sat	1000
+虱	sat	500
+蝨	sat	500
 㖟	sau
 㝊	sau
 㥅	sau
@@ -18774,78 +18774,78 @@ min_phrase_weight: 100
 䛵	sau
 䤇	sau
 䮟	sau
-修	sau
+修	sau	1000
 傁	sau
 兽	sau
 収	sau
-受	sau
-叟	sau
-售	sau
+受	sau	1000
+叟	sau	500
+售	sau	1000
 嗖	sau
-嗽	sau
-嗾	sau
-嗾	zuk
-壽	sau
+嗽	sau	1000
+嗾	sau	500
+嗾	zuk	500
+壽	sau	1000
 夀	sau
-守	sau
-宿	sau
-宿	suk
+守	sau	1000
+宿	sau	1000
+宿	suk	1000
 寿	sau
 廋	sau
-愁	sau
-手	sau
-授	sau
-搜	sau
+愁	sau	1000
+手	sau	1000
+授	sau	1000
+搜	sau	1000
 擞	sau
-擻	sau
-收	sau
+擻	sau	1000
+收	sau	1000
 棷	sau
 棷	zau
 溲	sau
 滫	sau
-漱	sau
-漱	sou
+漱	sau	1000
+漱	sou	0%
 潃	sau
-狩	sau
+狩	sau	500
 獀	sau
-獸	sau
+獸	sau	1000
 琇	sau
-瘦	sau
+瘦	sau	1000
 瞍	sau
-秀	sau
+秀	sau	1000
 籔	sau
 籔	sou
 糔	sau
 綉	sau
 綬	sau
-繡	sau
+繡	sau	1000
 绣	sau
 绶	sau
-羞	sau
-脩	sau
+羞	sau	1000
+脩	sau	500
 艏	sau
-艘	sau
-蒐	sau
+艘	sau	1000
+蒐	sau	1000
 蓨	sau
 蓨	tiu
 薮	sau
-藪	sau
+藪	sau	500
 謏	sau
 謏	siu
 鄋	sau
 鉎	sau
 銹	sau
 鎪	sau
-鏽	sau
+鏽	sau	1000
 锈	sau
 锼	sau
-颼	sau
+颼	sau	500
 飕	sau
-餿	sau
+餿	sau	500
 饈	sau
 馊	sau
 馐	sau
-首	sau
+首	sau	1000
 騪	sau
 𢯱	sau
 𥈟	sau
@@ -18866,30 +18866,30 @@ min_phrase_weight: 100
 䥱	se
 䥾	se
 䬷	se
-些	se
+些	se	1000
 佘	se
 写	se
 冩	se
 卌	se
-卸	se
+卸	se	1000
 厍	se
 厙	se
-寫	se
-捨	se
+寫	se	1000
+捨	se	1000
 揳	se
 揳	sip
 揳	sit
 泻	se
-瀉	se
+瀉	se	1000
 猞	se
-社	se
-舍	se
-賒	se
+社	se	1000
+舍	se	1000
+賒	se	500
 赊	se
-赦	se
+赦	se	500
 阇	se
 騇	se
-麝	se
+麝	se	500
 𠶈	se
 㔌	sei
 㔌	tam
@@ -18901,15 +18901,15 @@ min_phrase_weight: 100
 㕜	si
 䏤	sei
 䏤	si
-四	sei
-四	si
-死	sei
-死	si
+四	sei	1000
+四	si	200
+死	sei	1000
+死	si	200
 殔	sei
 肂	sei
 肂	si
-肆	sei
-肆	si
+肆	sei	1000
+肆	si	1000
 蕼	sei
 㒪	sek
 㛫	sek
@@ -18921,28 +18921,28 @@ min_phrase_weight: 100
 䖨	sek
 䲽	sek
 硕	sek
-碩	sek
+碩	sek	1000
 祏	sek
 祏	sik
-錫	sek
-錫	sik
+錫	sek	1000
+錫	sik	0%
 锡	sek
 鼫	sek
 𡃶	sek
-城	seng
-城	sing
+城	seng	501
+城	sing	1000
 声	seng
 声	sing
-姓	seng
-姓	sing
-星	seng
-星	sing
-聲	seng
-聲	sing
-腥	seng
-腥	sing
-醒	seng
-醒	sing
+姓	seng	0%
+姓	sing	1000
+星	seng	0%
+星	sing	1000
+聲	seng	501
+聲	sing	1000
+腥	seng	501
+腥	sing	1000
+醒	seng	0%
+醒	sing	1000
 鍟	seng
 㑔	seoi
 㑯	seoi
@@ -19000,54 +19000,54 @@ min_phrase_weight: 100
 䳠	seoi
 倕	seoi
 倠	seoi
-垂	seoi
-墅	seoi
+垂	seoi	1000
+墅	seoi	1000
 夊	seoi
 嬃	seoi
 岁	seoi
 嵗	seoi
 帅	seoi
-帥	seoi
-帥	seot
+帥	seoi	1000
+帥	seot	0%
 帨	seoi
-彗	seoi
-彗	wai
-悴	seoi
+彗	seoi	1000
+彗	wai	0%
+悴	seoi	1000
 挩	seoi
 挩	tyut
-摔	seoi
-摔	seot
+摔	seoi	0%
+摔	seot	1000
 楈	seoi
 槥	seoi
 槥	wai
 檖	seoi
-歲	seoi
-水	seoi
+歲	seoi	1000
+水	seoi	1000
 涗	seoi
 湑	seoi
 濉	seoi
 瀡	seoi
-燧	seoi
-瑞	seoi
+燧	seoi	500
+瑞	seoi	1000
 璲	seoi
-瘁	seoi
+瘁	seoi	500
 睟	seoi
-睡	seoi
+睡	seoi	1000
 睢	seoi
-碎	seoi
-祟	seoi
+碎	seoi	1000
+祟	seoi	1000
 稅	seoi
-税	seoi
+税	seoi	1000
 稰	seoi
-穗	seoi
+穗	seoi	1000
 穟	seoi
 篲	seoi
 篲	wai
-粹	seoi
+粹	seoi	1000
 糈	seoi
-絮	seoi
-綏	seoi
-緒	seoi
+絮	seoi	1000
+綏	seoi	500
+緒	seoi	1000
 緰	seoi
 緰	syu
 繀	seoi
@@ -19056,13 +19056,13 @@ min_phrase_weight: 100
 繻	seoi
 绥	seoi
 绪	seoi
-胥	seoi
+胥	seoi	500
 脽	seoi
 脽	zeoi
 膵	seoi
 荽	seoi
 荾	seoi
-萃	seoi
+萃	seoi	500
 葰	seoi
 葰	zeon
 蔧	seoi
@@ -19070,31 +19070,31 @@ min_phrase_weight: 100
 虽	seoi
 蛻	seoi
 蛻	teoi
-蜕	seoi
-蜕	teoi
+蜕	seoi	500
+蜕	teoi	500
 蝑	seoi
 裞	seoi
 襚	seoi
-誰	seoi
+誰	seoi	1000
 誶	seoi
 諝	seoi
 谁	seoi
 谇	seoi
 谞	seoi
 賥	seoi
-遂	seoi
+遂	seoi	1000
 邃	seoi
 醑	seoi
 鐆	seoi
 鐩	seoi
 鑐	seoi
-陲	seoi
-隧	seoi
-雖	seoi
-需	seoi
-須	seoi
+陲	seoi	1000
+隧	seoi	1000
+雖	seoi	1000
+需	seoi	1000
+須	seoi	1000
 须	seoi
-髓	seoi
+髓	seoi	1000
 𡑞	seoi
 𡻕	seoi
 㐰	seon
@@ -19132,22 +19132,22 @@ min_phrase_weight: 100
 䭀	seon
 䴄	seon
 侚	seon
-信	seon
+信	seon	1000
 唇	seon
 噀	seon
 囟	seon
 峋	seon
-巽	seon
-徇	seon
+巽	seon	500
+徇	seon	500
 恂	seon
 愻	seon
 楯	seon
 楯	teon
 榫	seon
-殉	seon
+殉	seon	1000
 汛	seon
 洵	seon
-淳	seon
+淳	seon	500
 湻	seon
 漘	seon
 潠	seon
@@ -19156,39 +19156,39 @@ min_phrase_weight: 100
 犉	seon
 狥	seon
 珣	seon
-皴	seon
-盾	seon
-盾	teon
+皴	seon	500
+盾	seon	0%
+盾	teon	1000
 瞚	seon
-瞬	seon
+瞬	seon	1000
 笋	seon
-筍	seon
+筍	seon	500
 簨	seon
-純	seon
-純	zeon
+純	seon	1000
+純	zeon	0%
 纯	seon
-脣	seon
+脣	seon	1000
 膞	seon
 膞	zyun
-舜	seon
-荀	seon
+舜	seon	1000
+荀	seon	500
 莼	seon
 蓴	seon
 蕣	seon
-訊	seon
-詢	seon
+訊	seon	1000
+詢	seon	1000
 讯	seon
 询	seon
-迅	seon
+迅	seon	1000
 迿	seon
 逊	seon
 逡	seon
-遜	seon
+遜	seon	1000
 郇	seon
-醇	seon
-順	seon
+醇	seon	1000
+順	seon	1000
 顺	seon
-鶉	seon
+鶉	seon	0%
 鹑	seon
 㖅	seot
 㞊	seot
@@ -19198,20 +19198,20 @@ min_phrase_weight: 100
 䆝	seot
 䘏	seot
 䢦	seot
-卹	seot
-恤	seot
-戌	seot
-朮	seot
+卹	seot	500
+恤	seot	1000
+戌	seot	1000
+朮	seot	500
 术	seot
 沭	seot
 秫	seot
 窣	seot
-蟀	seot
-術	seot
+蟀	seot	1000
+術	seot	1000
 裇	seot
 訹	seot
 訹	zeot
-述	seot
+述	seot	1000
 鉥	seot
 𣘚	seot
 㒋	si
@@ -19250,9 +19250,9 @@ min_phrase_weight: 100
 䲩	si
 䴓	si
 丝	si
-事	si
-仕	si
-侍	si
+事	si	1000
+仕	si	500
+侍	si	1000
 俬	si
 倳	si
 倳	zi
@@ -19263,45 +19263,45 @@ min_phrase_weight: 100
 剚	si
 剚	zi
 厮	si
-史	si
-司	si
-嗜	si
+史	si	1000
+司	si	1000
+嗜	si	1000
 埘	si
 塒	si
-士	si
-尸	si
-屍	si
-市	si
+士	si	1000
+尸	si	500
+屍	si	1000
+市	si	1000
 师	si
-師	si
-廝	si
+師	si	1000
+廝	si	500
 弑	si
-弒	si
-思	si
-思	soi
+弒	si	500
+思	si	1000
+思	soi	0%
 戺	si
-撕	si
-斯	si
+撕	si	1000
+斯	si	1000
 时	si
 旹	si
-是	si
-時	si
+是	si	1000
+時	si	1000
 柶	si
 榯	si
-氏	si
-氏	zi
-泗	si
+氏	si	1000
+氏	zi	0%
+泗	si	500
 溮	si
 澌	si
 狮	si
-獅	si
-示	si
+獅	si	1000
+示	si	1000
 禗	si
 禠	si
-私	si
+私	si	1000
 糹	si
 絁	si
-絲	si
+絲	si	1000
 緦	si
 纟	si
 缌	si
@@ -19318,17 +19318,17 @@ min_phrase_weight: 100
 褆	si
 褷	si
 襹	si
-視	si
+視	si	1000
 视	si
-試	si
-詩	si
+試	si	1000
+詩	si	1000
 諟	si
 諡	si
 謚	si
 试	si
 诗	si
 谥	si
-豉	si
+豉	si	1000
 跱	si
 跱	zi
 邿	si
@@ -19341,20 +19341,20 @@ min_phrase_weight: 100
 锶	si
 颸	si
 飔	si
-駟	si
+駟	si	500
 驷	si
 鰣	si
 鰤	si
 鲥	si
 鳲	si
-鷥	si
+鷥	si	500
 鸤	si
 鸶	si
 鼶	si
 𠿁	si
 𩶬	si
 𫚕	si
-惜	sik	500%
+惜	sik	5
 㛭	sik
 㛭	sim
 㝜	sik
@@ -19373,58 +19373,58 @@ min_phrase_weight: 100
 䵱	sik
 僁	sik
 啬	sik
-嗇	sik
+嗇	sik	1000
 奭	sik
-媳	sik
-式	sik
-息	sik
-悉	sik
-拭	sik
-昔	sik
+媳	sik	1000
+式	sik	1000
+息	sik	1000
+悉	sik	1000
+拭	sik	500
+昔	sik	1000
 晢	sik
 晢	zai
-晰	sik
+晰	sik	1000
 晹	sik
-淅	sik
-熄	sik
+淅	sik	500
+熄	sik	1000
 瘜	sik
 皙	sik
 穑	sik
-穡	sik
+穡	sik	500
 窸	sik
 緆	sik
 舄	sik
-色	sik
+色	sik	1000
 菥	sik
 蒠	sik
 蕮	sik
 蚀	sik
-蜥	sik
-蝕	sik
-蝕	sit
+蜥	sik	1000
+蝕	sik	1000
+蝕	sit	501
 螅	sik
-蟋	sik
+蟋	sik	1000
 衋	sik
 裼	sik
 裼	tik
 襫	sik
-識	sik
-識	zi
+識	sik	1000
+識	zi	1000
 识	sik
-軾	sik
+軾	sik	500
 轖	sik
 轼	sik
 鄎	sik
 释	sik
-釋	sik
+釋	sik	1000
 銫	sik
 鎴	sik
 铯	sik
-飾	sik
+飾	sik	1000
 餙	sik
 饰	sik
-骰	sik
-骰	tau
+骰	sik	500
+骰	tau	500
 㚒	sim
 㚒	sin
 㚲	sim
@@ -19440,31 +19440,31 @@ min_phrase_weight: 100
 䪜	zim
 婵	sim
 婵	sin
-嬋	sim
-嬋	sin
+嬋	sim	500
+嬋	sin	500
 掞	sim
 晱	sim
 煔	sim
 睒	sim
 禅	sim
 禅	sin
-禪	sim
-禪	sin
+禪	sim	500
+禪	sin	500
 笘	sim
 苫	sim
 蝉	sim
 蝉	sin
-蟬	sim
-蟬	sin
+蟬	sim	1000
+蟬	sin	0%
 蟾	sim
 裧	sim
-贍	sim
-贍	sin
+贍	sim	500
+贍	sin	500
 赡	sim
-閃	sim
+閃	sim	1000
 闪	sim
 陕	sim
-陝	sim
+陝	sim	1000
 鿃	sim
 㒨	sin
 㧥	sin
@@ -19489,33 +19489,33 @@ min_phrase_weight: 100
 䫪	song
 䱇	sin
 䱉	sin
-仙	sin
-倩	sin
+仙	sin	1000
+倩	sin	500
 僊	sin
-先	sin
+先	sin	1000
 冼	sin
-善	sin
+善	sin	1000
 墠	sin
 墡	sin
 姺	sin
 嬗	sin
 尟	sin
 廯	sin
-扇	sin
+扇	sin	1000
 搧	sin
-擅	sin
+擅	sin	1000
 樿	sin
 樿	zin
 毨	sin
 潬	sin
 潬	taan
 澶	sin
-煽	sin
+煽	sin	500
 燹	sin
 狝	sin
 獮	sin
 癣	sin
-癬	sin
+癬	sin	500
 硟	sin
 秈	sin
 筅	sin
@@ -19523,17 +19523,17 @@ min_phrase_weight: 100
 綪	sin
 綪	zang
 綫	sin
-線	sin
-繕	sin
+線	sin	1000
+繕	sin	500
 线	sin
 缮	sin
 羡	sin
-羨	sin
-腺	sin
-膳	sin
+羨	sin	1000
+腺	sin	500
+膳	sin	1000
 蒨	sin
 藓	sin
-蘚	sin
+蘚	sin	500
 蟮	sin
 蟺	sin
 褼	sin
@@ -19551,9 +19551,9 @@ min_phrase_weight: 100
 饍	sin
 騸	sin
 骟	sin
-鮮	sin
+鮮	sin	1000
 鱓	sin
-鱔	sin
+鱔	sin	500
 鲜	sin
 鳝	sin
 𠜎	sin
@@ -19575,34 +19575,34 @@ min_phrase_weight: 100
 䮪	zaang
 䱆	sing
 䳙	sing
-丞	sing
-乘	sing
-剩	sing
-剩	zing
-勝	sing
-升	sing
+丞	sing	500
+乘	sing	1000
+剩	sing	1000
+剩	zing	501
+勝	sing	1000
+升	sing	1000
 呏	sing
 圣	sing
 堘	sing
 塍	sing
 宬	sing
 嵊	sing
-性	sing
-惺	sing
-承	sing
-旌	sing
-旌	zing
-昇	sing
+性	sing	1000
+惺	sing	500
+承	sing	1000
+旌	sing	500
+旌	zing	500
+昇	sing	500
 晟	sing
 煋	sing
-猩	sing
+猩	sing	500
 瑆	sing
-盛	sing
+盛	sing	1000
 箵	sing
-繩	sing
+繩	sing	1000
 绳	sing
-聖	sing
-誠	sing
+聖	sing	1000
+誠	sing	1000
 诚	sing
 賸	sing
 郕	sing
@@ -19621,11 +19621,11 @@ min_phrase_weight: 100
 懾	sip
 懾	zip
 摄	sip
-涉	sip
+涉	sip	1000
 滠	sip
 灄	sip
-燮	sip
-燮	sit
+燮	sip	500
+燮	sit	500
 躞	sip
 躞	sit
 韘	sip
@@ -19645,21 +19645,21 @@ min_phrase_weight: 100
 伳	sit
 偰	sit
 媟	sit
-屑	sit
+屑	sit	1000
 屧	sit
-楔	sit
+楔	sit	500
 榍	sit
 渫	sit
 疶	sit
 窃	sit
-竊	sit
+竊	sit	1000
 紲	sit
 絏	sit
 緤	sit
 绁	sit
-舌	sit
-薛	sit
-褻	sit
+舌	sit	1000
+薛	sit	500
+褻	sit	500
 躠	sit
 靾	sit
 𧵳	sit
@@ -19689,59 +19689,59 @@ min_phrase_weight: 100
 䰑	siu
 䰑	sou
 䴛	siu
-兆	siu
-兆	ziu
+兆	siu	1000
+兆	ziu	0%
 劭	siu
 卲	siu
-召	siu
-召	ziu
+召	siu	0%
+召	ziu	1000
 啸	siu
-嘯	siu
-宵	siu
-小	siu
-少	siu
+嘯	siu	1000
+宵	siu	1000
+小	siu	1000
+少	siu	1000
 揱	siu
 揱	sok
 旐	siu
 旐	ziu
 櫹	siu
-消	siu
+消	siu	1000
 潇	siu
 潚	siu
-瀟	siu
+瀟	siu	1000
 烧	siu
-燒	siu
+燒	siu	1000
 痟	siu
-硝	siu
-笑	siu
+硝	siu	500
+笑	siu	1000
 筱	siu
 箫	siu
 箾	siu
 箾	sok
 篠	siu
-簫	siu
-紹	siu
+簫	siu	500
+紹	siu	1000
 綃	siu
 绍	siu
 绡	siu
 翛	siu
-肇	siu
+肇	siu	500
 肈	siu
 萧	siu
 萷	siu
 萷	sok
-蕭	siu
+蕭	siu	1000
 蟏	siu
 蠨	siu
 袑	siu
-迢	siu
-迢	tiu
-逍	siu
-邵	siu
-銷	siu
+迢	siu	500
+迢	tiu	500
+逍	siu	1000
+邵	siu	500
+銷	siu	1000
 销	siu
-霄	siu
-韶	siu
+霄	siu	1000
+韶	siu	500
 魈	siu
 鮡	siu
 㛖	so
@@ -19760,41 +19760,41 @@ min_phrase_weight: 100
 䟽	so
 䤬	so
 䵀	so
-傻	so
+傻	so	1000
 儍	so
-唆	so
+唆	so	500
 唢	so
-嗦	so
+嗦	so	500
 嗩	so
-娑	so
+娑	so	500
 惢	so
-所	so
+所	so	1000
 挱	so
 挲	so
 桫	so
-梭	so
-梳	so
+梭	so	1000
+梳	so	1000
 琐	so
-瑣	so
+瑣	so	1000
 璅	so
 璅	zou
 疎	so
-疏	so
+疏	so	1000
 簑	so
 綀	so
 羧	so
-蓑	so
-蔬	so
+蓑	so	1000
+蔬	so	1000
 趖	so
-鎖	so
+鎖	so	1000
 鏁	so
 锁	so
 𠿬	soe
 𡄽	soe
 䁻	soek
-削	soek
+削	soek	1000
 烁	soek
-鑠	soek
+鑠	soek	500
 铄	soek
 𠸑	soek
 㐮	soeng
@@ -19809,57 +19809,57 @@ min_phrase_weight: 100
 䵮	zoeng
 䵰	soeng
 䵼	soeng
-上	soeng
+上	soeng	1000
 伤	soeng
-倘	soeng
-倘	tong
+倘	soeng	0%
+倘	tong	1000
 偿	soeng
-傷	soeng
+傷	soeng	1000
 厢	soeng
 双	soeng
-商	soeng
-嘗	soeng
+商	soeng	1000
+嘗	soeng	1000
 嚐	soeng
 墑	soeng
-嫦	soeng
-孀	soeng
-孀	sung
-尚	soeng
+嫦	soeng	1000
+孀	soeng	500
+孀	sung	500
+尚	soeng	1000
 尝	soeng
-常	soeng
-廂	soeng
+常	soeng	1000
+廂	soeng	1000
 徜	soeng
 忀	soeng
-想	soeng
+想	soeng	1000
 欀	soeng
 殇	soeng
-殤	soeng
-湘	soeng
-湯	soeng
-湯	tong
+殤	soeng	500
+湘	soeng	500
+湯	soeng	0%
+湯	tong	1000
 熵	soeng
 瓖	soeng
 甞	soeng
-相	soeng
+相	soeng	1000
 礵	soeng
-箱	soeng
+箱	soeng	1000
 緗	soeng
 纕	soeng
 缃	soeng
 艭	soeng
 葙	soeng
 蔏	soeng
-裳	soeng
-襄	soeng
+裳	soeng	1000
+襄	soeng	500
 觞	soeng
-觴	soeng
+觴	soeng	500
 謪	soeng
-賞	soeng
+賞	soeng	1000
 赏	soeng
-鑲	soeng
+鑲	soeng	1000
 镶	soeng
-雙	soeng
-霜	soeng
+雙	soeng	1000
+霜	soeng	1000
 鞝	soeng
 鞝	zoeng
 驤	soeng
@@ -19878,21 +19878,21 @@ min_phrase_weight: 100
 愢	soi
 毢	soi
 毸	soi
-腮	soi
+腮	soi	500
 顋	soi
-鰓	soi
+鰓	soi	1000
 鳃	soi
 㮦	sok
 䂹	sok
 䅴	sok
 䞽	sok
 嗍	sok
-塑	sok
-塑	sou
+塑	sok	200
+塑	sou	1000
 搠	sok
 數	sok
 數	sou
-朔	sok
+朔	sok	1000
 槊	sok
 欶	sok
 溹	sok
@@ -19907,12 +19907,12 @@ min_phrase_weight: 100
 䫙	song
 䮣	song
 丧	song
-喪	song
-嗓	song
+喪	song	1000
+嗓	song	1000
 塽	song
 搡	song
-桑	song
-爽	song
+桑	song	1000
+爽	song	1000
 磉	song
 顙	song
 颡	song
@@ -19936,37 +19936,37 @@ min_phrase_weight: 100
 䲆	sou
 傃	sou
 嗉	sou
-囌	sou
+囌	sou	500
 埽	sou
 塐	sou
-嫂	sou
+嫂	sou	1000
 愫	sou
 愬	sou
 扫	sou
-掃	sou
-搔	sou
+掃	sou	1000
+搔	sou	500
 数	sou
 泝	sou
-溯	sou
-甦	sou
+溯	sou	1000
+甦	sou	1000
 瘙	sou
 稣	sou
-穌	sou
-素	sou
-繅	sou
+穌	sou	500
+素	sou	1000
+繅	sou	500
 缫	sou
 膆	sou
 臊	sou
 苏	sou
-蘇	sou
-訴	sou
+蘇	sou	1000
+訴	sou	1000
 诉	sou
 遡	sou
-酥	sou
+酥	sou	500
 颾	sou
-騷	sou
+騷	sou	1000
 骚	sou
-鬚	sou
+鬚	sou	1000
 㑐	suk
 㒔	suk
 㓘	suk
@@ -19993,35 +19993,35 @@ min_phrase_weight: 100
 䨹	suk
 䱙	suk
 䴰	suk
-倏	suk
+倏	suk	500
 倐	suk
 僳	suk
 儵	suk
-叔	suk
-塾	suk
-夙	suk
-妯	suk
-妯	zuk
-孰	suk
+叔	suk	1000
+塾	suk	500
+夙	suk	500
+妯	suk	500
+妯	zuk	500
+孰	suk	1000
 属	suk
 属	zuk
-屬	suk
-屬	zuk
+屬	suk	1000
+屬	zuk	0%
 橚	suk
-淑	suk
+淑	suk	500
 焂	suk
-熟	suk
-粟	suk
-縮	suk
+熟	suk	1000
+粟	suk	1000
+縮	suk	1000
 缩	suk
 肃	suk
-肅	suk
-菽	suk
+肅	suk	1000
+菽	suk	500
 蓿	suk
-蜀	suk
+蜀	suk	500
 謖	suk
 谡	suk
-贖	suk
+贖	suk	1000
 赎	suk
 蹜	suk
 钃	suk
@@ -20051,25 +20051,25 @@ min_phrase_weight: 100
 䯷	sung
 傱	sung
 娀	sung
-宋	sung
-崇	sung
+宋	sung	1000
+崇	sung	1000
 崧	sung
-嵩	sung
+嵩	sung	1000
 嵷	sung
 忪	sung
 忪	zung
 怂	sung
-悚	sung
-慫	sung
+悚	sung	500
+慫	sung	500
 摏	sung
-淞	sung
+淞	sung	500
 竦	sung
 耸	sung
-聳	sung
+聳	sung	1000
 菘	sung
-送	sung
+送	sung	1000
 駷	sung
-鬆	sung
+鬆	sung	1000
 𢥠	sung
 㓱	syu
 㛸	syu
@@ -20095,22 +20095,22 @@ min_phrase_weight: 100
 姝	syu
 姝	zyu
 尌	syu
-庶	syu
-恕	syu
-戍	syu
-抒	syu
+庶	syu	500
+恕	syu	1000
+戍	syu	1000
+抒	syu	1000
 摅	syu
 摴	syu
 攄	syu
-暑	syu
-書	syu
+暑	syu	1000
+書	syu	1000
 杸	syu
 枢	syu
 树	syu
 樗	syu
-樞	syu
-樹	syu
-殊	syu
+樞	syu	1000
+樹	syu	1000
+殊	syu	1000
 殳	syu
 洙	syu
 洙	zyu
@@ -20121,20 +20121,20 @@ min_phrase_weight: 100
 紓	syu
 纾	syu
 腧	syu
-舒	syu
-薯	syu
+舒	syu	1000
+薯	syu	1000
 藷	syu
 裋	syu
-豎	syu
+豎	syu	1000
 趎	syu
 趎	zyu
-輸	syu
+輸	syu	1000
 输	syu
 鄃	syu
-銖	syu
-銖	zyu
-黍	syu
-鼠	syu
+銖	syu	500
+銖	zyu	500
+黍	syu	500
+鼠	syu	1000
 㔯	syun
 㔵	syun
 㔵	wan
@@ -20158,23 +20158,23 @@ min_phrase_weight: 100
 僎	syun
 僎	zaan
 匴	syun
-吮	syun
+吮	syun	500
 孙	syun
-孫	syun
-宣	syun
+孫	syun	1000
+宣	syun	1000
 悛	syun
 损	syun
 揎	syun
-損	syun
+損	syun	1000
 搎	syun
-撰	syun
-撰	zaan
-旋	syun
+撰	syun	500
+撰	zaan	500
+旋	syun	1000
 朘	syun
 朘	zeoi
 朘	zeon
 槂	syun
-漩	syun
+漩	syun	500
 狲	syun
 狻	syun
 猻	syun
@@ -20185,20 +20185,20 @@ min_phrase_weight: 100
 璿	syun
 痠	syun
 筭	syun
-算	syun
-篆	syun
+算	syun	1000
+篆	syun	1000
 篹	syun
 篹	zaan
 腞	syun
-船	syun
+船	syun	1000
 荪	syun
-蒜	syun
-蓀	syun
+蒜	syun	500
+蓀	syun	500
 选	syun
-選	syun
-還	syun
-還	waan
-酸	syun
+選	syun	1000
+還	syun	0%
+還	waan	1000
+酸	syun	1000
 鏇	syun
 鐫	syun
 鐫	zeon
@@ -20206,28 +20206,28 @@ min_phrase_weight: 100
 镟	syun
 隽	syun
 隽	zeon
-雋	syun
-雋	zeon
-飧	syun
+雋	syun	500
+雋	zeon	500
+飧	syun	1000
 㡜	syut
 㥜	syut
 㥜	waai
 䨮	syut
-説	syut
+説	syut	1000
 说	syut
-雪	syut
+雪	syut	1000
 鱈	syut
 鳕	syut
 𠽌	syut
-他	taa
-他	to
-佗	taa
-佗	to
-它	taa
-它	to
+他	taa	1000
+他	to	0%
+佗	taa	0%
+佗	to	1000
+它	taa	1000
+它	to	0%
 怹	taa
-牠	taa
-牠	to
+牠	taa	1000
+牠	to	0%
 祂	taa
 鉈	taa
 鉈	to
@@ -20253,18 +20253,18 @@ min_phrase_weight: 100
 䧑	taai
 䴘	taai
 䶏	taai
-太	taai
+太	taai	1000
 忕	taai
 态	taai
-態	taai
+態	taai	1000
 殢	taai
 殢	tai
-汰	taai
-泰	taai
+汰	taai	1000
+泰	taai	1000
 舦	taai
 艜	taai
-貸	taai
-貸	tik
+貸	taai	1000
+貸	tik	0%
 贷	taai
 鈦	taai
 钛	taai
@@ -20280,26 +20280,26 @@ min_phrase_weight: 100
 墰	taam
 惔	taam
 憛	taam
-探	taam
+探	taam	1000
 撢	taam
 昙	taam
 曇	taam
 橝	taam
-毯	taam
-毯	taan
-潭	taam
-痰	taam
+毯	taam	1000
+毯	taan	1000
+潭	taam	1000
+痰	taam	1000
 緂	taam
-罈	taam
+罈	taam	500
 菼	taam
 藫	taam
 蟫	taam
-覃	taam
-談	taam
-譚	taam
+覃	taam	500
+談	taam	1000
+譚	taam	500
 谈	taam
 谭	taam
-貪	taam
+貪	taam	1000
 贉	taam
 贪	taam
 郯	taam
@@ -20322,24 +20322,24 @@ min_phrase_weight: 100
 叹	taan
 啴	taan
 嘆	taan
-坍	taan
+坍	taan	500
 坛	taan
-坦	taan
-壇	taan
+坦	taan	1000
+壇	taan	1000
 忐	taan
 摊	taan
-攤	taan
+攤	taan	1000
 枟	taan
-檀	taan
-歎	taan
+檀	taan	1000
+歎	taan	1000
 滩	taan
-灘	taan
-炭	taan
+灘	taan	1000
+炭	taan	1000
 疸	taan
 瘫	taan
-癱	taan
-碳	taan
-袒	taan
+癱	taan	1000
+碳	taan	1000
+袒	taan	500
 襢	taan
 贃	taan
 贃	zaam
@@ -20350,13 +20350,13 @@ min_phrase_weight: 100
 㙮	taap
 㯓	taap
 䌈	taap
-塌	taap
-塔	taap
-拓	taap
-拓	tok
-拓	zek
+塌	taap	1000
+塔	taap	1000
+拓	taap	1000
+拓	tok	1000
+拓	zek	0%
 搨	taap
-榻	taap
+榻	taap	500
 毾	taap
 涾	taap
 褟	taap
@@ -20380,7 +20380,7 @@ min_phrase_weight: 100
 闥	taat
 闼	taat
 鞑	taat
-韃	taat
+韃	taat	500
 㪗	taau
 㪗	tau
 䞬	taau
@@ -20398,17 +20398,17 @@ min_phrase_weight: 100
 䶍	tai
 䶑	tai
 偍	tai
-剃	tai
-啼	tai
+剃	tai	1000
+啼	tai	1000
 嗁	tai
-嚏	tai
-堤	tai
+嚏	tai	1000
+堤	tai	1000
 媞	tai
 屉	tai
-屜	tai
-替	tai
-梯	tai
-涕	tai
+屜	tai	1000
+替	tai	1000
+梯	tai	1000
+涕	tai	1000
 禔	tai
 稊	tai
 綈	tai
@@ -20418,16 +20418,16 @@ min_phrase_weight: 100
 蕛	tai
 薙	tai
 謕	tai
-蹄	tai
+蹄	tai	1000
 蹏	tai
 醍	tai
-銻	tai
+銻	tai	500
 锑	tai
 隄	tai
-題	tai
+題	tai	1000
 题	tai
 騠	tai
-體	tai
+體	tai	1000
 鬀	tai
 鬄	tai
 鯷	tai
@@ -20456,32 +20456,32 @@ min_phrase_weight: 100
 㳩	tan
 䞡	tan
 䵍	tan
-吞	tan
+吞	tan	1000
 揗	tan
 揗	tang
 暾	tan
 氽	tan
 涒	tan
 涒	wan
-褪	tan
+褪	tan	500
 蹆	tan
-飩	tan
+飩	tan	500
 饨	tan
 䕨	tang
 䲍	tang
 䲢	tang
 滕	tang
-疼	tang
-疼	tung
+疼	tang	1000
+疼	tung	0%
 籐	tang
 縢	tang
 腾	tang
-藤	tang
+藤	tang	1000
 誊	tang
-謄	tang
+謄	tang	500
 邆	tang
 駦	tang
-騰	tang
+騰	tang	1000
 䪚	tap
 佮	tap
 𠸊	tap
@@ -20490,26 +20490,26 @@ min_phrase_weight: 100
 䟝	tau
 䵉	tau
 亠	tau
-偷	tau
+偷	tau	1000
 偸	tau
 头	tau
 妵	tau
 媮	tau
-投	tau
+投	tau	1000
 敨	tau
-透	tau
-頭	tau
+透	tau	1000
+頭	tau	1000
 黈	tau
 𧿫	tau
-踢	tek
+踢	tek	1000
 㕔	teng
 㕔	ting
 厅	teng
-廳	teng
-聽	teng
-聽	ting
-艇	teng
-艇	ting
+廳	teng	1000
+聽	teng	501
+聽	ting	1000
+艇	teng	1000
+艇	ting	0%
 㞂	teoi
 㞜	teoi
 㢈	teoi
@@ -20532,12 +20532,12 @@ min_phrase_weight: 100
 僓	teoi
 墤	teoi
 穨	teoi
-腿	teoi
+腿	teoi	1000
 蓷	teoi
 藬	teoi
-退	teoi
+退	teoi	1000
 隤	teoi
-頹	teoi
+頹	teoi	1000
 颓	teoi
 魋	teoi
 䥴	teon
@@ -20550,7 +20550,7 @@ min_phrase_weight: 100
 啍	teon
 啍	zeon
 彖	teon
-湍	teon
+湍	teon	500
 芚	teon
 芚	tyun
 褖	teon
@@ -20564,17 +20564,17 @@ min_phrase_weight: 100
 䢰	tik
 䯜	tik
 倜	tik
-剔	tik
+剔	tik	1000
 忑	tik
 忒	tik
 悐	tik
-惕	tik
+惕	tik	1000
 惖	tik
 擿	tik
 擿	zek
 貣	tik
 趯	tik
-逖	tik
+逖	tik	500
 鋱	tik
 铽	tik
 㐁	tim
@@ -20588,14 +20588,14 @@ min_phrase_weight: 100
 㶺	tim
 䄼	tim
 䣶	tim
-忝	tim
-恬	tim
+忝	tim	500
+恬	tim	500
 掭	tim
-添	tim
+添	tim	1000
 湉	tim
-甜	tim
+甜	tim	1000
 簟	tim
-舔	tim
+舔	tim	1000
 菾	tim
 餂	tim
 㥏	tin
@@ -20613,21 +20613,21 @@ min_phrase_weight: 100
 䧃	tin
 䩄	tin
 塡	tin
-填	tin
-天	tin
+填	tin	1000
+天	tin	1000
 搷	tin
 沺	tin
 淟	tin
 瑱	tin
 瑱	zan
-田	tin
+田	tin	1000
 畋	tin
 磌	tin
 窴	tin
 窴	zi
-腆	tin
+腆	tin	500
 覥	tin
-闐	tin
+闐	tin	500
 阗	tin
 𧰊	tin
 㹶	ting
@@ -20639,15 +20639,15 @@ min_phrase_weight: 100
 䩠	ting
 䯕	ting
 䱓	ting
-亭	ting
+亭	ting	1000
 侹	ting
-停	ting
-婷	ting
-庭	ting
-廷	ting
-挺	ting
+停	ting	1000
+婷	ting	500
+庭	ting	1000
+廷	ting	1000
+挺	ting	1000
 桯	ting
-梃	ting
+梃	ting	500
 楟	ting
 渟	ting
 烃	ting
@@ -20658,10 +20658,10 @@ min_phrase_weight: 100
 脡	ting
 莛	ting
 葶	ting
-蜓	ting
+蜓	ting	1000
 鋌	ting
 铤	ting
-霆	ting
+霆	ting	1000
 頲	ting
 颋	ting
 鼮	ting
@@ -20669,13 +20669,13 @@ min_phrase_weight: 100
 䥌	tip
 䥌	zing
 䴴	tip
-帖	tip
+帖	tip	1000
 怗	tip
-貼	tip
+貼	tip	1000
 贴	tip
 鉄	tit
 銕	tit
-鐵	tit
+鐵	tit	1000
 铁	tit
 餮	tit
 驖	tit
@@ -20689,17 +20689,17 @@ min_phrase_weight: 100
 䩦	tiu
 䯾	tiu
 䱔	tiu
-佻	tiu
+佻	tiu	500
 嬥	tiu
 岧	tiu
 庣	tiu
 恌	tiu
-挑	tiu
-挑	tou
+挑	tiu	1000
+挑	tou	0%
 朓	tiu
 条	tiu
-條	tiu
-眺	tiu
+條	tiu	1000
+眺	tiu	1000
 祧	tiu
 窱	tiu
 笤	tiu
@@ -20712,7 +20712,7 @@ min_phrase_weight: 100
 蜩	tiu
 覜	tiu
 趒	tiu
-跳	tiu
+跳	tiu	1000
 鞗	tiu
 髫	tiu
 鰷	tiu
@@ -20733,38 +20733,38 @@ min_phrase_weight: 100
 䲁	to
 䲁	waai
 䲊	to
-唾	to
-唾	toe
-唾	tou
+唾	to	1000
+唾	toe	1000
+唾	tou	0%
 坨	to
 堶	to
-妥	to
+妥	to	1000
 嫷	to
 拕	to
-拖	to
+拖	to	1000
 柁	to
 梼	to
 椭	to
-橢	to
+橢	to	1000
 毻	to
-沱	to
+沱	to	500
 沲	to
 砣	to
 紽	to
-舵	to
+舵	to	1000
 詑	to
-跎	to
+跎	to	1000
 酡	to
-陀	to
-馱	to
-駝	to
+陀	to	500
+馱	to	1000
+駝	to	1000
 驒	to
 驮	to
 驼	to
 鮀	to
 鳚	to
 鳚	waai
-鴕	to
+鴕	to	500
 鸵	to
 鼉	to
 鼍	to
@@ -20778,20 +20778,20 @@ min_phrase_weight: 100
 䈚	toi
 䑓	toi
 儓	toi
-抬	toi
+抬	toi	1000
 擡	toi
-枱	toi
+枱	toi	1000
 檯	toi
 炱	toi
 籉	toi
-胎	toi
+胎	toi	1000
 臺	toi
-苔	toi
+苔	toi	1000
 薹	toi
-跆	toi
+跆	toi	500
 邰	toi
 鈶	toi
-颱	toi
+颱	toi	1000
 駘	toi
 骀	toi
 鮐	toi
@@ -20803,7 +20803,7 @@ min_phrase_weight: 100
 乇	zaak
 侂	tok
 庹	tok
-托	tok
+托	tok	1000
 柝	tok
 槖	tok
 橐	tok
@@ -20811,7 +20811,7 @@ min_phrase_weight: 100
 箨	tok
 籜	tok
 蘀	tok
-託	tok
+託	tok	1000
 讬	tok
 跅	tok
 飥	tok
@@ -20841,41 +20841,41 @@ min_phrase_weight: 100
 䣘	tong
 傥	tong
 儻	tong
-唐	tong
-堂	tong
-塘	tong
+唐	tong	1000
+堂	tong	1000
+塘	tong	1000
 捅	tong
 捅	tung
-搪	tong
+搪	tong	500
 摚	tong
 曭	tong
-棠	tong
+棠	tong	500
 樘	tong
 汤	tong
-淌	tong
+淌	tong	1000
 溏	tong
 烫	tong
 煻	tong
-熨	tong
-熨	wai
-熨	wan
-熨	wat
-燙	tong
+熨	tong	500
+熨	wai	500
+熨	wan	500
+熨	wat	500
+燙	tong	1000
 爣	tong
 瑭	tong
 矘	tong
-糖	tong
+糖	tong	1000
 羰	tong
-膛	tong
+膛	tong	500
 螗	tong
-螳	tong
+螳	tong	500
 赯	tong
-趟	tong
+趟	tong	1000
 蹚	tong
-躺	tong
-醣	tong
+躺	tong	1000
+醣	tong	500
 鎲	tong
-鏜	tong
+鏜	tong	500
 鐋	tong
 铴	tong
 镗	tong
@@ -20911,33 +20911,33 @@ min_phrase_weight: 100
 䮻	tou
 䳜	tou
 兎	tou
-兔	tou
+兔	tou	1000
 匋	tou
-吐	tou
+吐	tou	1000
 咷	tou
-啕	tou
+啕	tou	500
 图	tou
-圖	tou
-土	tou
+圖	tou	1000
+土	tou	1000
 堍	tou
-塗	tou
-套	tou
-屠	tou
+塗	tou	1000
+套	tou	1000
+屠	tou	1000
 廜	tou
 弢	tou
-徒	tou
+徒	tou	1000
 悇	tou
 慆	tou
-掏	tou
+掏	tou	1000
 搯	tou
-桃	tou
+桃	tou	1000
 槄	tou
 檮	tou
 涂	tou
 涛	tou
-淘	tou
-滔	tou
-濤	tou
+淘	tou	1000
+滔	tou	1000
+濤	tou	1000
 瘏	tou
 祷	tou
 絛	tou
@@ -20945,22 +20945,22 @@ min_phrase_weight: 100
 縚	tou
 绦	tou
 绹	tou
-肚	tou
-荼	tou
+肚	tou	1000
+荼	tou	500
 菟	tou
-萄	tou
-討	tou
+萄	tou	1000
+討	tou	1000
 謟	tou
 讨	tou
-逃	tou
-途	tou
+逃	tou	1000
+途	tou	1000
 酴	tou
 醄	tou
 釷	tou
 钍	tou
 鞀	tou
 鞉	tou
-韜	tou
+韜	tou	500
 韬	tou
 饕	tou
 駣	tou
@@ -20970,7 +20970,7 @@ min_phrase_weight: 100
 鷋	tou
 鼗	tou
 䛢	tuk
-禿	tuk
+禿	tuk	1000
 秃	tuk
 鵚	tuk
 㛚	tung
@@ -20991,30 +20991,30 @@ min_phrase_weight: 100
 䶱	tung
 仝	tung
 佟	tung
-僮	tung
-僮	zung
-同	tung
-彤	tung
+僮	tung	500
+僮	zung	500
+同	tung	1000
+彤	tung	500
 曈	tung
 朣	tung
-桐	tung
-桶	tung
+桐	tung	500
+桶	tung	1000
 氃	tung
-潼	tung
+潼	tung	500
 烔	tung
 熥	tung
 犝	tung
 獞	tung
 獞	zong
 痌	tung
-痛	tung
-瞳	tung
+痛	tung	1000
+瞳	tung	1000
 穜	tung
 穜	zung
-童	tung
-筒	tung
+童	tung	1000
+筒	tung	1000
 筩	tung
-統	tung
+統	tung	1000
 綂	tung
 统	tung
 膧	tung
@@ -21022,9 +21022,9 @@ min_phrase_weight: 100
 茼	tung
 蓪	tung
 赨	tung
-通	tung
+通	tung	1000
 酮	tung
-銅	tung
+銅	tung	1000
 铜	tung
 鲖	tung
 𧚔	tung
@@ -21034,9 +21034,9 @@ min_phrase_weight: 100
 剸	tyun
 剸	zyun
 团	tyun
-團	tyun
-屯	tyun
-屯	zeon
+團	tyun	1000
+屯	tyun	500
+屯	zeon	500
 庉	tyun
 忳	tyun
 忳	zeon
@@ -21047,9 +21047,9 @@ min_phrase_weight: 100
 篿	tyun
 篿	zyun
 糰	tyun
-臀	tyun
+臀	tyun	500
 豘	tyun
-豚	tyun
+豚	tyun	1000
 軘	tyun
 魨	tyun
 鲀	tyun
@@ -21057,11 +21057,11 @@ min_phrase_weight: 100
 鷻	tyun
 侻	tyut
 脫	tyut
-脱	tyut
+脱	tyut	1000
 莌	tyut
 瓮	ung
 齆	ung
-汙	waa	0%
+汙	waa	0
 汙	wu
 㕦	waa
 㕦	zyu
@@ -21079,40 +21079,40 @@ min_phrase_weight: 100
 䯄	waa
 䵷	waa
 䶤	waa
-划	waa
+划	waa	1000
 剐	waa
 剮	waa
 华	waa
-哇	waa
+哇	waa	1000
 哗	waa
 喎	waa
 喎	wo	1000
-娃	waa
+娃	waa	1000
 崋	waa
-挖	waa
-挖	waat
+挖	waa	0%
+挖	waat	1000
 搲	waa
 搲	we
 摦	waa
 桦	waa
 槬	waa
-樺	waa
+樺	waa	500
 洼	waa
 漥	waa
-畫	waa
-畫	waak
+畫	waa	1000
+畫	waak	1000
 窊	waa
 窐	waa
-窪	waa
-蛙	waa
+窪	waa	500
+蛙	waa	1000
 蜗	waa
 蜗	wo
-蝸	waa
-蝸	wo
-話	waa
-譁	waa
+蝸	waa	0%
+蝸	wo	1000
+話	waa	1000
+譁	waa	500
 话	waa
-踝	waa
+踝	waa	500
 鏵	waa
 铧	waa
 驊	waa
@@ -21151,14 +21151,14 @@ min_phrase_weight: 100
 䵳	waai
 䵳	wui
 䵻	waai
-壞	waai
+壞	waai	1000
 怀	waai
-懷	waai
-槐	waai
+懷	waai	1000
+槐	waai	500
 櫰	waai
-淮	waai
-獲	waai
-獲	wok
+淮	waai	1000
+獲	waai	0%
+獲	wok	1000
 蘹	waai
 蘾	waai
 褢	waai
@@ -21171,11 +21171,11 @@ min_phrase_weight: 100
 㩇	waak
 䬉	waak
 䰥	waak
-劃	waak
+劃	waak	1000
 婳	waak
 嫿	waak
-惑	waak
-或	waak
+惑	waak	1000
+或	waak	1000
 湱	waak
 画	waak
 砉	waak
@@ -21208,30 +21208,30 @@ min_phrase_weight: 100
 䰟	waat
 婠	waan
 婠	wun
-宦	waan
+宦	waan	1000
 寰	waan
-幻	waan
+幻	waan	1000
 弯	waan
-彎	waan
-患	waan
-挽	waan
+彎	waan	1000
+患	waan	1000
+挽	waan	1000
 攌	waan
 湾	waan
 漶	waan
 潫	waan
 澴	waan
-灣	waan
-玩	waan
-玩	wun
+灣	waan	1000
+玩	waan	1000
+玩	wun	1000
 环	waan
-環	waan
+環	waan	1000
 綄	waan
-綰	waan
+綰	waan	500
 绾	waan
 缳	waan
-豢	waan
+豢	waan	500
 豩	waan
-輓	waan
+輓	waan	500
 轘	waan
 还	waan
 鍰	waan
@@ -21240,7 +21240,7 @@ min_phrase_weight: 100
 镮	waan
 闤	waan
 阛	waan
-頑	waan
+頑	waan	1000
 鬟	waan
 鯇	waan
 鲩	waan
@@ -21253,7 +21253,7 @@ min_phrase_weight: 100
 䬖	waang
 䬝	waang
 横	waang
-橫	waang
+橫	waang	1000
 軭	waang
 㮧	waat
 㮧	wu
@@ -21271,7 +21271,7 @@ min_phrase_weight: 100
 䬇	waat
 䬇	zyun
 姡	waat
-猾	waat
+猾	waat	1000
 穵	waat
 螖	waat
 㕟	wai
@@ -21302,99 +21302,99 @@ min_phrase_weight: 100
 䴧	wai
 为	wai
 伟	wai
-位	wai
-倭	wai
-倭	wo
-偉	wai
-卉	wai
+位	wai	1000
+倭	wai	500
+倭	wo	500
+偉	wai	1000
+卉	wai	1000
 卫	wai
-唯	wai
-喂	wai
-喟	wai
+唯	wai	1000
+喂	wai	1000
+喟	wai	500
 喴	wai
 喴	wi
 嘒	wai
 囗	wai
 围	wai
-圍	wai
+圍	wai	1000
 壝	wai
-委	wai
-威	wai
+委	wai	1000
+威	wai	1000
 媦	wai
 寪	wai
-尉	wai
-尉	wat
+尉	wai	500
+尉	wat	500
 崣	wai
 崴	wai
 帏	wai
-帷	wai
+帷	wai	1000
 幃	wai
-彙	wai
-彙	wui
+彙	wai	500
+彙	wui	500
 恚	wai
-惟	wai
-惠	wai
-慧	wai
-慰	wai
+惟	wai	1000
+惠	wai	1000
+慧	wai	1000
+慰	wai	1000
 憓	wai
 暐	wai
 橞	wai
-毀	wai
+毀	wai	1000
 毁	wai
 毇	wai
 涠	wai
-渭	wai
+渭	wai	1000
 湋	wai
 潍	wai
 潿	wai
 濰	wai
 炜	wai
-為	wai
+為	wai	1000
 煒	wai
 煟	wai
-燬	wai
+燬	wai	500
 爲	wai
 犚	wai
-猥	wai
-猥	wui
+猥	wai	500
+猥	wui	500
 猬	wai
 獩	wai
 玮	wai
 瑋	wai
-畏	wai
-痿	wai
+畏	wai	1000
+痿	wai	500
 碨	wai
 碨	wui
 秽	wai
-穢	wai
-維	wai
-緯	wai
+穢	wai	1000
+維	wai	1000
+緯	wai	500
 纬	wai
 维	wai
 罻	wai
 罻	wat
 翽	wai
-胃	wai
+胃	wai	1000
 腲	wai
 苇	wai
-萎	wai
-葦	wai
+萎	wai	1000
+葦	wai	500
 葳	wai
 蒍	wai
-蔚	wai
-蔚	wat
-蕙	wai
+蔚	wai	1000
+蔚	wat	0%
+蕙	wai	500
 薉	wai
 蜼	wai
 蝛	wai
 蝟	wai
 蟪	wai
 衛	wai
-衞	wai
+衞	wai	1000
 褽	wai
-諉	wai
-諱	wai
-謂	wai
+諉	wai	500
+諱	wai	500
+謂	wai	1000
 譓	wai
 譭	wai
 讆	wai
@@ -21404,21 +21404,21 @@ min_phrase_weight: 100
 躗	wai
 违	wai
 逶	wai
-違	wai
+違	wai	1000
 遗	wai
-遺	wai
+遺	wai	1000
 鄬	wai
 鏏	wai
 鏸	wai
-闈	wai
+闈	wai	500
 闱	wai
 霨	wai
-韋	wai
+韋	wai	500
 韙	wai
 韡	wai
 韦	wai
 韪	wai
-餵	wai
+餵	wai	1000
 骫	wai
 𧬨	wai
 䇈	wak
@@ -21449,18 +21449,18 @@ min_phrase_weight: 100
 䮝	wan
 䲰	wan
 䴷	wan
-云	wan
+云	wan	1000
 倱	wan
-允	wan
-勻	wan
+允	wan	1000
+勻	wan	1000
 匀	wan
 呍	wan
 圂	wan
 妘	wan
-尹	wan
+尹	wan	500
 恽	wan
 惲	wan
-愠	wan
+愠	wan	1000
 慁	wan
 慍	wan
 抎	wan
@@ -21471,13 +21471,13 @@ min_phrase_weight: 100
 殒	wan
 殞	wan
 殟	wan
-氲	wan
+氲	wan	500
 氳	wan
 沄	wan
 浑	wan
-混	wan
-温	wan
-渾	wan
+混	wan	1000
+温	wan	1000
+渾	wan	1000
 溫	wan
 溳	wan
 溷	wan
@@ -21486,20 +21486,20 @@ min_phrase_weight: 100
 熅	wan
 狁	wan
 珲	wan
-琿	wan
+琿	wan	500
 畇	wan
-瘟	wan
+瘟	wan	500
 磒	wan
 秐	wan
 稳	wan
-穩	wan
+穩	wan	1000
 筼	wan
 篔	wan
-紜	wan
+紜	wan	1000
 縕	wan
 纭	wan
 缊	wan
-耘	wan
+耘	wan	1000
 芸	wan
 荺	wan
 蕓	wan
@@ -21516,7 +21516,7 @@ min_phrase_weight: 100
 轀	wan
 辒	wan
 运	wan
-運	wan
+運	wan	1000
 郓	wan
 郧	wan
 鄆	wan
@@ -21525,19 +21525,19 @@ min_phrase_weight: 100
 醞	wan
 鋆	wan
 陨	wan
-雲	wan
+雲	wan	1000
 霣	wan
 韗	wan
 韞	wan
 韫	wan
 韵	wan
-韻	wan
+韻	wan	1000
 顐	wan
 顽	wan
-餛	wan
+餛	wan	500
 餫	wan
 馄	wan
-魂	wan
+魂	wan	1000
 鼲	wan
 𨋍	wan
 𨋍	wen
@@ -21552,11 +21552,11 @@ min_phrase_weight: 100
 䩑	wang
 䫺	wang
 吰	wang
-宏	wang
-弘	wang
+宏	wang	1000
+弘	wang	1000
 彋	wang
 汯	wang
-泓	wang
+泓	wang	500
 浤	wang
 竑	wang
 紘	wang
@@ -21575,7 +21575,7 @@ min_phrase_weight: 100
 䴳	wok
 䵥	wat
 嗢	wat
-屈	wat
+屈	wat	1000
 抇	wat
 搰	wat
 欝	wat
@@ -21590,7 +21590,7 @@ min_phrase_weight: 100
 詘	zeot
 诎	wat
 驈	wat
-鬱	wat
+鬱	wat	1000
 鱊	wat
 鴥	wat
 鹬	wat
@@ -21600,7 +21600,7 @@ min_phrase_weight: 100
 㚜	wik
 㽣	wik
 䈅	wik
-域	wik
+域	wik	1000
 棫	wik
 窢	wik
 緎	wik
@@ -21614,16 +21614,16 @@ min_phrase_weight: 100
 㯋	wing
 咏	wing
 嵘	wing
-榮	wing
-永	wing
-泳	wing
+榮	wing	1000
+永	wing	1000
+泳	wing	1000
 潁	wing
 禜	wing
-穎	wing
+穎	wing	1000
 荣	wing
 蝾	wing
 蠑	wing
-詠	wing
+詠	wing	1000
 醟	wing
 颍	wing
 颎	wing
@@ -21636,7 +21636,7 @@ min_phrase_weight: 100
 䒩	wu
 䰀	wo
 咊	wo
-和	wo
+和	wo	1000
 啝	wo
 埚	wo
 堝	wo
@@ -21649,15 +21649,15 @@ min_phrase_weight: 100
 猧	wo
 盉	wo
 祸	wo
-禍	wo
-禾	wo
+禍	wo	1000
+禾	wo	1000
 窝	wo
-窩	wo
+窩	wo	1000
 莴	wo
-萵	wo
+萵	wo	500
 踒	wo
 鉌	wo
-鍋	wo
+鍋	wo	1000
 锅	wo
 龢	wo
 𡁜	wo
@@ -21670,11 +21670,11 @@ min_phrase_weight: 100
 濩	wok
 濩	wu
 瓁	wok
-瓠	wok
-瓠	wu
+瓠	wok	500
+瓠	wu	500
 矱	wok
-穫	wok
-穫	wu
+穫	wok	1000
+穫	wu	0%
 臒	wok
 臒	wu
 获	wok
@@ -21699,44 +21699,44 @@ min_phrase_weight: 100
 䰣	wong
 䳨	wong
 偟	wong
-凰	wong
+凰	wong	1000
 喤	wong
 堭	wong
 尢	wong
 尪	wong
-往	wong
+往	wong	1000
 徃	wong
-徨	wong
-惶	wong
-旺	wong
-枉	wong
-汪	wong
+徨	wong	500
+惶	wong	1000
+旺	wong	1000
+枉	wong	1000
+汪	wong	1000
 湟	wong
 潢	wong
 瀇	wong
-煌	wong
+煌	wong	1000
 獚	wong
-王	wong
-璜	wong
+王	wong	1000
+璜	wong	500
 癀	wong
-皇	wong
-磺	wong
-篁	wong
-簧	wong
+皇	wong	1000
+磺	wong	500
+篁	wong	500
+簧	wong	500
 艎	wong
-蝗	wong
+蝗	wong	1000
 蟥	wong
 趪	wong
 迋	wong
-遑	wong
+遑	wong	500
 鍠	wong
 锽	wong
-隍	wong
+隍	wong	500
 餭	wong
 騜	wong
 鰉	wong
 鳇	wong
-黃	wong
+黃	wong	1000
 黄	wong
 𫗮	wong
 㕆	wu
@@ -21765,64 +21765,64 @@ min_phrase_weight: 100
 䭅	wu
 䭌	wu
 乌	wu
-互	wu
+互	wu	1000
 冱	wu
 呜	wu
-嗚	wu
-圬	wu
+嗚	wu	1000
+圬	wu	500
 坞	wu
-塢	wu
+塢	wu	500
 壶	wu
-壺	wu
+壺	wu	1000
 婟	wu
 嫭	wu
 嫮	wu
 岵	wu
-弧	wu
+弧	wu	1000
 怙	wu
 戶	wu
-户	wu
-扈	wu
+户	wu	1000
+扈	wu	500
 护	wu
-捂	wu
+捂	wu	500
 摀	wu
 杇	wu
 枑	wu
 楜	wu
 歍	wu
 汚	wu
-污	wu
+污	wu	1000
 沍	wu
 沪	wu
 洿	wu
 浒	wu
-湖	wu
-滬	wu
+湖	wu	1000
+滬	wu	500
 滸	wu
-烏	wu
-狐	wu
+烏	wu	1000
+狐	wu	1000
 猢	wu
-瑚	wu
+瑚	wu	1000
 祜	wu
-糊	wu
-胡	wu
-芋	wu
-葫	wu
-蝴	wu
+糊	wu	1000
+胡	wu	1000
+芋	wu	500
+葫	wu	1000
+蝴	wu	1000
 衚	wu
-護	wu
+護	wu	1000
 邬	wu
 鄔	wu
 鄠	wu
 醐	wu
 釫	wu
-鎢	wu
+鎢	wu	500
 钨	wu
 隝	wu
 靰	wu
 頀	wu
 餬	wu
-鬍	wu
+鬍	wu	1000
 魱	wu
 鶘	wu
 鶦	wu
@@ -21837,13 +21837,13 @@ min_phrase_weight: 100
 䋿	wui
 会	wui
 佪	wui
-偎	wui
-匯	wui
+偎	wui	500
+匯	wui	1000
 囘	wui
-回	wui
+回	wui	1000
 囬	wui
 廻	wui
-徊	wui
+徊	wui	1000
 恛	wui
 椳	wui
 汇	wui
@@ -21851,15 +21851,15 @@ min_phrase_weight: 100
 渨	wui
 滙	wui
 烩	wui
-煨	wui
-燴	wui
+煨	wui	500
+燴	wui	500
 痐	wui
 硙	wui
-茴	wui
+茴	wui	500
 蚘	wui
-蛔	wui
+蛔	wui	500
 蛕	wui
-迴	wui
+迴	wui	1000
 隈	wui
 㣪	wun
 㬇	wun
@@ -21876,51 +21876,51 @@ min_phrase_weight: 100
 䯘	wun
 䯛	wun
 䴟	wun
-剜	wun
+剜	wun	500
 唤	wun
-垣	wun
+垣	wun	500
 奂	wun
-奐	wun
+奐	wun	500
 峘	wun
 忨	wun
 换	wun
 捥	wun
-換	wun
+換	wun	1000
 晥	wun
-桓	wun
+桓	wun	500
 椀	wun
 浣	wun
 涣	wun
-渙	wun
+渙	wun	500
 澣	wun
 焕	wun
-煥	wun
+煥	wun	1000
 狟	wun
 獂	wun
 瓛	wun
 痪	wun
-瘓	wun
-皖	wun
+瘓	wun	1000
+皖	wun	500
 盌	wun
 睆	wun
-碗	wun
-緩	wun
+碗	wun	1000
+緩	wun	1000
 缓	wun
 羦	wun
 翫	wun
-腕	wun
+腕	wun	1000
 荁	wun
 萑	wun
-豌	wun
+豌	wun	500
 貆	wun
 輐	wun
 逭	wun
 雈	wun
 䄆	wut
 䄑	wut
-活	wut
+活	wut	1000
 咋	zaa	1000
-咋	zaak
+咋	zaak	500
 揸	zaa	1000
 㗬	zaa
 㡸	zaa
@@ -21937,27 +21937,27 @@ min_phrase_weight: 100
 䨨	zaa
 䨨	zeoi
 䵙	zaa
-乍	zaa
-乍	zok	0%
+乍	zaa	500
+乍	zok	0
 偺	zaa
 厏	zaa
-吒	zaa
+吒	zaa	500
 咤	zaa
-咱	zaa
+咱	zaa	1000
 喒	zaa
 嵖	zaa
 拃	zaa
 挓	zaa
-搾	zaa
+搾	zaa	500
 摣	zaa
 柤	zaa
 柤	zo
-榨	zaa
+榨	zaa	1000
 樝	zaa
 檛	zaa
-渣	zaa
+渣	zaa	1000
 溠	zaa
-炸	zaa
+炸	zaa	1000
 煠	zaa
 痄	zaa
 皻	zaa
@@ -21965,10 +21965,10 @@ min_phrase_weight: 100
 砟	zok
 膪	zaa
 苲	zaa
-蚱	zaa
-蚱	zaak
+蚱	zaa	500
+蚱	zaak	500
 觰	zaa
-詐	zaa
+詐	zaa	1000
 诈	zaa
 醡	zaa
 髽	zaa
@@ -22005,9 +22005,9 @@ min_phrase_weight: 100
 䜞	zi
 䰏	zaai
 债	zaai
-債	zaai
-寨	zaai
-寨	zai
+債	zaai	1000
+寨	zaai	1000
+寨	zai	0%
 廌	zaai
 廌	zai
 廌	zi
@@ -22019,8 +22019,8 @@ min_phrase_weight: 100
 砦	zaai
 豸	zaai
 豸	zi
-齋	zaai
-齋	zai
+齋	zaai	500
+齋	zai	500
 𡄡	zaai
 㖽	zaak
 㟙	zaak
@@ -22036,30 +22036,30 @@ min_phrase_weight: 100
 唶	ze
 啧	zaak
 啧	zik
-嘖	zaak
-嘖	zik
-宅	zaak
+嘖	zaak	500
+嘖	zik	500
+宅	zaak	1000
 岝	zaak
 岝	zok
 择	zaak
 掷	zaak
-摘	zaak
-擇	zaak
+摘	zaak	1000
+擇	zaak	1000
 擢	zaak
 擢	zok
-擲	zaak
+擲	zaak	1000
 柞	zaak
 柞	zok
 檡	zaak
 泽	zaak
-澤	zaak
+澤	zaak	1000
 矺	zaak
 碛	zaak
 碛	zik
 磔	zaak
 磧	zaak
 磧	zik
-窄	zaak
+窄	zaak	1000
 笮	zaak
 笮	zok
 箦	zaak
@@ -22069,12 +22069,12 @@ min_phrase_weight: 100
 謫	zaak
 讁	zaak
 谪	zaak
-責	zaak
+責	zaak	1000
 賾	zaak
 賾	zak
 责	zaak
 踯	zaak
-躑	zaak
+躑	zaak	500
 迮	zaak
 齰	zaak
 㕂	zaam
@@ -22110,19 +22110,19 @@ min_phrase_weight: 100
 寁	zaam
 寁	zaan
 崭	zaam
-嶄	zaam
+嶄	zaam	1000
 斩	zaam
-斬	zaam
+斬	zaam	1000
 暂	zaam
-暫	zaam
-眨	zaam
-眨	zaap
-站	zaam
-簪	zaam
+暫	zaam	1000
+眨	zaam	501
+眨	zaap	1000
+站	zaam	1000
+簪	zaam	500
 糌	zaam
-蘸	zaam
-賺	zaam
-賺	zaan
+蘸	zaam	500
+賺	zaam	0%
+賺	zaan	1000
 赚	zaam
 赚	zaan
 蹔	zaam
@@ -22182,19 +22182,19 @@ min_phrase_weight: 100
 攥	zaan
 昝	zaan
 栈	zaan
-棧	zaan
+棧	zaan	500
 灒	zaan
 琖	zaan
 瓒	zaan
 瓚	zaan
 盏	zaan
-盞	zaan
-綻	zaan
+盞	zaan	1000
+綻	zaan	1000
 绽	zaan
 譔	zaan
-讚	zaan
+讚	zaan	1000
 賛	zaan
-贊	zaan
+贊	zaan	1000
 赞	zaan
 趱	zaan
 趲	zaan
@@ -22217,30 +22217,30 @@ min_phrase_weight: 100
 䨸	zaang
 争	zaang
 争	zang
-崢	zaang
-崢	zang
+崢	zaang	500
+崢	zang	500
 挣	zaang
 挣	zang
-掙	zaang
-掙	zang
+掙	zaang	0%
+掙	zang	1000
 狰	zaang
 狰	zang
-猙	zaang
-猙	zang
+猙	zaang	500
+猙	zang	500
 睁	zaang
 睁	zang
-睜	zaang
-睜	zang
+睜	zaang	0%
+睜	zang	1000
 筝	zaang
 筝	zang
-箏	zaang
-箏	zang
-諍	zaang
-諍	zang
+箏	zaang	0%
+箏	zang	1000
+諍	zaang	500
+諍	zang	500
 诤	zaang
 诤	zang
-錚	zaang
-錚	zang
+錚	zaang	500
+錚	zang	500
 铮	zaang
 铮	zang
 𠲜	zaang
@@ -22270,22 +22270,22 @@ min_phrase_weight: 100
 亼	zaap
 剳	zaap
 劄	zaap
-匝	zaap
+匝	zaap	500
 嶍	zaap
-摺	zaap
-摺	zip
+摺	zaap	501
+摺	zip	1000
 杂	zaap
 槢	zaap
-砸	zaap
-習	zaap
+砸	zaap	500
+習	zaap	1000
 袭	zaap
-襲	zaap
+襲	zaap	1000
 钑	zaap
-閘	zaap
+閘	zaap	1000
 闸	zaap
 隰	zaap
-集	zaap
-雜	zaap
+集	zaap	1000
+雜	zaap	1000
 雥	zaap
 霫	zaap
 霫	zap
@@ -22309,11 +22309,11 @@ min_phrase_weight: 100
 䬹	zaat
 䭿	zaat
 哳	zaat
-扎	zaat
+扎	zaat	1000
 拶	zaat
-札	zaat
+札	zaat	500
 紥	zaat
-紮	zaat
+紮	zaat	1000
 蚻	zaat
 鍘	zaat
 铡	zaat
@@ -22402,33 +22402,33 @@ min_phrase_weight: 100
 䰆	zaau
 䰍	zaau
 䱂	zaau
-嘲	zaau
-帚	zaau
-帚	zau
-找	zaau
-棹	zaau
-棹	zoek
-櫂	zaau
-爪	zaau
+嘲	zaau	1000
+帚	zaau	1000
+帚	zau	0%
+找	zaau	1000
+棹	zaau	500
+棹	zoek	500
+櫂	zaau	500
+爪	zaau	1000
 爫	zaau
 瑵	zaau
 瑵	zou
-着	zaau
-着	zau
-着	zoek
+着	zaau	0%
+着	zau	0%
+着	zoek	1000
 笊	zaau
-罩	zaau
-肘	zaau
-肘	zau
-驟	zaau
-驟	zau
+罩	zaau	1000
+肘	zaau	500
+肘	zau	500
+驟	zaau	1000
+驟	zau	0%
 骤	zaau
 骤	zau
 鵫	zaau
 鵫	zok
 𦻐	zaau
 仔	zai	1000
-仔	zi
+仔	zi	1000
 㨈	zai
 㸄	zai
 㿃	zai
@@ -22442,36 +22442,36 @@ min_phrase_weight: 100
 䬩	zok
 䭁	zai
 䮺	zai
-制	zai
+制	zai	1000
 剂	zai
-劑	zai
+劑	zai	1000
 挤	zai
-擠	zai
+擠	zai	1000
 櫅	zai
 泲	zai
 泲	zi
 济	zai
 滞	zai
-滯	zai
+滯	zai	1000
 漈	zai
-濟	zai
+濟	zai	1000
 狾	zai
 猘	zai
 癠	zai
 癠	zik
-祭	zai
+祭	zai	1000
 穄	zai
 穧	zai
 虀	zai
-製	zai
+製	zai	1000
 赍	zai
 跻	zai
 躋	zai
 际	zai
-際	zai
+際	zai	1000
 隮	zai
 霁	zai
-霽	zai
+霽	zai	500
 齌	zai
 齎	zai
 齏	zai
@@ -22484,11 +22484,11 @@ min_phrase_weight: 100
 䕉	zak
 䵂	zak
 䶦	zak
-仄	zak
+仄	zak	500
 侧	zak
-側	zak
+側	zak	1000
 则	zak
-則	zak
+則	zak	1000
 崱	zak
 庂	zak
 昃	zak
@@ -22507,29 +22507,29 @@ min_phrase_weight: 100
 寖	zam
 嶜	zam
 帎	zam
-怎	zam
+怎	zam	1000
 揕	zam
-斟	zam
-朕	zam
-枕	zam
+斟	zam	500
+朕	zam	500
+枕	zam	1000
 栚	zam
-浸	zam
+浸	zam	1000
 瑊	zam
 眹	zam
 眹	zan
-砧	zam
+砧	zam	1000
 祲	zam
-箴	zam
+箴	zam	500
 絼	zam
 絼	zi
 葴	zam
 谮	zam
-針	zam
+針	zam	1000
 鍖	zam
 鍼	zam
 针	zam
 鱵	zam
-鴆	zam
+鴆	zam	500
 鸩	zam
 𠹻	zam
 𩬎	zam
@@ -22545,14 +22545,14 @@ min_phrase_weight: 100
 䬤	zin
 䳲	zan
 侲	zan
-圳	zan
+圳	zan	1000
 抮	zan
-振	zan
-珍	zan
+振	zan	1000
+珍	zan	1000
 珎	zan
 畛	zan
 眞	zan
-真	zan
+真	zan	1000
 禛	zan
 稹	zan
 籈	zan
@@ -22562,16 +22562,16 @@ min_phrase_weight: 100
 薽	zan
 蜄	zan
 裖	zan
-賑	zan
+賑	zan	1000
 赈	zan
 軫	zan
 轸	zan
 鎭	zan
-鎮	zan
+鎮	zan	1000
 镇	zan
 阵	zan
-陣	zan
-震	zan
+陣	zan	1000
+震	zan	1000
 鬒	zan
 黰	zan
 𨸬	zan
@@ -22580,10 +22580,10 @@ min_phrase_weight: 100
 䎖	zang
 䰝	zang
 䱢	zang
-增	zang
+增	zang	1000
 峥	zang
 崝	zang
-憎	zang
+憎	zang	1000
 橧	zang
 甑	zang
 矰	zang
@@ -22591,18 +22591,18 @@ min_phrase_weight: 100
 繒	zang
 缯	zang
 罾	zang
-贈	zang
+贈	zang	1000
 赠	zang
 鬙	zang
 𢛵	zang
 𤺧	zang
 㙫	zap
 㳧	zap
-執	zap
+執	zap	1000
 慹	zap
 慹	zip
 执	zap
-汁	zap
+汁	zap	1000
 絷	zap
 縶	zap
 蓻	zap
@@ -22617,8 +22617,8 @@ min_phrase_weight: 100
 䵵	zyut
 侄	zat
 厔	zat
-姪	zat
-嫉	zat
+姪	zat	1000
+嫉	zat	1000
 庢	zat
 挃	zat
 揤	zat
@@ -22628,20 +22628,20 @@ min_phrase_weight: 100
 桎	zat
 槉	zat
 櫍	zat
-疾	zat
+疾	zat	1000
 礩	zat
 礩	zi
 秷	zat
-窒	zat
+窒	zat	1000
 膣	zat
 蒺	zat
-蛭	zat
+蛭	zat	500
 蛰	zat
 蟄	zat
 蟄	zik
 蟄	zit
-質	zat
-質	zi
+質	zat	1000
+質	zi	1000
 质	zat
 郅	zat
 銍	zat
@@ -22671,48 +22671,48 @@ min_phrase_weight: 100
 侜	zau
 僦	zau
 僽	zau
-冑	zau
-周	zau
+冑	zau	500
+周	zau	1000
 呪	zau
-咒	zau
+咒	zau	1000
 咮	zau
 咮	zyu
-啁	zau
-啾	zau
+啁	zau	500
+啾	zau	500
 喌	zau
-奏	zau
+奏	zau	1000
 娵	zau
 娵	zeoi
 婤	zau
-宙	zau
-就	zau
-岫	zau
-州	zau
+宙	zau	1000
+就	zau	1000
+岫	zau	500
+州	zau	1000
 掫	zau
-揍	zau
-揪	zau
+揍	zau	500
+揪	zau	500
 昼	zau
-晝	zau
+晝	zau	1000
 棸	zau
-洲	zau
+洲	zau	1000
 湫	zau
 湫	ziu
 甃	zau
 皱	zau
-皺	zau
+皺	zau	1000
 盩	zau
 睭	zau
 箒	zau
 籀	zau
-紂	zau
+紂	zau	500
 緅	zau
 縐	zau
 纣	zau
 绉	zau
 胄	zau
-舟	zau
+舟	zau	1000
 菆	zau
-袖	zau
+袖	zau	1000
 諏	zau
 謅	zau
 譸	zau
@@ -22721,17 +22721,17 @@ min_phrase_weight: 100
 诹	zau
 賙	zau
 赒	zau
-走	zau
+走	zau	1000
 輈	zau
 輖	zau
 辀	zau
-週	zau
+週	zau	1000
 邹	zau
 郰	zau
-鄒	zau
+鄒	zau	500
 鄹	zau
 酎	zau
-酒	zau
+酒	zau	1000
 陬	zau
 騶	zau
 驺	zau
@@ -22762,69 +22762,69 @@ min_phrase_weight: 100
 䥺	ze
 䦈	ze
 䩾	ze
-借	ze
-嗟	ze
-姊	ze
-姊	zi
-姐	ze
+借	ze	1000
+嗟	ze	500
+姊	ze	501
+姊	zi	1000
+姐	ze	1000
 柘	ze
-榭	ze
+榭	ze	500
 罝	ze
 罝	zeoi
-者	ze
-蔗	ze
-藉	ze
-藉	zik
+者	ze	1000
+蔗	ze	1000
+藉	ze	1000
+藉	zik	1000
 蟅	ze
-謝	ze
+謝	ze	1000
 谢	ze
-赭	ze
+赭	ze	500
 这	ze
-這	ze
-遮	ze
+這	ze	1000
+遮	ze	1000
 鍺	ze
 锗	ze
-鷓	ze
+鷓	ze	500
 鹧	ze
 𡂪	ze
-只	zek
-只	zi
+只	zek	0%
+只	zi	1000
 呮	zek
-唧	zek
-唧	zik
+唧	zek	500
+唧	zik	500
 摭	zek
-炙	zek
-炙	zik
-績	zek
-績	zik
-脊	zek
-脊	zik
+炙	zek	1000
+炙	zik	0%
+績	zek	0%
+績	zik	1000
+脊	zek	1000
+脊	zik	0%
 膌	zek
-蓆	zek
-蓆	zik
+蓆	zek	500
+蓆	zik	500
 跖	zek
-跡	zek
-跡	zik
-隻	zek
+跡	zek	0%
+跡	zik	1000
+隻	zek	1000
 丼	zeng
 丼	zing
-井	zeng
-井	zing
+井	zeng	1000
+井	zing	0%
 净	zeng
 净	zing
 凈	zeng
 凈	zing
-正	zeng
-正	zing
+正	zeng	501
+正	zing	1000
 汫	zeng
-淨	zeng
-淨	zing
-精	zeng
-精	zing
+淨	zeng	0%
+淨	zing	1000
+精	zeng	501
+精	zing	1000
 肼	zeng
 郑	zeng
-鄭	zeng
-鄭	zing	0%
+鄭	zeng	1000
+鄭	zing	0
 㐨	zeoi
 㑺	zeoi
 㑺	zeon
@@ -22864,51 +22864,51 @@ min_phrase_weight: 100
 䳡	zeoi
 䶥	zeoi
 叙	zeoi
-咀	zeoi
-嘴	zeoi
-墜	zeoi
+咀	zeoi	1000
+嘴	zeoi	1000
+墜	zeoi	1000
 岨	zeoi
 岨	zo
-序	zeoi
+序	zeoi	1000
 怚	zeoi
-敍	zeoi
+敍	zeoi	1000
 敘	zeoi
 晬	zeoi
-最	zeoi
+最	zeoi	1000
 檇	zeoi
-沮	zeoi
+沮	zeoi	500
 溆	zeoi
 漵	zeoi
-狙	zeoi
+狙	zeoi	500
 甀	zeoi
-疽	zeoi
+疽	zeoi	500
 砠	zeoi
 砠	zo
 硾	zeoi
-綴	zeoi
-綴	zyut
+綴	zeoi	1000
+綴	zyut	200
 縋	zeoi
 缀	zeoi
 缀	zyut
 缒	zeoi
-罪	zeoi
-聚	zeoi
+罪	zeoi	1000
+聚	zeoi	1000
 苴	zeoi
 菹	zeoi
 葅	zeoi
 蕞	zeoi
 觜	zeoi
 觜	zi
-贅	zeoi
+贅	zeoi	500
 赘	zeoi
 趄	zeoi
-足	zeoi
-足	zuk
+足	zeoi	0%
+足	zuk	1000
 跙	zeoi
 辠	zeoi
-追	zeoi
-醉	zeoi
-錐	zeoi
+追	zeoi	1000
+醉	zeoi	1000
+錐	zeoi	1000
 锥	zeoi
 隹	zeoi
 雎	zeoi
@@ -22919,7 +22919,7 @@ min_phrase_weight: 100
 鱮	zeoi
 鵻	zeoi
 鵻	zeon
-齟	zeoi
+齟	zeoi	500
 龃	zeoi
 𧐅	zeoi
 𨣦	zeoi
@@ -22946,43 +22946,43 @@ min_phrase_weight: 100
 䜭	zeon
 䝲	zeon
 䦞	zeon
-俊	zeon
-儘	zeon
-准	zeon
+俊	zeon	1000
+儘	zeon	1000
+准	zeon	1000
 埻	zeon
 寯	zeon
-尊	zeon
-尊	zyun
+尊	zeon	0%
+尊	zyun	1000
 尽	zeon
-峻	zeon
+峻	zeon	1000
 搢	zeon
-晉	zeon
+晉	zeon	1000
 晋	zeon
 晙	zeon
-榛	zeon
+榛	zeon	500
 樼	zeon
-津	zeon
-浚	zeon
-準	zeon
+津	zeon	1000
+浚	zeon	500
+準	zeon	1000
 溱	zeon
 濜	zeon
-濬	zeon
+濬	zeon	500
 烬	zeon
 燼	zeon
 獉	zeon
 璡	zeon
 畯	zeon
-盡	zeon
+盡	zeon	1000
 窀	zeon
-竣	zeon
+竣	zeon	1000
 綧	zeon
 縉	zeon
 缙	zeon
 罇	zeon
-肫	zeon
+肫	zeon	500
 脧	zeon
 臇	zeon
-臻	zeon
+臻	zeon	500
 荩	zeon
 蓁	zeon
 藎	zeon
@@ -22993,13 +22993,13 @@ min_phrase_weight: 100
 轃	zeon
 迍	zeon
 进	zeon
-進	zeon
-遵	zeon
-遵	zyun
+進	zeon	1000
+遵	zeon	1000
+遵	zyun	0%
 隼	zeon
 餕	zeon
 馂	zeon
-駿	zeon
+駿	zeon	500
 骏	zeon
 鵔	zeon
 㔘	zeot
@@ -23009,7 +23009,7 @@ min_phrase_weight: 100
 䚝	zeot
 崒	zeot
 崒	zyut
-怵	zeot
+怵	zeot	500
 蜶	zeot
 𠻘	zeot
 㑥	zi
@@ -23109,106 +23109,106 @@ min_phrase_weight: 100
 䳅	zi
 䵝	zi
 䵹	zi
-之	zi
-伺	zi
+之	zi	1000
+伺	zi	500
 傂	zi
-兕	zi
+兕	zi	500
 兹	zi
-卮	zi
+卮	zi	500
 厎	zi
-吱	zi
+吱	zi	1000
 呰	zi
 呲	zi
-咨	zi
-咫	zi
+咨	zi	500
+咫	zi	500
 嗞	zi
-嗣	zi
-址	zi
+嗣	zi	500
+址	zi	1000
 坁	zi
 姉	zi
-姿	zi
-子	zi
-字	zi
-孜	zi
-孳	zi
+姿	zi	1000
+子	zi	1000
+字	zi	1000
+孜	zi	500
+孳	zi	500
 寘	zi
-寺	zi
+寺	zi	1000
 嵫	zi
-巳	zi
+巳	zi	1000
 巵	zi
 庤	zi
 彘	zi
-徵	zi
-徵	zing
-志	zi
+徵	zi	0%
+徵	zing	1000
+志	zi	1000
 恉	zi
 懫	zi
 扺	zi
-指	zi
+指	zi	1000
 挚	zi
 搘	zi
-摯	zi
-支	zi
-旨	zi
-智	zi
+摯	zi	1000
+支	zi	1000
+旨	zi	1000
+智	zi	1000
 栀	zi
-梓	zi
+梓	zi	500
 梔	zi
 椥	zi
 榰	zi
-止	zi
+止	zi	1000
 沚	zi
 涘	zi
-淄	zi
+淄	zi	500
 渍	zi
-滋	zi
-滓	zi
-漬	zi
+滋	zi	1000
+滓	zi	1000
+漬	zi	0%
 牸	zi
 甾	zi
 甾	zoi
 畤	zi
 疐	zi
 疻	zi
-痔	zi
-痣	zi
+痔	zi	500
+痣	zi	500
 眦	zi
-知	zi
-祀	zi
-祉	zi
-祗	zi
+知	zi	1000
+祀	zi	500
+祉	zi	500
+祗	zi	500
 秄	zi
 秖	zi
 秭	zi
-稚	zi
+稚	zi	1000
 稺	zi
 竢	zi
 笥	zi
 籽	zi
 粢	zi
-紙	zi
-紫	zi
-緇	zi
-緻	zi
+紙	zi	1000
+紫	zi	1000
+緇	zi	500
+緻	zi	1000
 纸	zi
 缁	zi
-置	zi
+置	zi	1000
 耔	zi
-耜	zi
-肢	zi
+耜	zi	500
+肢	zi	1000
 胏	zi
 胑	zi
 胾	zi
-脂	zi
-自	zi
-至	zi
-致	zi
+脂	zi	1000
+自	zi	1000
+至	zi	1000
+致	zi	1000
 芓	zi
-芝	zi
+芝	zi	1000
 芷	zi
 菑	zi
 菑	zoi
-蜘	zi
+蜘	zi	1000
 螆	zi
 衹	zi
 覗	zi
@@ -23216,22 +23216,22 @@ min_phrase_weight: 100
 觶	zi
 訾	zi
 訿	zi
-誌	zi
-諮	zi
+誌	zi	1000
+諮	zi	1000
 谘	zi
-貲	zi
-資	zi
+貲	zi	500
+資	zi	1000
 贄	zi
 贽	zi
 赀	zi
 资	zi
 趑	zi
-趾	zi
+趾	zi	1000
 踬	zi
 躓	zi
 軹	zi
-輊	zi
-輜	zi
+輊	zi	500
+輜	zi	500
 轵	zi
 轾	zi
 辎	zi
@@ -23243,13 +23243,13 @@ min_phrase_weight: 100
 锱	zi
 镃	zi
 阯	zi
-雉	zi
+雉	zi	500
 飤	zi
-飼	zi
+飼	zi	1000
 饲	zi
 駤	zi
 騺	zi
-髭	zi
+髭	zi	500
 鯔	zi
 鲻	zi
 鳷	zi
@@ -23303,40 +23303,40 @@ min_phrase_weight: 100
 䴬	zik
 䴬	zim
 値	zik
-值	zik
+值	zik	1000
 勣	zik
-即	zik
+即	zik	1000
 卽	zik
 埴	zik
 堲	zik
-夕	zik
-寂	zik
-席	zik
+夕	zik	1000
+寂	zik	1000
+席	zik	1000
 帻	zik
 幘	zik
-植	zik
+植	zik	1000
 楖	zik
 楖	zit
 樴	zik
-殖	zik
-汐	zik
+殖	zik	1000
+汐	zik	500
 漃	zik
-瘠	zik
+瘠	zik	500
 癪	zik
-直	zik
-矽	zik
+直	zik	1000
+矽	zik	500
 积	zik
 稙	zik
-稷	zik
-積	zik
+稷	zik	1000
+積	zik	1000
 穸	zik
-籍	zik
-織	zik
+籍	zik	1000
+織	zik	1000
 织	zik
 绩	zik
 耤	zik
 职	zik
-職	zik
+職	zik	1000
 蘵	zik
 蝍	zik
 蟙	zik
@@ -23349,7 +23349,7 @@ min_phrase_weight: 100
 軄	zik
 迹	zik
 陟	zik
-鯽	zik
+鯽	zik	500
 鰿	zik
 鲫	zik
 鶺	zik
@@ -23385,16 +23385,16 @@ min_phrase_weight: 100
 䶫	zim
 䶮	zim
 䶲	zim
-佔	zim
+佔	zim	1000
 僣	zim
-占	zim
-尖	zim
+占	zim	1000
+尖	zim	1000
 惉	zim
-沾	zim
+沾	zim	1000
 渐	zim
-漸	zim
+漸	zim	1000
 熸	zim
-瞻	zim
+瞻	zim	1000
 秥	zim
 聻	zim
 臜	zim
@@ -23403,10 +23403,10 @@ min_phrase_weight: 100
 螹	zim
 覘	zim
 觇	zim
-詹	zim
+詹	zim	1000
 譫	zim
 谵	zim
-霑	zim
+霑	zim	1000
 颭	zim
 飐	zim
 魙	zim
@@ -23460,54 +23460,54 @@ min_phrase_weight: 100
 䳿	zin
 䴏	zin
 䵐	zin
-剪	zin
+剪	zin	1000
 劗	zin
-展	zin
+展	zin	1000
 帴	zin
 戋	zin
 戔	zin
 战	zin
 戩	zin
 戬	zin
-戰	zin
+戰	zin	1000
 揃	zin
 搌	zin
 旃	zin
 栫	zin
 栴	zin
 毡	zin
-氈	zin
+氈	zin	1000
 氊	zin
 洊	zin
-湔	zin
+湔	zin	500
 溅	zin
-濺	zin
-煎	zin
+濺	zin	1000
+煎	zin	1000
 牋	zin
 牮	zin
 皽	zin
 笺	zin
-箋	zin
-箭	zin
+箋	zin	500
+箭	zin	1000
 籛	zin
 繟	zin
-羶	zin
+羶	zin	500
 翦	zin
 荐	zin
 葥	zin
-薦	zin
+薦	zin	1000
 諓	zin
 譾	zin
 谫	zin
-賤	zin
+賤	zin	1000
 赕	zin
 辗	zin
 邅	zin
 鞯	zin
 韉	zin
-顫	zin
+顫	zin	1000
 颤	zin
-餞	zin
+餞	zin	500
 饘	zin
 饯	zin
 鬋	zin
@@ -23574,46 +23574,46 @@ min_phrase_weight: 100
 䯚	zoek
 䴖	zing
 侦	zing
-偵	zing
+偵	zing	1000
 凊	zing
 婧	zing
 帧	zing
-幀	zing
-征	zing
-怔	zing
-政	zing
-整	zing
+幀	zing	500
+征	zing	1000
+怔	zing	500
+政	zing	1000
+整	zing	1000
 旍	zing
-晶	zing
+晶	zing	1000
 晸	zing
 桢	zing
-楨	zing
+楨	zing	500
 浈	zing
 湞	zing
 烝	zing
-症	zing
-癥	zing
+症	zing	1000
+癥	zing	500
 眐	zing
-睛	zing
+睛	zing	1000
 祯	zing
-禎	zing
+禎	zing	500
 穽	zing
 竫	zing
 箐	zing
-蒸	zing
+蒸	zing	1000
 証	zing
-證	zing
+證	zing	1000
 证	zing
-貞	zing
+貞	zing	500
 贞	zing
 遉	zing
 鉦	zing
 钲	zing
-阱	zing
+阱	zing	1000
 陉	zing
-靖	zing
+靖	zing	500
 静	zing
-靜	zing
+靜	zing	1000
 鶄	zing
 㐖	zip
 㖕	zip
@@ -23638,18 +23638,18 @@ min_phrase_weight: 100
 倢	zip
 倢	zit
 嗫	zip
-囁	zip
+囁	zip	500
 慴	zip
-接	zip
+接	zip	1000
 椄	zip
-楫	zip
+楫	zip	500
 浃	zip
 耴	zip
 襵	zip
 讋	zip
 讘	zip
-輒	zip
-輒	zit
+輒	zip	1000
+輒	zit	0%
 辄	zip
 霅	zip
 鮿	zip
@@ -23676,29 +23676,29 @@ min_phrase_weight: 100
 䯵	zit
 䲙	zit
 卩	zit
-哲	zit
+哲	zit	500
 喆	zit
 婕	zit
 岊	zit
 悊	zit
-截	zit
-折	zit
-捷	zit
+截	zit	1000
+折	zit	1000
+捷	zit	1000
 擮	zit
 擳	zit
 栉	zit
 楶	zit
-櫛	zit
-浙	zit
+櫛	zit	500
+浙	zit	1000
 淛	zit
 瀄	zit
 疌	zit
 疖	zit
 癤	zit
-睫	zit
-節	zit
+睫	zit	500
+節	zit	1000
 节	zit
-蜇	zit
+蜇	zit	500
 谒	zit
 踕	zit
 𡁶	zit
@@ -23734,29 +23734,29 @@ min_phrase_weight: 100
 䶰	ziu
 僬	ziu
 噍	ziu
-嚼	ziu
-嚼	zoek
+嚼	ziu	0%
+嚼	zoek	1000
 垗	ziu
-招	ziu
+招	ziu	1000
 曌	ziu
-椒	ziu
-沼	ziu
+椒	ziu	500
+沼	ziu	1000
 灂	ziu
 灂	zok
 灂	zuk
 炤	ziu
-焦	ziu
-照	ziu
+焦	ziu	1000
+照	ziu	1000
 皭	ziu
 皭	zoek
-礁	ziu
+礁	ziu	500
 膲	ziu
-蕉	ziu
+蕉	ziu	1000
 蟭	ziu
-詔	ziu
+詔	ziu	500
 诏	ziu
 赵	ziu
-趙	ziu
+趙	ziu	500
 趭	ziu
 醮	ziu
 釂	ziu
@@ -23767,17 +23767,17 @@ min_phrase_weight: 100
 咗	zo	100000
 㘴	zo
 㝾	zo
-佐	zo
-俎	zo
-助	zo
+佐	zo	500
+俎	zo	500
+助	zo	1000
 唑	zo
 唨	zo
-左	zo
-座	zo
-詛	zo
+左	zo	1000
+座	zo	1000
+詛	zo	500
 謯	zo
 诅	zo
-阻	zo
+阻	zo	1000
 㒂	zoek
 㩱	zoek
 㵸	zoek
@@ -23797,18 +23797,18 @@ min_phrase_weight: 100
 䶂	zoek
 䶳	zoek
 妁	zoek
-斫	zoek
+斫	zoek	500
 斮	zoek
 晫	zoek
 櫡	zoek
 櫡	zyu
 爝	zoek
-爵	zoek
+爵	zoek	1000
 禚	zoek
-著	zoek
-著	zyu
-酌	zoek
-雀	zoek
+著	zoek	0%
+著	zyu	1000
+酌	zoek	500
+雀	zoek	1000
 㒕	zoeng
 㔦	zoeng
 㕩	zoeng
@@ -23837,59 +23837,59 @@ min_phrase_weight: 100
 䬗	zoeng
 䭥	zoeng
 䴂	zoeng
-丈	zoeng
+丈	zoeng	1000
 仉	zoeng
-仗	zoeng
+仗	zoeng	1000
 傽	zoeng
-像	zoeng
-匠	zoeng
+像	zoeng	1000
+匠	zoeng	1000
 奖	zoeng
 奬	zoeng
 嫜	zoeng
 将	zoeng
-將	zoeng
+將	zoeng	1000
 嶂	zoeng
 帐	zoeng
-帳	zoeng
-幛	zoeng
+帳	zoeng	1000
+幛	zoeng	500
 张	zoeng
-張	zoeng
-彰	zoeng
+張	zoeng	1000
+彰	zoeng	1000
 慞	zoeng
-掌	zoeng
-杖	zoeng
+掌	zoeng	1000
+杖	zoeng	1000
 桨	zoeng
-槳	zoeng
-樟	zoeng
-橡	zoeng
+槳	zoeng	500
+樟	zoeng	500
+橡	zoeng	1000
 浆	zoeng
 涨	zoeng
-漲	zoeng
-漳	zoeng
-漿	zoeng
-獎	zoeng
-獐	zoeng
-璋	zoeng
-瘴	zoeng
-章	zoeng
+漲	zoeng	1000
+漳	zoeng	500
+漿	zoeng	1000
+獎	zoeng	1000
+獐	zoeng	500
+璋	zoeng	500
+瘴	zoeng	500
+章	zoeng	1000
 粻	zoeng
 绱	zoeng
 胀	zoeng
-脹	zoeng
+脹	zoeng	1000
 蒋	zoeng
-蔣	zoeng
+蔣	zoeng	500
 螀	zoeng
 螿	zoeng
-蟑	zoeng
+蟑	zoeng	1000
 蟓	zoeng
 襐	zoeng
-象	zoeng
-賬	zoeng
+象	zoeng	1000
+賬	zoeng	1000
 账	zoeng
 鄣	zoeng
 酱	zoeng
-醬	zoeng
-障	zoeng
+醬	zoeng	1000
+障	zoeng	1000
 鱆	zoeng
 麞	zoeng
 𤕭	zoeng
@@ -23898,18 +23898,18 @@ min_phrase_weight: 100
 䔂	zoi
 䮨	zoi
 䵧	zoi
-再	zoi
-哉	zoi
-在	zoi
-宰	zoi
+再	zoi	1000
+哉	zoi	1000
+在	zoi	1000
+宰	zoi	1000
 崽	zoi
-栽	zoi
+栽	zoi	1000
 渽	zoi
-災	zoi
+災	zoi	1000
 灾	zoi
 烖	zoi
 縡	zoi
-載	zoi
+載	zoi	1000
 载	zoi
 㑅	zok
 㘀	zok
@@ -23919,17 +23919,17 @@ min_phrase_weight: 100
 䎰	zok
 䝫	zok
 䥣	zok
-作	zok
+作	zok	1000
 凿	zok
 怍	zok
-昨	zok
+昨	zok	1000
 浞	zok
 浞	zuk
-濯	zok
+濯	zok	1000
 筰	zok
 莋	zok
 鍩	zok
-鑿	zok
+鑿	zok	1000
 飵	zok
 鷟	zok
 㘸	zong
@@ -23940,30 +23940,30 @@ min_phrase_weight: 100
 䚎	zong
 塟	zong
 壮	zong
-壯	zong
-奘	zong
+壯	zong	1000
+奘	zong	500
 妆	zong
-妝	zong
+妝	zong	500
 庄	zong
 桩	zong
-樁	zong
+樁	zong	1000
 牂	zong
 状	zong
-狀	zong
+狀	zong	1000
 粧	zong
 脏	zong
-臟	zong
-臧	zong
-莊	zong
-葬	zong
+臟	zong	1000
+臧	zong	500
+莊	zong	1000
+葬	zong	1000
 装	zong
-裝	zong
+裝	zong	1000
 賍	zong
-贓	zong
+贓	zong	1000
 贜	zong
 赃	zong
 驵	zong
-髒	zong
+髒	zong	1000
 𥅾	zong
 𥊙	zong
 㡟	zou
@@ -23974,30 +23974,30 @@ min_phrase_weight: 100
 䗢	zou
 䜊	zou
 䲃	zou
-做	zou
-早	zou
+做	zou	1000
+早	zou	1000
 枣	zou
-棗	zou
-灶	zou
+棗	zou	500
+灶	zou	500
 璪	zou
 皁	zou
-皂	zou
-祖	zou
-祚	zou
-租	zou
+皂	zou	1000
+祖	zou	1000
+祚	zou	500
+租	zou	1000
 竈	zou
 簉	zou
-糟	zou
-組	zou
+糟	zou	1000
+組	zou	1000
 组	zou
 胙	zou
 葃	zou
 葄	zou
 蒩	zou
-藻	zou
-蚤	zou
+藻	zou	1000
+蚤	zou	1000
 蹧	zou
-遭	zou
+遭	zou	1000
 阼	zou
 靻	zou
 坠	zui
@@ -24024,41 +24024,41 @@ min_phrase_weight: 100
 䥮	zuk
 䮱	zuk
 䳑	zuk
-俗	zuk
+俗	zuk	1000
 哫	zuk
 嘱	zuk
-囑	zuk
-捉	zuk
+囑	zuk	1000
+捉	zuk	1000
 斸	zuk
-族	zuk
+族	zuk	1000
 柷	zuk
 欘	zuk
 浊	zuk
-濁	zuk
+濁	zuk	1000
 烛	zuk
-燭	zuk
+燭	zuk	1000
 瘃	zuk
 瞩	zuk
-矚	zuk
-祝	zuk
-竹	zuk
-竺	zuk
+矚	zuk	1000
+祝	zuk	1000
+竹	zuk	1000
+竺	zuk	500
 筑	zuk
-築	zuk
-粥	zuk
-續	zuk
+築	zuk	1000
+粥	zuk	1000
+續	zuk	1000
 续	zuk
 臅	zuk
 舳	zuk
 蓫	zuk
 藚	zuk
 蠋	zuk
-躅	zuk
-軸	zuk
+躅	zuk	500
+軸	zuk	1000
 轴	zuk
-逐	zuk
-鏃	zuk
-鐲	zuk
+逐	zuk	1000
+鏃	zuk	500
+鐲	zuk	500
 镞	zuk
 镯	zuk
 鱁	zuk
@@ -24120,8 +24120,8 @@ min_phrase_weight: 100
 䩺	zung
 䰌	zung
 䱵	zung
-中	zung
-仲	zung
+中	zung	1000
+仲	zung	500
 伀	zung
 众	zung
 倧	zung
@@ -24129,15 +24129,15 @@ min_phrase_weight: 100
 偬	zung
 傯	zung
 妐	zung
-宗	zung
+宗	zung	1000
 尰	zung
 嵕	zung
 彸	zung
-忠	zung
+忠	zung	1000
 总	zung
 惾	zung
 摠	zung
-棕	zung
+棕	zung	1000
 椶	zung
 歱	zung
 熜	zung
@@ -24146,44 +24146,44 @@ min_phrase_weight: 100
 瘇	zung
 瘲	zung
 盅	zung
-眾	zung
-種	zung
+眾	zung	1000
+種	zung	1000
 稯	zung
-粽	zung
+粽	zung	1000
 糉	zung
 糭	zung
-終	zung
-綜	zung
-縱	zung
-總	zung
+終	zung	1000
+綜	zung	1000
+縱	zung	1000
+總	zung	1000
 繌	zung
 纵	zung
 终	zung
 综	zung
 翪	zung
 肿	zung
-腫	zung
-舂	zung
+腫	zung	1000
+舂	zung	500
 舯	zung
 蔠	zung
 螽	zung
 衆	zung
-訟	zung
-誦	zung
+訟	zung	1000
+誦	zung	1000
 讼	zung
 诵	zung
 豵	zung
 踪	zung
-蹤	zung
+蹤	zung	1000
 鍐	zung
-鍾	zung
-鐘	zung
+鍾	zung	1000
+鐘	zung	1000
 钟	zung
 锺	zung
-頌	zung
+頌	zung	1000
 颂	zung
 騣	zung
-鬃	zung
+鬃	zung	500
 鬷	zung
 鱅	zung
 𠂝	zung
@@ -24267,54 +24267,54 @@ min_phrase_weight: 100
 䲣	zyu
 䴁	zyu
 丶	zyu
-主	zyu
-住	zyu
-侏	zyu
-拄	zyu
-朱	zyu
-株	zyu
+主	zyu	1000
+住	zyu	1000
+侏	zyu	500
+拄	zyu	500
+朱	zyu	1000
+株	zyu	1000
 槠	zyu
 橥	zyu
 櫧	zyu
 櫫	zyu
 殶	zyu
-注	zyu
-渚	zyu
+注	zyu	1000
+渚	zyu	500
 潴	zyu
 瀦	zyu
 炷	zyu
 煑	zyu
-煮	zyu
+煮	zyu	1000
 猪	zyu
-珠	zyu
+珠	zyu	1000
 疰	zyu
-硃	zyu
+硃	zyu	500
 祩	zyu
 筯	zyu
 箸	zyu
 紸	zyu
 罜	zyu
 翥	zyu
-茱	zyu
+茱	zyu	1000
 藸	zyu
-蛀	zyu
-蛛	zyu
+蛀	zyu	1000
+蛛	zyu	1000
 袾	zyu
-註	zyu
-誅	zyu
-諸	zyu
+註	zyu	1000
+誅	zyu	1000
+諸	zyu	1000
 诛	zyu
 诸	zyu
-豬	zyu
+豬	zyu	1000
 跦	zyu
 邾	zyu
 鉒	zyu
-鑄	zyu
+鑄	zyu	1000
 铢	zyu
 铸	zyu
 陼	zyu
 馵	zyu
-駐	zyu
+駐	zyu	1000
 驻	zyu
 麈	zyu
 𩅻	zyu
@@ -24367,27 +24367,27 @@ min_phrase_weight: 100
 僔	zyun
 啭	zyun
 噂	zyun
-囀	zyun
+囀	zyun	500
 塼	zyun
 嫥	zyun
-專	zyun
+專	zyun	1000
 捘	zyun
 撙	zyun
 甎	zyun
 砖	zyun
-磚	zyun
+磚	zyun	1000
 縳	zyun
-纂	zyun
+纂	zyun	500
 纘	zyun
 缵	zyun
 躜	zyun
 躦	zyun
-轉	zyun
+轉	zyun	1000
 转	zyun
 鄟	zyun
 酂	zyun
 鐏	zyun
-鑽	zyun
+鑽	zyun	1000
 钻	zyun
 镌	zyun
 顓	zyun
@@ -24410,7 +24410,7 @@ min_phrase_weight: 100
 䮕	zyut
 剟	zyut
 惙	zyut
-拙	zyut
+拙	zyut	500
 掇	zyut
 敪	zyut
 梲	zyut
@@ -24419,15 +24419,15 @@ min_phrase_weight: 100
 歠	zyut
 畷	zyut
 窋	zyut
-絕	zyut
+絕	zyut	1000
 绌	zyut
 绝	zyut
 腏	zyut
-茁	zyut
+茁	zyut	1000
 蕝	zyut
 裰	zyut
 諁	zyut
-輟	zyut
+輟	zyut	1000
 辍	zyut
 醊	zyut
 錣	zyut
@@ -24436,7 +24436,6 @@ out	au
 book	buk
 check	cek
 cheap	cip
-鬥細佬哥	dau
 foul	fau
 friend	fen
 feel	fiu

--- a/jyutping.dict.yaml
+++ b/jyutping.dict.yaml
@@ -24454,6 +24454,8 @@ talk	tok
 van	wen
 可汗	hak hon
 什麼	sam mo
+番禺	pun jyu
+南番順	naam pun seon
 # 粵語用詞
 亞爸	aa baa
 亞保亞勝	aa bou aa sing

--- a/jyutping.dict.yaml
+++ b/jyutping.dict.yaml
@@ -6,9 +6,10 @@
 #   derived from scim-table-zh Jyutping table.
 #   add phrases from open Cantonese dictionary: http://kaifangcidian.com/han/yue
 #   weight adjustment based on http://www.edbchinese.hk/lexlist_ch/ and manual checking
+
 ---
 name: jyutping
-version: "2018.04.14"
+version: "2018.04.18"
 sort: by_weight
 use_preset_vocabulary: true
 max_phrase_length: 7
@@ -31,20 +32,20 @@ min_phrase_weight: 100
 䳬	tou
 䳬	zik
 䳬	zim
-丫	aa	1000
+丫	aa
 亚	aa
 亚	ngaa
-亞	aa	1000
+亞	aa
 亞	ngaa	0%
 厂	aa
 厂	hon
 厊	aa
 厊	ngaa
-呀	aa	1000
+呀	aa
 咓	aa
 哑	aa
-啊	aa	1000
-啞	aa	1000
+啊	aa
+啞	aa
 啞	ak	0%
 嗄	aa
 嗄	saa
@@ -64,18 +65,18 @@ min_phrase_weight: 100
 襾	aa
 襾	kaa
 那	aa	0%
-那	naa	1000
+那	naa
 那	no	0%
 錏	aa
 錒	aa
 铔	aa
 锕	aa
-阿	aa	1000
+阿	aa
 阿	aak	0%
-阿	o	1000
+阿	o
 雅	aa	0%
-雅	ngaa	1000
-鴉	aa	1000
+雅	ngaa
+鴉	aa
 鴉	ngaa	0%
 鸦	aa
 𠮩	aa
@@ -96,12 +97,12 @@ min_phrase_weight: 100
 㶭	ai
 㶭	jiu
 㶭	zaau
-哎	aai	1000
-哎	ai	200
-唉	aai	1000
+哎	aai
+哎	ai
+唉	aai
 唉	oi	0%
-埃	aai	1000
-埃	oi	1000
+埃	aai
+埃	oi
 娭	aai
 娭	ngaai
 娭	oi
@@ -109,7 +110,7 @@ min_phrase_weight: 100
 欸	ei
 欸	oi
 矮	aai	0%
-矮	ai	1000
+矮	ai
 矮	ngai	0%
 誒	aai
 誒	e
@@ -121,7 +122,7 @@ min_phrase_weight: 100
 诶	aai
 诶	ei
 诶	oi
-隘	aai	1000
+隘	aai
 餲	aai
 餲	aat
 㧖	aak
@@ -135,26 +136,26 @@ min_phrase_weight: 100
 䧄	gok
 䮸	aak
 䮸	ak
-厄	aak	1000
-厄	ak	1000
-呃	aak	500
+厄	aak
+厄	ak
+呃	aak
 呃	ak	1000
-扼	aak	500
-扼	ak	500
-握	aak	1000
-握	ak	1000
+扼	aak
+扼	ak
+握	aak
+握	ak
 搹	aak
 搹	ngak
-軛	aak	500
-軛	ngaak	500
+軛	aak
+軛	ngaak
 軶	aak
 軶	ngaak
 轭	aak
 轭	ngaak
 鈪	aak
 鈪	ngaak
-齷	aak	500
-齷	ak	500
+齷	aak
+齷	ak
 龌	aak
 㛪	aam
 㛪	gim
@@ -183,12 +184,12 @@ min_phrase_weight: 100
 䳺	an
 菡	aam
 菡	haam
-贋	aam	500
-贋	am	500
-贋	ngaam	500
-贋	ngam	500
-贋	ngan	500
-晏	aan	500
+贋	aam
+贋	am
+贋	ngaam
+贋	ngam
+贋	ngan
+晏	aan
 晏	ngaan	1000
 鴳	aan
 鴳	ngaan
@@ -203,8 +204,8 @@ min_phrase_weight: 100
 罌	aang
 㔩	aap
 押	aap	0%
-押	aat	1000
-鴨	aap	1000
+押	aat
+鴨	aap
 鴨	ngaap	0%
 鸭	aap
 鸭	ngaap
@@ -216,23 +217,23 @@ min_phrase_weight: 100
 堨	ngaat
 堨	ngoi
 堨	oi
-壓	aat	1000
+壓	aat
 壓	ngaat	0%
 恝	aat
 恝	gaat
-戛	aat	500
-戛	gaat	500
+戛	aat
+戛	gaat
 戞	aat
 揠	aat
 桔	aat	0%
-桔	gat	1000
+桔	gat
 歹	aat	0%
-歹	daai	1000
+歹	daai
 猒	aat
 猒	jim
 猒	ngaat
-遏	aat	500
-遏	kit	500
+遏	aat
+遏	kit
 閼	aat
 閼	jin
 阏	aat
@@ -270,17 +271,17 @@ min_phrase_weight: 100
 䥲	aau
 䥲	au
 䳼	aau
-凹	aau	1000
-凹	lap	200
-凹	nap	1000
+凹	aau
+凹	lap
+凹	nap
 凹	waa	0%
 坳	aau
 抓	aau	0%
-抓	zaa	501
-抓	zaau	1000
+抓	zaa
+抓	zaau
 抝	aau
-拗	aau	500
-拗	ngaau	500
+拗	aau
+拗	ngaau
 靿	aau
 靿	ngaau
 䅬	ai
@@ -290,10 +291,10 @@ min_phrase_weight: 100
 屭	hei
 曀	ai
 曀	ngai
-縊	ai	500
+縊	ai
 缢	ai
-翳	ai	500
-翳	ji	500
+翳	ai
+翳	ji
 豷	ai
 豷	ngai
 躷	ai
@@ -301,12 +302,12 @@ min_phrase_weight: 100
 㬬	ak
 㬬	geoi
 偓	ak
-喔	ak	1000
-喔	o	1000
+喔	ak
+喔	o
 幄	ak
 戹	ak
 搤	ak
-渥	ak	500
+渥	ak
 腛	ak
 腛	ngak
 阨	ak
@@ -324,13 +325,13 @@ min_phrase_weight: 100
 埯	jim
 媕	am
 媕	om
-庵	am	500
-掩	am	501
-掩	jim	1000
+庵	am
+掩	am
+掩	jim
 揞	am
 揞	ngam
 晻	am
-暗	am	1000
+暗	am
 暗	ngam	0%
 盦	am
 腤	am
@@ -341,11 +342,11 @@ min_phrase_weight: 100
 闇	am
 韽	am
 韽	ngam
-鵪	am	1000
+鵪	am
 鹌	am
 黭	am
 黭	jim
-黯	am	1000
+黯	am
 𡁏	am
 𡁏	ngam
 㜝	an
@@ -362,20 +363,20 @@ min_phrase_weight: 100
 哽	gang	1000
 嘤	ang
 嘤	jing
-嚶	ang	500
-嚶	jing	500
-更	ang	501
-更	gaang	1000
-更	gang	1000
+嚶	ang
+嚶	jing
+更	ang	0%
+更	gaang
+更	gang
 罃	ang
 莺	ang
 鞥	ang
-鶯	ang	1000
+鶯	ang
 噏	ap
 噏	ngap
 洽	ap	0%
 洽	haap	0%
-洽	hap	1000
+洽	hap
 㕈	at
 㕈	zi
 㦣	at
@@ -412,11 +413,11 @@ min_phrase_weight: 100
 䫜	au
 勾	au	0%
 勾	gau	0%
-勾	ngau	1000
+勾	ngau
 区	au
 区	keoi
 呕	au
-嘔	au	1000
+嘔	au
 怄	au
 慪	au
 敺	au
@@ -424,16 +425,16 @@ min_phrase_weight: 100
 櫙	au
 欧	au
 欧	ngau
-歐	au	1000
+歐	au
 歐	ngau	0%
 殴	au
-毆	au	1000
+毆	au
 沤	au
 漚	au
 熰	au
 熰	ngau
 瓯	au
-甌	au	500
+甌	au
 謳	au
 讴	au
 鉤	au
@@ -441,7 +442,7 @@ min_phrase_weight: 100
 鉤	ngau
 鏂	au
 鏂	ngau
-鷗	au	1000
+鷗	au
 鸥	au
 𩥋	au
 𩥋	ngau
@@ -465,39 +466,39 @@ min_phrase_weight: 100
 䶕	baa
 䶕	paa
 伯	baa	0%
-伯	baak	1000
-叭	baa	1000
-吧	baa	1000
+伯	baak
+叭	baa
+吧	baa
 坝	baa
 垻	baa
 埧	baa
 埧	geoi
-壩	baa	500
+壩	baa
 峇	baa
 峇	hap
-巴	baa	1000
+巴	baa
 弝	baa
-把	baa	1000
+把	baa
 灞	baa
-爸	baa	1000
-疤	baa	1000
-笆	baa	1000
+爸	baa
+疤	baa
+笆	baa
 粑	baa
 罢	baa
-罷	baa	1000
+罷	baa
 罷	pei	0%
 羓	baa
-芭	baa	1000
-葩	baa	500
-葩	paa	500
+芭	baa
+葩	baa
+葩	paa
 覇	baa
 豝	baa
 鈀	baa
 鈀	paa
 钯	baa
 钯	paa
-霸	baa	1000
-靶	baa	500
+霸	baa
+靶	baa
 鲃	baa
 㔥	baai
 㔥	pei
@@ -522,16 +523,16 @@ min_phrase_weight: 100
 唄	baai
 惫	baai
 惫	bei
-憊	baai	500
-憊	bei	500
-拜	baai	1000
+憊	baai
+憊	bei
+拜	baai
 捭	baai
 掰	baai
 掰	maak
 摆	baai
-擺	baai	1000
-敗	baai	1000
-湃	baai	1000
+擺	baai
+敗	baai
+湃	baai
 湃	paai	0%
 稗	baai
 稗	bai
@@ -539,38 +540,38 @@ min_phrase_weight: 100
 粺	bai
 襬	baai
 败	baai
-北	baak	0
-北	bak	1000
+北	baak	0%
+北	bak
 㤳	baak
 㼟	baak
 㼣	baak
 䞳	baak
 䳆	baak
-佰	baak	500
+佰	baak
 僰	baak
 僰	bok
-匐	baak	500
-帛	baak	500
+匐	baak
+帛	baak
 廹	baak
 廹	bik
-柏	baak	1000
-柏	paak	1000
+柏	baak
+柏	paak
 栢	baak
 檗	baak
 檗	paak
-白	baak	1000
-百	baak	1000
+白	baak
+百	baak
 糪	baak
 糪	bok
 舶	baak	0%
-舶	bok	1000
+舶	bok
 舶	paak	0%
 菔	baak
 菔	fuk
-蔔	baak	1000
+蔔	baak
 踣	baak
-迫	baak	1000
-迫	bik	1000
+迫	baak
+迫	bik
 㡦	baan
 㡦	faan
 㥹	baan
@@ -591,31 +592,31 @@ min_phrase_weight: 100
 䬱	mang
 办	baan
 坂	baan
-扮	baan	1000
+扮	baan
 攽	baan
 攽	ban
-斑	baan	1000
+斑	baan
 斒	baan
 昄	baan
-板	baan	1000
+板	baan
 湴	baan
 爿	baan
 爿	coeng
-版	baan	1000
-班	baan	1000
-瓣	baan	1000
-瓣	faan	1000
+版	baan
+班	baan
+瓣	baan
+瓣	faan
 瘢	baan
-舨	baan	500
+舨	baan
 蝂	baan
 螌	baan
-辦	baan	1000
+辦	baan
 鈑	baan
 钣	baan
-闆	baan	1000
-阪	baan	500
-阪	faan	500
-頒	baan	1000
+闆	baan
+阪	baan
+阪	faan
+頒	baan
 頒	paan	0%
 颁	baan
 魬	baan
@@ -631,9 +632,9 @@ min_phrase_weight: 100
 䨜	wik
 嘭	baang
 嘭	paang
-繃	baang	500
-繃	bang	500
-繃	maang	500
+繃	baang
+繃	bang
+繃	maang
 蹦	baang	0%
 𠾴	baang
 𨭌	baang
@@ -662,7 +663,7 @@ min_phrase_weight: 100
 䥬	hot
 䳊	baat
 䳊	but
-八	baat	1000
+八	baat
 捌	baat
 朳	baat
 朳	paa
@@ -670,22 +671,22 @@ min_phrase_weight: 100
 魃	baat
 䭋	baau
 勹	baau
-包	baau	1000
+包	baau
 孢	baau
 炮	baau	0%
-炮	paau	1000
-爆	baau	1000
-砲	baau	500
-砲	paau	500
-胞	baau	1000
-苞	baau	500
+炮	paau
+爆	baau
+砲	baau
+砲	paau
+胞	baau
+苞	baau
 豹	baau	0%
-豹	paau	1000
-飽	baau	1000
+豹	paau
+飽	baau
 饱	baau
 骲	baau
 骲	biu
-鮑	baau	1000
+鮑	baau
 鲍	baau
 齙	baau
 龅	baau
@@ -712,17 +713,17 @@ min_phrase_weight: 100
 坒	bai
 坒	bei
 币	bai
-幣	bai	1000
-弊	bai	1000
-敝	bai	1000
-斃	bai	1000
+幣	bai
+弊	bai
+敝	bai
+斃	bai
 梐	bai
 毙	bai
 狴	bai
 獘	bai
 箅	bai
 箅	bei
-蔽	bai	1000
+蔽	bai
 薜	bai
 蜌	bai
 贔	bai
@@ -730,13 +731,13 @@ min_phrase_weight: 100
 赑	bai
 跛	bai	0%
 跛	bei	0%
-跛	bo	1000
+跛	bo
 鄨	bai
 鎞	bai
 鎞	pei
-閉	bai	1000
+閉	bai
 闭	bai
-陛	bai	1000
+陛	bai
 𠻻	bai
 𡃇	bai
 𡚁	bai
@@ -755,8 +756,8 @@ min_phrase_weight: 100
 䧶	but
 䧶	git
 䧶	kit
-乓	bam	1000
-乓	pong	1000
+乓	bam
+乓	pong
 泵	bam
 㟗	ban
 㤓	ban
@@ -775,20 +776,20 @@ min_phrase_weight: 100
 䰉	bun
 䰉	pun
 份	ban	0%
-份	fan	1000
+份	fan
 体	ban
 体	tai
 傧	ban
-儐	ban	500
-品	ban	1000
+儐	ban
+品	ban
 坋	ban
 坋	fan
 坌	ban
-奔	ban	1000
-嬪	ban	500
-嬪	pan	500
+奔	ban
+嬪	ban
+嬪	pan
 宾	ban
-彬	ban	500
+彬	ban
 捹	ban
 捹	fang
 捹	fing
@@ -797,38 +798,38 @@ min_phrase_weight: 100
 斌	ban
 梹	ban
 槟	ban
-檳	ban	500
-檳	bing	500
+檳	ban
+檳	bing
 殡	ban
-殯	ban	1000
+殯	ban
 汃	ban
 汃	paak
 滨	ban
 濒	ban
 濒	pan
-濱	ban	1000
+濱	ban
 濵	ban
 瀕	ban	0%
-瀕	pan	1000
+瀕	pan
 犇	ban
 玢	ban
 玢	fan
 璸	ban
 禀	ban
-稟	ban	500
-稟	lam	500
-笨	ban	1000
-繽	ban	1000
+稟	ban
+稟	lam
+笨	ban
+繽	ban
 缤	ban
 膑	ban
-臏	ban	500
+臏	ban
 蠙	ban
 蠙	pan
 豳	ban
-賁	ban	500
-賁	bei	500
-賁	fan	500
-賓	ban	1000
+賁	ban
+賁	bei
+賁	fan
+賓	ban
 賔	ban
 贲	ban
 贲	bei
@@ -840,7 +841,7 @@ min_phrase_weight: 100
 髌	ban
 髕	ban
 鬓	ban
-鬢	ban	1000
+鬢	ban
 𡣕	ban
 𢷤	ban
 𦆯	ban
@@ -863,13 +864,13 @@ min_phrase_weight: 100
 堋	pang
 塴	bang
 塴	paang
-崩	bang	1000
+崩	bang
 弸	bang
 弸	pang
-憑	bang	501
-憑	pang	1000
-甭	bang	500
-甭	bat	500
+憑	bang
+憑	pang
+甭	bang
+甭	bat
 痭	bang
 祊	bang
 絣	bang
@@ -889,10 +890,10 @@ min_phrase_weight: 100
 䟆	bat
 䟦	bat
 䳁	bat
-不	bat	1000
-不	fau	0
+不	bat
+不	fau	0%
 佛	bat	0%
-佛	fat	1000
+佛	fat
 冹	bat
 吥	bat
 吥	bau
@@ -901,21 +902,21 @@ min_phrase_weight: 100
 咇	bit
 哔	bat
 嗶	bat
-弼	bat	500
+弼	bat
 彃	bat
-拔	bat	1000
+拔	bat
 毕	bat
 泌	bat	0%
-泌	bei	1000
+泌	bei
 滗	bat
 滗	bei
 滭	bat
 潷	bat
 潷	bei
 犮	bat
-畢	bat	1000
+畢	bat
 笔	bat
-筆	bat	1000
+筆	bat
 筚	bat
 篳	bat
 縪	bat
@@ -925,14 +926,14 @@ min_phrase_weight: 100
 荜	bat
 菝	bat
 蓽	bat
-跋	bat	500
-跋	but	500
+跋	bat
+跋	but
 跸	bat
 蹕	bat
 軷	bat
 軷	but
-鈸	bat	500
-鈸	but	500
+鈸	bat
+鈸	but
 钹	bat
 韠	bat
 飶	bat
@@ -954,7 +955,7 @@ min_phrase_weight: 100
 㼰	paai
 㼰	pei
 㼰	sit
-啤	be	1000
+啤	be
 畀	bei	10000
 㔗	bei
 㔗	faai
@@ -1010,40 +1011,40 @@ min_phrase_weight: 100
 䴽	bik
 䴽	pei
 俻	bei
-俾	bei	1000
-備	bei	1000
-匕	bei	500
-卑	bei	1000
+俾	bei
+備	bei
+匕	bei
+卑	bei
 吡	bei
 嚊	bei
 备	bei
 奰	bei
-妣	bei	500
-媲	bei	500
-媲	pei	500
+妣	bei
+媲	bei
+媲	pei
 屄	bei
 岥	bei
 岥	pei
 岥	po
-庇	bei	1000
+庇	bei
 庳	bei
 庳	pei
-彼	bei	1000
-悲	bei	1000
+彼	bei
+悲	bei
 柀	bei
 柲	bei
 椑	bei
 椑	pei
-比	bei	1000
+比	bei
 比	pei	0%
 毖	bei
 沘	bei
 犤	bei
 疕	bei
 痹	bei
-痺	bei	1000
-碑	bei	1000
-祕	bei	1000
+痺	bei
+碑	bei
+祕	bei
 祕	bit	0%
 秕	bei
 秘	bei
@@ -1058,25 +1059,25 @@ min_phrase_weight: 100
 罴	bei
 羆	bei
 肶	bei
-臂	bei	1000
+臂	bei
 芘	bei
 芘	pei
 萆	bei
 蓖	bei
 藣	bei
-被	bei	1000
-被	pei	1000
-裨	bei	500
-裨	pei	500
+被	bei
+被	pei
+裨	bei
+裨	pei
 襣	bei
 襣	jyu
 詖	bei
 诐	bei
 費	bei	0%
-費	fai	1000
-轡	bei	500
+費	fai
+轡	bei
 辔	bei
-避	bei	1000
+避	bei
 邲	bei
 鄪	bei
 鉍	bei
@@ -1096,19 +1097,19 @@ min_phrase_weight: 100
 髲	bei
 鵯	bei
 鹎	bei
-鼻	bei	1000
+鼻	bei
 𡀠	bei
 𦱔	bei
 壁	bek	0%
-壁	bik	1000
+壁	bik
 㝸	beng
 㝸	bin
-柄	beng	1000
+柄	beng
 柄	bing	0%
-病	beng	1000
-病	bing	1000
+病	beng
+病	bing
 窉	beng
-餅	beng	1000
+餅	beng
 餅	bing	0%
 㱸	bik
 㷶	bik
@@ -1120,17 +1121,17 @@ min_phrase_weight: 100
 䮠	bik
 偪	bik
 愊	bik
-愎	bik	500
-愎	fuk	500
+愎	bik
+愎	fuk
 憵	bik
 揊	bik
 楅	bik
 楅	fuk
 湢	bik
 煏	bik
-璧	bik	1000
+璧	bik
 皕	bik
-碧	bik	1000
+碧	bik
 綼	bik
 腷	bik
 襞	bik
@@ -1138,8 +1139,8 @@ min_phrase_weight: 100
 躄	bik
 躄	pik
 辟	bik	0%
-辟	pik	1000
-逼	bik	1000
+辟	pik
+逼	bik
 㣐	bin
 㦚	bin
 㭓	bin
@@ -1154,16 +1155,16 @@ min_phrase_weight: 100
 䛒	bin
 䟍	bin
 䪻	bin
-便	bin	1000
-便	pin	1000
-匾	bin	1000
-卞	bin	500
+便	bin
+便	pin
+匾	bin
+卞	bin
 变	bin
-弁	bin	500
-弁	pun	500
+弁	bin
+弁	pun
 忭	bin
 惼	bin
-扁	bin	1000
+扁	bin
 扁	pin	0%
 抃	bin
 昪	bin
@@ -1177,7 +1178,7 @@ min_phrase_weight: 100
 猵	bin
 甂	bin
 甂	pin
-砭	bin	500
+砭	bin
 碥	bin
 稨	bin
 窆	bin
@@ -1189,25 +1190,25 @@ min_phrase_weight: 100
 艑	bin
 萹	bin
 萹	pin
-蝙	bin	1000
-蝙	pin	1000
+蝙	bin
+蝙	pin
 褊	bin
-變	bin	1000
-貶	bin	1000
+變	bin
+貶	bin
 贬	bin
-辨	bin	1000
+辨	bin
 辩	bin
 辫	bin
-辮	bin	1000
-辯	bin	1000
+辮	bin
+辯	bin
 边	bin
 辺	bin
 遍	bin	0%
-遍	pin	1000
-邊	bin	1000
+遍	pin
+邊	bin
 釆	bin
 閞	bin
-鞭	bin	1000
+鞭	bin
 鯿	bin
 㓈	bing
 㨀	bing
@@ -1219,37 +1220,37 @@ min_phrase_weight: 100
 䈂	ping
 䋑	bing
 䴵	bing
-丙	bing	1000
-並	bing	1000
-並	bong	0
-乒	bing	1000
-乒	ping	1000
-併	bing	1000
+丙	bing
+並	bing
+並	bong	0%
+乒	bing
+乒	ping
+併	bing
 併	ping	0%
 偋	bing
 偋	ping
-兵	bing	1000
+兵	bing
 冫	bing
-冰	bing	1000
+冰	bing
 寎	bing
 屏	bing	0%
-屏	ping	1000
+屏	ping
 屛	bing
-并	bing	500
+并	bing
 幷	bing
 怲	bing
 抦	bing
 掤	bing
 掤	maang
 掤	mang
-摒	bing	500
+摒	bing
 昺	bing
 栟	bing
 氷	bing
-炳	bing	500
-秉	bing	1000
+炳	bing
+秉	bing
 竝	bing
-迸	bing	500
+迸	bing
 邴	bing
 饼	bing
 㓖	bit
@@ -1276,10 +1277,10 @@ min_phrase_weight: 100
 䭱	mok
 䳤	bit
 佖	bit
-別	bit	1000
+別	bit
 别	bit
-彆	bit	500
-必	bit	1000
+彆	bit
+必	bit
 怭	bit
 憋	bit
 珌	bit
@@ -1298,7 +1299,7 @@ min_phrase_weight: 100
 鱉	bit
 鳖	bit
 鷩	bit
-鼈	bit	500
+鼈	bit
 㟽	biu
 㠒	biu
 㧼	biu
@@ -1315,30 +1316,30 @@ min_phrase_weight: 100
 䮽	biu
 俵	biu
 儦	biu
-婊	biu	500
-彪	biu	500
+婊	biu
+彪	biu
 杓	biu
 杓	soek
 标	biu
-標	biu	1000
+標	biu
 滮	biu
 瀌	biu
 熛	biu
 猋	biu
 瘭	biu
 票	biu	0%
-票	piu	1000
+票	piu
 穮	biu
 膘	biu
 臕	biu
 蔈	biu
 藨	biu
-表	biu	1000
+表	biu
 裱	biu
 褾	biu
-錶	biu	1000
-鏢	biu	500
-鑣	biu	500
+錶	biu
+鏢	biu
+鑣	biu
 镖	biu
 镳	biu
 颩	biu
@@ -1356,22 +1357,22 @@ min_phrase_weight: 100
 䝛	bo
 䝛	fu
 啵	bo
-坡	bo	1000
+坡	bo
 坡	po	0%
 嶓	bo
 抪	bo
 抪	bou
-播	bo	1000
-波	bo	1000
-玻	bo	1000
+播	bo
+波	bo
+玻	bo
 碆	bo
-簸	bo	1000
+簸	bo
 般	bo	0%
-般	bun	1000
-菠	bo	1000
+般	bun
+菠	bo
 譒	bo
-鄱	bo	500
-鄱	po	500
+鄱	bo
+鄱	po
 陃	bo
 𡃓	bo
 㗘	bok
@@ -1412,21 +1413,21 @@ min_phrase_weight: 100
 䶈	bok
 亳	bok
 剝	bok	0%
-剝	mok	1000
+剝	mok
 剥	bok
 剥	mok
-博	bok	1000
+博	bok
 嚗	bok
 壆	bok
 嶨	bok
 嶨	hok
 懪	bok
-搏	bok	1000
+搏	bok
 攴	bok
 攴	pok
 欂	bok
-泊	bok	1000
-泊	paak	501
+泊	bok
+泊	paak
 泺	bok
 泺	lok
 濼	bok
@@ -1439,32 +1440,32 @@ min_phrase_weight: 100
 瓟	paau
 礡	bok
 礴	bok
-箔	bok	500
+箔	bok
 簙	bok
-縛	bok	1000
+縛	bok
 縛	fok	0%
 缚	bok
 缚	fok
 胉	bok
-膊	bok	1000
-薄	bok	1000
+膊	bok
+薄	bok
 襮	bok
 襮	buk
 謈	bok
-鉑	bok	500
+鉑	bok
 鎛	bok
 鑮	bok
 铂	bok
 镈	bok
-雹	bok	500
+雹	bok
 餺	bok
 馎	bok
-駁	bok	1000
+駁	bok
 駮	bok
 驳	bok
 髆	bok
 魄	bok	0%
-魄	paak	1000
+魄	paak
 魄	tok	0%
 㙃	bong
 㨍	bong
@@ -1480,32 +1481,32 @@ min_phrase_weight: 100
 䩷	pang
 䰃	bong
 䰃	pang
-傍	bong	1000
-傍	pong	1000
+傍	bong
+傍	pong
 埲	bong
 埲	bung
 埲	pung
 帮	bong
 幇	bong
-幫	bong	1000
+幫	bong
 挷	bong
 搒	bong
 搒	pong
-梆	bong	500
-榜	bong	1000
+梆	bong
+榜	bong
 榜	pong	0%
 牓	bong
 甏	bong
 甏	paang
-磅	bong	1000
-綁	bong	1000
+磅	bong
+綁	bong
 縍	bong
 绑	bong
-膀	bong	1000
-膀	pong	1000
+膀	bong
+膀	pong
 蒡	bong
-邦	bong	1000
-鎊	bong	500
+邦	bong
+鎊	bong
 镑	bong
 鞤	bong
 髈	bong
@@ -1539,38 +1540,38 @@ min_phrase_weight: 100
 䳰	bou
 䴐	bou
 䴺	bou
-佈	bou	1000
-保	bou	1000
+佈	bou
+保	bou
 儤	bou
 勽	bou
-哺	bou	1000
+哺	bou
 圃	bou	0%
-圃	pou	1000
-埔	bou	1000
+圃	pou
+埔	bou
 埗	bou
-埠	bou	501
-埠	fau	1000
-堡	bou	1000
-報	bou	1000
+埠	bou
+埠	fau
+堡	bou
+報	bou
 媬	bou
 孬	bou
 孬	naau
 宝	bou
-寶	bou	1000
+寶	bou
 峬	bou
-布	bou	1000
-怖	bou	1000
+布	bou
+怖	bou
 报	bou
 抱	bou	0%
-抱	pou	1000
-捕	bou	1000
+抱	pou
+捕	bou
 晡	bou
-暴	bou	1000
-暴	buk	1000
-步	bou	1000
+暴	bou
+暴	buk
+步	bou
 煲	bou
 篰	bou
-簿	bou	1000
+簿	bou
 缹	bou
 缹	fau
 菢	bou
@@ -1578,12 +1579,12 @@ min_phrase_weight: 100
 蔀	bou
 虣	bou
 补	bou
-補	bou	1000
-褒	bou	1000
-褓	bou	500
+補	bou
+褒	bou
+褓	bou
 襃	bou
 逋	bou
-部	bou	1000
+部	bou
 鈽	bou
 钸	bou
 餔	bou
@@ -1612,27 +1613,27 @@ min_phrase_weight: 100
 偝	bui
 孛	bui
 孛	but
-悖	bui	500
+悖	bui
 揹	bui
-杯	bui	1000
+杯	bui
 桮	bui
 梖	bui
 棓	bui
 棓	paang
 浿	bui
-焙	bui	500
+焙	bui
 狈	bui
-狽	bui	1000
-盃	bui	500
-背	bui	1000
-蓓	bui	500
-蓓	pui	500
+狽	bui
+盃	bui
+背	bui
+蓓	bui
+蓓	pui
 褙	bui
 誖	bui
-貝	bui	1000
+貝	bui
 贝	bui
 軰	bui
-輩	bui	1000
+輩	bui
 辈	bui
 邶	bui
 鋇	bui
@@ -1655,21 +1656,21 @@ min_phrase_weight: 100
 䪁	buk
 䪁	pun
 䴆	buk
-伏	buk	501
-伏	fuk	1000
-僕	buk	1000
-卜	buk	1000
+伏	buk
+伏	fuk
+僕	buk
+卜	buk
 卟	buk
 幞	buk
-曝	buk	1000
+曝	buk
 樸	buk	0%
-樸	pok	1000
+樸	pok
 濮	buk
-瀑	buk	1000
+瀑	buk
 纀	buk
 纀	fuk
 襆	buk
-蹼	buk	500
+蹼	buk
 轐	buk
 醭	buk
 醭	pok
@@ -1696,26 +1697,26 @@ min_phrase_weight: 100
 䨰	fuk
 䨰	pak
 䨰	pok
-伴	bun	1000
-伴	pun	501
-半	bun	1000
-叛	bun	1000
+伴	bun
+伴	pun
+半	bun
+叛	bun
 姅	bun
-拌	bun	1000
+拌	bun
 拌	pun	0%
 搫	bun
-搬	bun	1000
-本	bun	1000
+搬	bun
+本	bun
 柈	bun
 牉	bun
 牉	pun
-畔	bun	1000
-畚	bun	500
+畔	bun
+畚	bun
 籓	bun
 籓	faan
-絆	bun	1000
+絆	bun
 绊	bun
-胖	bun	1000
+胖	bun
 胖	pun	0%
 苯	bun
 靽	bun
@@ -1728,9 +1729,9 @@ min_phrase_weight: 100
 䭰	zaai
 塳	bung
 塳	pung
-捧	bung	1000
+捧	bung
 捧	fung	0%
-捧	pung	1000
+捧	pung
 玤	bung
 琫	bung
 琫	fung
@@ -1751,21 +1752,21 @@ min_phrase_weight: 100
 䭯	but
 䮀	but
 䮂	but
-勃	but	1000
+勃	but
 哱	but
 拨	but
-撥	but	1000
-撥	put	501
+撥	but
+撥	put
 桲	but
 浡	but
-渤	but	1000
+渤	but
 癶	but
 砵	but
 綍	but
 綍	fat
-缽	but	500
-脖	but	1000
-荸	but	500
+缽	but
+脖	but
+荸	but
 葧	but
 袯	but
 襏	but
@@ -1804,22 +1805,22 @@ min_phrase_weight: 100
 䱹	caa
 䱹	zaa
 侘	caa
-叉	caa	1000
+叉	caa
 喳	caa	0%
-喳	zaa	1000
+喳	zaa
 嗏	caa
 嗏	zaa
 垞	caa
 奼	caa
 姹	caa
-岔	caa	500
-差	caa	1000
+岔	caa
+差	caa
 差	caai	3
 差	ci	0%
 扠	caa
-搽	caa	500
+搽	caa
 杈	caa
-查	caa	1000
+查	caa
 查	zaa	0%
 査	caa
 楂	caa
@@ -1835,12 +1836,12 @@ min_phrase_weight: 100
 秅	caa
 艖	caa
 艖	co
-茶	caa	1000
+茶	caa
 蜡	caa
 蜡	caai
 蜡	zaa
 衩	caa
-詫	caa	1000
+詫	caa
 诧	caa
 蹅	caa
 蹅	zaa
@@ -1876,10 +1877,10 @@ min_phrase_weight: 100
 囆	caai
 搋	caai
 搋	ci
-搓	caai	501
-搓	co	1000
-柴	caai	1000
-猜	caai	1000
+搓	caai
+搓	co
+柴	caai
+猜	caai
 瘥	caai
 瘥	co
 茈	caai
@@ -1887,13 +1888,13 @@ min_phrase_weight: 100
 茈	zi
 虿	caai
 蠆	caai
-豺	caai	500
-踩	caai	1000
+豺	caai
+踩	caai
 踩	coi	0%
-踹	caai	500
-踹	cyun	500
-踹	jaai	500
-釵	caai	500
+踹	caai
+踹	cyun
+踹	jaai
+釵	caai
 钗	caai
 㥽	caak
 㨲	caak
@@ -1904,30 +1905,30 @@ min_phrase_weight: 100
 㿭	cak
 䊂	caak
 䰹	caak
-冊	caak	1000
+冊	caak
 册	caak
 圠	caak
-坼	caak	500
-惻	caak	500
-惻	cak	500
+坼	caak
+惻	caak
+惻	cak
 戝	caak
-拆	caak	1000
-柵	caak	500
-柵	saan	500
+拆	caak
+柵	caak
+柵	saan
 栅	caak
 栅	saan
-測	caak	1000
-測	cak	1000
+測	caak
+測	cak
 烢	caak
 烢	zaak
-策	caak	1000
+策	caak
 筴	caak
 筴	gaap
 簎	caak
 茦	caak
 茦	zaak
 蠈	caak
-賊	caak	1000
+賊	caak
 贼	caak
 鰂	caak
 鰂	zak
@@ -1986,10 +1987,10 @@ min_phrase_weight: 100
 劖	caam
 参	caam
 参	sam
-參	caam	1000
-參	cam	1000
+參	caam
+參	cam
 參	saam	0%
-參	sam	1000
+參	sam
 叄	caam
 叄	sam
 噆	caam
@@ -2001,19 +2002,19 @@ min_phrase_weight: 100
 忏	caam
 惨	caam
 惭	caam
-慘	caam	1000
+慘	caam
 慙	caam
-慚	caam	1000
+慚	caam
 憯	caam
-懺	caam	500
+懺	caam
 掺	caam
 搀	caam
 摻	caam
 摻	saam
-攙	caam	500
+攙	caam
 朁	caam
-杉	caam	500
-杉	saam	500
+杉	caam
+杉	saam
 枨	caam
 枨	caang
 梫	caam
@@ -2034,16 +2035,16 @@ min_phrase_weight: 100
 舕	taam
 蚕	caam
 蚕	tim
-蠶	caam	1000
-讒	caam	1000
-讖	caam	500
-讖	cam	500
+蠶	caam
+讒	caam
+讖	caam
+讖	cam
 谗	caam
 辿	caam
 辿	cin
 鑱	caam
 镵	caam
-饞	caam	500
+饞	caam
 馋	caam
 驂	caam
 骖	caam
@@ -2080,24 +2081,24 @@ min_phrase_weight: 100
 僝	saan
 刬	caan
 剗	caan
-剷	caan	500
-孱	caan	500
-孱	saan	500
+剷	caan
+孱	caan
+孱	saan
 残	caan
-殘	caan	1000
+殘	caan
 浐	caan
 滻	caan
 澯	caan
-燦	caan	1000
+燦	caan
 璨	caan
-產	caan	1000
+產	caan
 粲	caan
 羼	caan
 羼	can
-鏟	caan	1000
+鏟	caan
 铲	caan
 飡	caan
-餐	caan	1000
+餐	caan
 撐	caang	5
 䁎	caang
 䟫	caang
@@ -2105,11 +2106,11 @@ min_phrase_weight: 100
 䟫	zing
 伧	caang
 伧	cong
-倀	caang	500
-倀	coeng	500
-倀	zaang	500
-傖	caang	500
-傖	cong	500
+倀	caang
+倀	coeng
+倀	zaang
+傖	caang
+傖	cong
 掁	caang
 撑	caang
 撜	caang
@@ -2119,13 +2120,13 @@ min_phrase_weight: 100
 棦	caang
 棦	zaang
 橕	caang
-橙	caang	1000
-爭	caang	501
-爭	zaang	501
-爭	zang	1000
-瞠	caang	500
-瞠	tong	500
-瞠	zaang	500
+橙	caang
+爭	caang
+爭	zaang
+爭	zang
+瞠	caang
+瞠	tong
+瞠	zaang
 𥋇	caang
 𦉘	caang
 㠍	caap
@@ -2147,7 +2148,7 @@ min_phrase_weight: 100
 䐕	tou
 䶓	caap
 䶓	zaai
-插	caap	1000
+插	caap
 臿	caap
 鍤	caap
 锸	caap
@@ -2155,18 +2156,18 @@ min_phrase_weight: 100
 䃰	caat
 䕓	caat
 䶪	caat
-刷	caat	1000
+刷	caat
 刷	saat	0%
 刹	caat
 刹	saat
 剎	caat	0%
-剎	saat	1000
+剎	saat
 唰	caat
 嚓	caat
-察	caat	1000
-擦	caat	1000
+察	caat
+擦	caat
 獭	caat
-獺	caat	500
+獺	caat
 礤	caat
 詧	caat
 𩟔	caat
@@ -2211,20 +2212,20 @@ min_phrase_weight: 100
 䵎	toi
 䵎	zyun
 䵸	caau
-剿	caau	500
-剿	ziu	500
+剿	caau
+剿	ziu
 勦	caau
 勦	cau
 勦	ziu
-吵	caau	1000
-巢	caau	1000
-抄	caau	1000
+吵	caau
+巢	caau
+抄	caau
 摷	caau
 摷	ziu
 樔	caau
 樔	ziu
 漅	caau
-炒	caau	1000
+炒	caau
 罺	caau
 耖	caau
 肏	caau
@@ -2232,7 +2233,7 @@ min_phrase_weight: 100
 訬	miu
 轈	caau
 鄛	caau
-鈔	caau	1000
+鈔	caau
 钞	caau
 𠳕	caau
 𤙴	caau
@@ -2252,25 +2253,25 @@ min_phrase_weight: 100
 䶒	cai
 傺	cai
 凄	cai
-切	cai	1000
-切	cit	1000
+切	cai
+切	cit
 哜	cai
 啛	cai
 嚌	cai
 嚌	zai
-妻	cai	1000
-悽	cai	1000
+妻	cai
+悽	cai
 懠	cai
 摕	cai
 栖	cai
-棲	cai	1000
+棲	cai
 沏	cai
 沏	cit
-淒	cai	500
-砌	cai	1000
+淒	cai
+砌	cai
 艩	cai
 荠	cai
-萋	cai	500
+萋	cai
 薺	cai
 薺	ci
 蛴	cai
@@ -2280,7 +2281,7 @@ min_phrase_weight: 100
 鮆	zai
 鱭	cai
 鲚	cai
-齊	cai	1000
+齊	cai
 齊	zai	0%
 齊	zi	0%
 齐	cai
@@ -2289,7 +2290,7 @@ min_phrase_weight: 100
 䍉	zak
 䞣	cak
 廁	cak	0%
-廁	ci	1000
+廁	ci
 恻	cak
 测	cak
 畟	cak
@@ -2328,7 +2329,7 @@ min_phrase_weight: 100
 䫖	cam
 䫮	cam
 䰼	cam
-侵	cam	1000
+侵	cam
 吣	cam
 唚	cam
 噖	cam
@@ -2337,16 +2338,16 @@ min_phrase_weight: 100
 墋	cam
 寑	cam
 寝	cam
-寢	cam	500
+寢	cam
 寻	cam
-尋	cam	1000
+尋	cam
 嵾	cam
 挦	cam
 撏	cam
 棽	cam
-沈	cam	500
-沈	sam	500
-沉	cam	1000
+沈	cam
+沈	sam
+沉	cam
 沉	zam	0%
 浔	cam
 潯	cam
@@ -2394,12 +2395,12 @@ min_phrase_weight: 100
 亲	can
 儭	can
 吲	can
-哂	can	500
-哂	saai	500
+哂	can
+哂	saai
 嗔	can
 嗔	zan
 嚫	can
-塵	can	1000
+塵	can
 尘	can
 抻	can
 捵	can
@@ -2411,14 +2412,14 @@ min_phrase_weight: 100
 瀙	can
 灿	can
 疢	can
-疹	can	500
-疹	zan	500
+疹	can
+疹	zan
 眕	can
 眕	zan
 瞋	can
 矧	can
 稱	can	0%
-稱	cing	1000
+稱	cing
 紖	can
 紖	jan
 紖	zan
@@ -2431,16 +2432,16 @@ min_phrase_weight: 100
 衬	can
 袗	can
 袗	zan
-襯	can	1000
-親	can	1000
+襯	can
+親	can
 訠	can
-診	can	1000
+診	can
 診	zan	0%
 诊	can
-趁	can	1000
+趁	can
 辴	can
 陈	can
-陳	can	1000
+陳	can
 陳	zan	0%
 齔	can
 龀	can
@@ -2473,16 +2474,16 @@ min_phrase_weight: 100
 噌	cang
 噌	zang
 层	cang
-層	cang	1000
+層	cang
 嶒	cang
-曾	cang	1000
-曾	zang	1000
+曾	cang
+曾	zang
 竀	cang
 竀	cing
 罉	cang
 鄫	cang
-鐺	cang	500
-鐺	dong	500
+鐺	cang
+鐺	dong
 铛	cang
 铛	dong
 㔍	cap
@@ -2506,14 +2507,14 @@ min_phrase_weight: 100
 䮜	cap
 䮜	saap
 咠	cap
-戢	cap	500
+戢	cap
 濈	cap
 緁	cap
-緝	cap	1000
+緝	cap
 缉	cap
 葺	cap
 蕺	cap
-輯	cap	1000
+輯	cap
 辑	cap
 㭍	cat
 㯃	cat
@@ -2522,10 +2523,10 @@ min_phrase_weight: 100
 䌨	cat
 䓭	cat
 䵽	cat
-七	cat	1000
+七	cat
 柒	cat
 桼	cat
-漆	cat	1000
+漆	cat
 𠀁	cat
 𨳍	cat
 抽	cau	5
@@ -2551,20 +2552,20 @@ min_phrase_weight: 100
 䠗	cau
 䨂	cau
 䲡	cau
-丑	cau	1000
+丑	cau
 仇	cau	0%
 仇	kau	0%
-仇	sau	1000
+仇	sau
 俦	cau
 偢	cau
 偢	ciu
 傶	cau
 傶	cik
-儔	cau	500
+儔	cau
 凑	cau
-嗅	cau	1000
+嗅	cau
 嗅	hung	0%
-囚	cau	1000
+囚	cau
 崷	cau
 帱	cau
 帱	dou
@@ -2572,7 +2573,7 @@ min_phrase_weight: 100
 幬	cau
 幬	dou
 幬	tou
-惆	cau	500
+惆	cau
 懤	cau
 揫	cau
 揫	zau
@@ -2584,32 +2585,32 @@ min_phrase_weight: 100
 楱	zeon
 楸	cau
 殠	cau
-泅	cau	500
-泅	jau	500
-湊	cau	1000
+泅	cau
+泅	jau
+湊	cau
 溴	cau
 煍	cau
 煍	ciu
 犨	cau
 畴	cau
-疇	cau	500
+疇	cau
 瘳	cau
 瞅	cau
-秋	cau	1000
+秋	cau
 秌	cau
-稠	cau	1000
+稠	cau
 筹	cau
 篘	cau
-籌	cau	1000
+籌	cau
 糗	cau
 糗	jau
 糗	zau
 紬	cau
-綢	cau	1000
+綢	cau
 緧	cau
 绸	cau
 腠	cau
-臭	cau	1000
+臭	cau
 萩	cau
 蝤	cau
 蝤	jau
@@ -2618,26 +2619,26 @@ min_phrase_weight: 100
 讎	cau
 讐	cau
 踌	cau
-躊	cau	500
+躊	cau
 輳	cau
 辏	cau
 遒	cau
 酋	cau	0%
-酋	jau	1000
+酋	jau
 酘	cau
 酘	tau
 酧	cau
-酬	cau	1000
-醜	cau	1000
+酬	cau
+醜	cau
 雔	cau
 雔	sau
 雠	cau
-鞦	cau	500
+鞦	cau
 鞧	cau
 鮂	cau
 鰌	cau
 鰌	jau
-鰍	cau	500
+鰍	cau
 鳅	cau
 鶖	cau
 鹙	cau
@@ -2661,22 +2662,22 @@ min_phrase_weight: 100
 䏡	to
 䔑	ce
 䵦	ce
-且	ce	1000
+且	ce
 且	zeoi	0%
-且	zoeng	0
+且	zoeng	0%
 哆	ce
 哆	ci
 哆	do
-奢	ce	1000
+奢	ce
 奢	se	0%
 奲	ce
 奲	do
 尺	ce	0%
-尺	cek	1000
-扯	ce	1000
+尺	cek
+扯	ce
 抯	ce
 撦	ce
-斜	ce	1000
+斜	ce
 斜	je	0%
 檨	ce
 檨	se
@@ -2684,12 +2685,12 @@ min_phrase_weight: 100
 灺	se
 砗	ce
 硨	ce
-車	ce	1000
-車	geoi	1000
+車	ce
+車	geoi
 輋	ce
 车	ce
 车	geoi
-邪	ce	1000
+邪	ce
 邪	je	0%
 𠳏	ce
 𠾏	ce
@@ -2702,22 +2703,22 @@ min_phrase_weight: 100
 䨏	cek
 䨏	ci
 䨏	maan
-呎	cek	1000
-赤	cek	1000
-赤	cik	1000
+呎	cek
+赤	cek
+赤	cik
 𤆍	cek
 𤷫	cek
 𤷫	cik
 䙲	ceng
 䙲	cin
 晴	ceng	0%
-晴	cing	1000
+晴	cing
 清	ceng	0%
-清	cing	1000
+清	cing
 請	ceng	0%
-請	cing	1000
-青	ceng	501
-青	cing	1000
+請	cing
+青	ceng
+青	cing
 㕑	ceoi
 㕑	cyu
 㜠	ceoi
@@ -2785,42 +2786,42 @@ min_phrase_weight: 100
 䶴	ceoi
 倅	ceoi
 倅	zeot
-催	ceoi	1000
+催	ceoi
 厜	ceoi
 厜	seoi
 厨	ceoi
 厨	cyu
-取	ceoi	1000
-吹	ceoi	1000
+取	ceoi
+吹	ceoi
 啐	ceoi
 啐	seoi
 嗺	ceoi
 墔	ceoi
-娶	ceoi	1000
-崔	ceoi	500
-廚	ceoi	1000
-廚	cyu	1000
-徐	ceoi	1000
-捶	ceoi	500
+娶	ceoi
+崔	ceoi
+廚	ceoi
+廚	cyu
+徐	ceoi
+捶	ceoi
 推	ceoi	0%
-推	teoi	1000
-揣	ceoi	500
-揣	cyun	500
+推	teoi
+揣	ceoi
+揣	cyun
 搥	ceoi
-摧	ceoi	1000
+摧	ceoi
 棰	ceoi
 棰	zeoi
-椎	ceoi	500
-椎	zeoi	500
+椎	ceoi
+椎	zeoi
 榱	ceoi
-槌	ceoi	500
-橇	ceoi	500
-橇	hiu	500
+槌	ceoi
+橇	ceoi
+橇	hiu
 毳	ceoi
 淬	ceoi
 淬	seoi
 漼	ceoi
-炊	ceoi	500
+炊	ceoi
 焠	ceoi
 焠	seoi
 璀	ceoi
@@ -2834,9 +2835,9 @@ min_phrase_weight: 100
 綷	ceoi
 縗	ceoi
 缞	ceoi
-翠	ceoi	1000
+翠	ceoi
 脃	ceoi
-脆	ceoi	1000
+脆	ceoi
 脺	ceoi
 脺	seoi
 腄	ceoi
@@ -2844,13 +2845,13 @@ min_phrase_weight: 100
 膗	saai
 膬	ceoi
 菙	ceoi
-蛆	ceoi	500
-蛆	zeoi	500
+蛆	ceoi
+蛆	zeoi
 蜍	ceoi
 蜍	cyu
 蜍	syu
 衰	ceoi	0%
-衰	seoi	1000
+衰	seoi
 覰	ceoi
 覷	ceoi
 觑	ceoi
@@ -2861,22 +2862,22 @@ min_phrase_weight: 100
 趋	ceoi
 趍	ceoi
 趡	ceoi
-趣	ceoi	1000
+趣	ceoi
 趣	cuk	0%
-趨	ceoi	1000
+趨	ceoi
 趨	cuk	0%
-錘	ceoi	500
-錘	seoi	500
+錘	ceoi
+錘	seoi
 鎚	ceoi
 鏙	ceoi
 锤	ceoi
 陏	ceoi
 陏	do
-除	ceoi	1000
+除	ceoi
 除	cyu	0%
-隋	ceoi	1000
+隋	ceoi
 随	ceoi
-隨	ceoi	1000
+隨	ceoi
 龡	ceoi
 𡃴	ceoi
 𢊍	ceoi
@@ -2900,44 +2901,44 @@ min_phrase_weight: 100
 䮞	ceon
 䲠	ceon
 偆	ceon
-巡	ceon	1000
+巡	ceon
 廵	ceon
-循	ceon	1000
+循	ceon
 惷	ceon
-旬	ceon	1000
-春	ceon	1000
+旬	ceon
+春	ceon
 杶	ceon
 栒	ceon
 栒	seon
 椿	ceon
 橁	ceon
-秦	ceon	1000
+秦	ceon
 紃	ceon
 膥	ceon
 螓	ceon
-蠢	ceon	1000
+蠢	ceon
 賰	ceon
 賰	seon
 踳	ceon
 踳	cyun
 輴	ceon
 馴	ceon	0%
-馴	seon	1000
+馴	seon
 驯	ceon
 驯	seon
 鰆	ceon
 鰆	zeon
 䢺	ceot
-出	ceot	1000
+出	ceot
 焌	ceot
 焌	zeon
-絀	ceot	500
-絀	zeot	500
-絀	zyut	500
-黜	ceot	500
-黜	zeot	500
-黜	zyut	500
-齣	ceot	500
+絀	ceot
+絀	zeot
+絀	zyut
+黜	ceot
+黜	zeot
+黜	zyut
+齣	ceot
 㓨	ci
 㔭	ci
 㖢	ci
@@ -3046,56 +3047,56 @@ min_phrase_weight: 100
 䶔	ci
 䶵	ci
 䶵	si
-似	ci	1000
+似	ci
 佌	ci
 佽	ci
-侈	ci	1000
+侈	ci
 偨	ci
 偨	zi
 儩	ci
-刺	ci	1000
+刺	ci
 刺	cik	0%
 刺	sik	0%
-匙	ci	1000
-匙	si	1000
+匙	ci
+匙	si
 厕	ci
 厠	ci
 哧	ci
-啻	ci	500
-嗤	ci	500
+啻	ci
+嗤	ci
 嘁	ci
 嘁	cik
 坻	ci
 坻	dai
-墀	ci	500
+墀	ci
 奓	ci
 奓	se
 奓	zaa
-始	ci	1000
-姒	ci	500
+始	ci
+姒	ci
 姼	ci
 姼	si
 媸	ci
-峙	ci	500
-峙	si	500
+峙	ci
+峙	si
 帜	ci
-幟	ci	1000
+幟	ci
 庛	ci
-弛	ci	1000
+弛	ci
 恀	ci
-恃	ci	500
-恃	si	500
-恣	ci	500
-恣	zi	500
-恥	ci	1000
-慈	ci	1000
+恃	ci
+恃	si
+恣	ci
+恣	zi
+恥	ci
+慈	ci
 懥	ci
 懥	zi
 扡	ci
 扡	to
 拸	ci
 拸	ji
-持	ci	1000
+持	ci
 揓	ci
 揓	to
 摛	ci
@@ -3108,41 +3109,41 @@ min_phrase_weight: 100
 柂	ci
 柂	ji
 柂	to
-柿	ci	1000
-次	ci	1000
+柿	ci
+次	ci
 欼	ci
 欼	syut
-此	ci	1000
+此	ci
 歭	ci
 歭	zi
 歯	ci
 汜	ci
-池	ci	1000
+池	ci
 治	ci	0%
-治	zi	1000
+治	zi
 泚	ci
 泜	ci
 泜	zi
 滍	ci
 滍	zi
 炽	ci
-熾	ci	1000
+熾	ci
 玆	ci
 玆	zi
 玼	ci
-瓷	ci	1000
+瓷	ci
 瓻	ci
-疵	ci	500
-痴	ci	1000
+疵	ci
+痴	ci
 癡	ci
 眙	ci
 眙	ji
 眡	ci
 眵	ci
-矢	ci	500
-磁	ci	1000
-祠	ci	1000
-笞	ci	500
+矢	ci
+磁	ci
+祠	ci
+笞	ci
 箈	ci
 箎	ci
 篪	ci
@@ -3150,7 +3151,7 @@ min_phrase_weight: 100
 絘	ci
 絺	ci
 翄	ci
-翅	ci	1000
+翅	ci
 翨	ci
 翨	si
 耻	ci
@@ -3160,48 +3161,48 @@ min_phrase_weight: 100
 胣	ji
 胵	ci
 脐	ci
-臍	ci	1000
+臍	ci
 茌	ci
 茨	ci
 茬	ci
 茲	ci	0%
-茲	zi	1000
+茲	zi
 荎	ci
 莿	ci
 薋	ci
 蚝	ci
 蚝	hou
-蚩	ci	500
+蚩	ci
 蚳	ci
 蛓	ci
 蛓	zi
 螭	ci
-褫	ci	500
-詞	ci	1000
+褫	ci
+詞	ci
 誃	ci
 誃	zi
 謻	ci
 謻	ji
 词	ci
-豕	ci	500
-賜	ci	1000
+豕	ci
+賜	ci
 赐	ci
 跐	ci
 跐	coi
 跮	ci
-踟	ci	500
+踟	ci
 辞	ci
 辤	ci
-辭	ci	1000
+辭	ci
 迉	ci
 迟	ci
-遲	ci	1000
+遲	ci
 郗	ci
-雌	ci	1000
+雌	ci
 飺	ci
 餈	ci
 饎	ci
-馳	ci	1000
+馳	ci
 驰	ci
 骴	ci
 髊	ci
@@ -3213,7 +3214,7 @@ min_phrase_weight: 100
 鸱	ci
 鹚	ci
 黐	ci
-齒	ci	1000
+齒	ci
 齝	ci
 齿	ci
 𦙼	ci
@@ -3231,31 +3232,31 @@ min_phrase_weight: 100
 勅	cik
 勑	cik
 勑	loi
-叱	cik	1000
+叱	cik
 彳	cik
-慼	cik	500
+慼	cik
 慽	cik
-戚	cik	1000
+戚	cik
 抶	cik
 抶	maat
 抶	mut
 摵	cik
 摵	saak
 敕	cik
-斥	cik	1000
+斥	cik
 析	cik	0%
-析	sik	1000
+析	sik
 栻	cik
 栻	sik
 槭	cik
 槭	zik
 磩	cik
 磩	cit
-螫	cik	500
-螫	sik	500
+螫	cik
+螫	sik
 鏚	cik
-飭	cik	500
-飭	sik	500
+飭	cik
+飭	sik
 饬	cik
 鶒	cik
 鷘	cik
@@ -3312,10 +3313,10 @@ min_phrase_weight: 100
 䵌	cim
 佥	cim
 僉	cim
-僭	cim	500
-僭	zim	500
+僭	cim
+僭	zim
 堑	cim
-塹	cim	500
+塹	cim
 壍	cim
 嬐	cim
 孅	cim
@@ -3324,14 +3325,14 @@ min_phrase_weight: 100
 憸	cim
 撍	cim
 攕	cim
-暹	cim	500
+暹	cim
 椠	cim
 槧	cim
 櫼	cim
 櫼	zim
 歼	cim
-殲	cim	1000
-潛	cim	1000
+殲	cim
+潛	cim
 潜	cim
 濳	cim
 瀸	cim
@@ -3339,10 +3340,10 @@ min_phrase_weight: 100
 燂	cim
 燂	taam
 签	cim
-簽	cim	1000
-籤	cim	500
+簽	cim
+籤	cim
 纎	cim
-纖	cim	1000
+纖	cim
 纤	cim
 莶	cim
 薟	cim
@@ -3350,7 +3351,7 @@ min_phrase_weight: 100
 襳	cim
 襳	sam
 襳	sim
-諂	cim	500
+諂	cim
 讇	cim
 谄	cim
 酟	cim
@@ -3378,15 +3379,15 @@ min_phrase_weight: 100
 䤔	zim
 䤔	zit
 䧖	cin
-仟	cin	500
+仟	cin
 俴	cin
 俴	zin
 儃	cin
 儃	sin
 儃	taan
 冁	cin
-前	cin	1000
-千	cin	1000
+前	cin
+千	cin
 嘽	cin
 嘽	taan
 嘽	zin
@@ -3397,7 +3398,7 @@ min_phrase_weight: 100
 扦	cin
 梴	cin
 浅	cin
-淺	cin	1000
+淺	cin
 瀍	cin
 灛	cin
 灛	zin
@@ -3406,7 +3407,7 @@ min_phrase_weight: 100
 燀	zin
 瓩	cin
 瓩	ngaa
-纏	cin	1000
+纏	cin
 纏	zin	0%
 缠	cin
 芊	cin
@@ -3415,20 +3416,20 @@ min_phrase_weight: 100
 蕆	cin
 蕆	zin
 践	cin
-踐	cin	1000
+踐	cin
 踐	zin	0%
 躔	cin
 迁	cin
-遷	cin	1000
-錢	cin	1000
+遷	cin
+錢	cin
 錢	zin	0%
 钱	cin
-闡	cin	500
-闡	zin	500
+闡	cin
+闡	zin
 阐	cin
 阐	zin
-阡	cin	1000
-韆	cin	500
+阡	cin
+韆	cin
 驏	cin
 驏	zaan
 骣	cin
@@ -3453,49 +3454,49 @@ min_phrase_weight: 100
 䡕	cing
 䨝	cing
 偁	cing
-呈	cing	1000
+呈	cing
 圊	cing
 埕	cing
-情	cing	1000
+情	cing
 惩	cing
-懲	cing	1000
+懲	cing
 成	cing	0%
-成	seng	501
-成	sing	1000
-拯	cing	1000
+成	seng
+成	sing
+拯	cing
 掅	cing
 柽	cing
 檉	cing
 氰	cing
 氶	cing
 澂	cing
-澄	cing	1000
-澄	dang	1000
+澄	cing
+澄	dang
 珵	cing
 瞪	cing	0%
-瞪	dang	1000
-秤	cing	1000
+瞪	dang
+秤	cing
 称	cing
-程	cing	1000
+程	cing
 脀	cing
-菁	cing	500
-菁	zing	500
+菁	cing
+菁	zing
 蛏	cing
-蜻	cing	1000
+蜻	cing
 蟶	cing
 裎	cing
 请	cing
 赪	cing
 赬	cing
-逞	cing	1000
+逞	cing
 郢	cing
 郢	jing
 酲	cing
 靘	cing
 餳	cing
 饧	cing
-騁	cing	500
-騁	ping	500
+騁	cing
+騁	ping
 骋	cing
 鯖	cing
 鲭	cing
@@ -3514,7 +3515,7 @@ min_phrase_weight: 100
 唼	cip
 唼	saap
 唼	zaap
-妾	cip	1000
+妾	cip
 菨	cip
 菨	zip
 詀	cip
@@ -3538,22 +3539,22 @@ min_phrase_weight: 100
 䱨	zaai
 屮	cit
 彻	cit
-徹	cit	1000
+徹	cit
 懘	cit
 掣	cit	0%
 掣	zai	1000
-撤	cit	1000
-澈	cit	1000
+撤	cit
+澈	cit
 硩	cit
 硩	zit
 蔎	cit
-設	cit	1000
+設	cit
 设	cit
 踅	cit
 踅	cyut
 踅	zai
 踅	zi
-轍	cit	500
+轍	cit
 辙	cit
 㣍	ciu
 㣍	cong
@@ -3569,11 +3570,11 @@ min_phrase_weight: 100
 䫿	ciu
 䫿	coi
 䵲	ciu
-俏	ciu	500
+俏	ciu
 劁	ciu
 嫶	ciu
 嫶	ziu
-峭	ciu	1000
+峭	ciu
 嶕	ciu
 嶕	ziu
 帩	ciu
@@ -3581,21 +3582,21 @@ min_phrase_weight: 100
 弨	ciu
 怊	ciu
 怊	tiu
-悄	ciu	1000
-愀	ciu	500
-憔	ciu	1000
-昭	ciu	500
-昭	ziu	500
+悄	ciu
+愀	ciu
+憔	ciu
+昭	ciu
+昭	ziu
 晁	ciu
-朝	ciu	1000
-朝	ziu	1000
-樵	ciu	500
-潮	ciu	1000
+朝	ciu
+朝	ziu
+樵	ciu
+潮	ciu
 燋	ciu
 燋	ziu
 睄	ciu
 睄	saau
-瞧	ciu	1000
+瞧	ciu
 繰	ciu
 繰	sou
 繰	tiu
@@ -3603,20 +3604,20 @@ min_phrase_weight: 100
 缲	ciu
 缲	sou
 缲	tiu
-肖	ciu	1000
+肖	ciu
 誚	ciu
 譙	ciu
 诮	ciu
 谯	ciu
-超	ciu	1000
-釗	ciu	500
+超	ciu
+釗	ciu
 鍫	ciu
-鍬	ciu	500
+鍬	ciu
 钊	ciu
 锹	ciu
 陗	ciu
-鞘	ciu	500
-鞘	saau	500
+鞘	ciu
+鞘	saau
 顦	ciu
 㟇	co
 㭫	co
@@ -3645,16 +3646,16 @@ min_phrase_weight: 100
 傞	co
 儊	co
 刍	co
-初	co	1000
+初	co
 剉	co
-坐	co	501
-坐	zo	1000
+坐	co
+坐	zo
 媰	co
 媰	zau
 嵯	co
 憷	co
-挫	co	1000
-楚	co	1000
+挫	co
+楚	co
 檚	co
 濋	co
 犓	co
@@ -3662,24 +3663,24 @@ min_phrase_weight: 100
 痤	co
 矬	co
 础	co
-磋	co	1000
-礎	co	1000
+磋	co
+礎	co
 耡	co
 脞	co
-芻	co	500
+芻	co
 莏	co
 莏	so
 莝	co
 莝	zo
 蒭	co
 蓌	co
-蹉	co	1000
+蹉	co
 醝	co
 鉏	co
-銼	co	500
-鋤	co	1000
-錯	co	1000
-錯	cok	1000
+銼	co
+鋤	co
+錯	co
+錯	cok
 錯	cou	0%
 锄	co
 锉	co
@@ -3688,7 +3689,7 @@ min_phrase_weight: 100
 阤	to
 阤	zi
 雏	co
-雛	co	1000
+雛	co
 鶵	co
 鹺	co
 鹾	co
@@ -3732,20 +3733,20 @@ min_phrase_weight: 100
 勺	coek
 勺	soek
 勺	zoek
-卓	coek	1000
+卓	coek
 卓	zoek	0%
-噱	coek	500
-噱	kek	500
-噱	koek	500
+噱	coek
+噱	kek
+噱	koek
 婥	coek
 婼	coek
-戳	coek	500
-桌	coek	1000
-桌	zoek	1000
+戳	coek
+桌	coek
+桌	zoek
 潟	coek
 潟	sik
-灼	coek	501
-灼	zoek	1000
+灼	coek
+灼	zoek
 焯	coek
 焯	zoek
 皵	coek
@@ -3754,16 +3755,16 @@ min_phrase_weight: 100
 碏	zoek
 穛	coek
 穛	zoek
-綽	coek	1000
+綽	coek
 绰	coek
-芍	coek	500
-芍	zoek	500
+芍	coek
+芍	zoek
 趠	coek
 踔	coek
 辵	coek
 逴	coek
 鵲	coek	0%
-鵲	zoek	1000
+鵲	zoek
 鹊	coek
 暢	coeng	5
 㙊	coeng
@@ -3795,47 +3796,47 @@ min_phrase_weight: 100
 䵁	coeng
 伥	coeng
 伥	zaang
-倡	coeng	1000
+倡	coeng
 償	coeng	0%
-償	soeng	1000
+償	soeng
 呛	coeng
-唱	coeng	1000
-嗆	coeng	500
+唱	coeng
+嗆	coeng
 囪	coeng
 囪	cung
 囱	coeng	0%
-囱	cung	1000
+囱	cung
 场	coeng
-場	coeng	1000
+場	coeng
 塲	coeng
 墙	coeng
 墻	coeng
-娼	coeng	500
+娼	coeng
 嫱	coeng
 嬙	coeng
-庠	coeng	500
+庠	coeng
 廧	coeng
 怅	coeng
-悵	coeng	500
-悵	zoeng	500
-戕	coeng	500
+悵	coeng
+悵	zoeng
+戕	coeng
 戗	coeng
 戧	coeng
 抢	coeng
-搶	coeng	1000
+搶	coeng
 搶	cong	0%
 斨	coeng
-昌	coeng	1000
+昌	coeng
 枪	coeng
-槍	coeng	1000
+槍	coeng
 樯	coeng
 檣	coeng
 炝	coeng
 熗	coeng
 牄	coeng
-牆	coeng	1000
+牆	coeng
 牕	coeng
-猖	coeng	500
+猖	coeng
 玱	coeng
 瑒	coeng
 瑒	dong
@@ -3845,22 +3846,22 @@ min_phrase_weight: 100
 磢	coeng
 磢	cong
 磢	saang
-祥	coeng	1000
+祥	coeng
 窓	coeng
-窗	coeng	1000
+窗	coeng
 窻	coeng
 羥	coeng
 羥	koeng
-翔	coeng	1000
+翔	coeng
 肠	coeng
-腸	coeng	1000
+腸	coeng
 苌	coeng
 菖	coeng
 萇	coeng
 蔷	coeng
-薔	coeng	500
+薔	coeng
 蘠	coeng
-詳	coeng	1000
+詳	coeng
 謒	coeng
 详	coeng
 跄	coeng
@@ -3869,11 +3870,11 @@ min_phrase_weight: 100
 錆	coeng
 錩	coeng
 鎗	coeng
-鏘	coeng	500
+鏘	coeng
 锠	coeng
 锵	coeng
-長	coeng	1000
-長	zoeng	1000
+長	coeng
+長	zoeng
 长	coeng
 长	zoeng
 閶	coeng
@@ -3893,29 +3894,29 @@ min_phrase_weight: 100
 䴭	coi
 啋	coi
 埰	coi
-塞	coi	1000
-塞	sak	1000
+塞	coi
+塞	sak
 寀	coi
-彩	coi	1000
-才	coi	1000
-採	coi	1000
-材	coi	1000
-睬	coi	1000
-綵	coi	1000
+彩	coi
+才	coi
+採	coi
+材	coi
+睬	coi
+綵	coi
 縩	coi
 縩	zoi
 纔	coi
 茞	coi
 茞	zi
-菜	coi	1000
-蔡	coi	1000
-裁	coi	1000
-財	coi	1000
-賽	coi	1000
+菜	coi
+蔡	coi
+裁	coi
+財	coi
+賽	coi
 财	coi
 赛	coi
 跴	coi
-采	coi	1000
+采	coi
 䥘	cok
 䥘	cou
 䱜	cok
@@ -3935,43 +3936,43 @@ min_phrase_weight: 100
 䡴	cung
 䭚	cong
 仓	cong
-倉	cong	1000
+倉	cong
 凔	cong
 创	cong
 刱	cong
-創	cong	1000
+創	cong
 厰	cong
 幢	cong	0%
 幢	tong	0%
-幢	zong	1000
+幢	zong
 床	cong
-廠	cong	1000
+廠	cong
 怆	cong
 惝	cong
 惝	tong
-愴	cong	500
+愴	cong
 戃	cong
 戃	tong
 撞	cong	0%
-撞	zong	1000
-敞	cong	1000
+撞	zong
+敞	cong
 昶	cong
 橦	cong
 橦	tung
 氅	cong
 沧	cong
-滄	cong	1000
-牀	cong	1000
+滄	cong
+牀	cong
 疮	cong
-瘡	cong	1000
+瘡	cong
 舱	cong
-艙	cong	1000
+艙	cong
 苍	cong
-蒼	cong	1000
-藏	cong	1000
-藏	zong	1000
+蒼	cong
+藏	cong
+藏	zong
 鋹	cong
-闖	cong	1000
+闖	cong
 闯	cong
 駔	cong
 駔	zong
@@ -3999,46 +4000,46 @@ min_phrase_weight: 100
 傮	zou
 厝	cou
 喿	cou
-嘈	cou	1000
-噪	cou	1000
+嘈	cou
+噪	cou
 徂	cou
 慅	cou
 慅	sou
 慥	cou
 慥	zou
 懆	cou
-措	cou	1000
+措	cou
 措	zaak	0%
-操	cou	1000
-曹	cou	1000
-槽	cou	1000
+操	cou
+曹	cou
+槽	cou
 殂	cou
 氉	cou
 氉	so
-漕	cou	500
-澡	cou	1000
-澡	zou	1000
-燥	cou	1000
+漕	cou
+澡	cou
+澡	zou
+燥	cou
 矂	cou
-粗	cou	1000
-糙	cou	1000
+粗	cou
+糙	cou
 艚	cou
 艸	cou
-草	cou	1000
+草	cou
 螬	cou
 觕	cou
 譟	cou
 趮	cou
 跿	cou
 跿	tou
-躁	cou	1000
-造	cou	1000
-造	zou	1000
+躁	cou
+造	cou
+造	zou
 鄵	cou
 酢	cou
 酢	zaa
 酢	zok
-醋	cou	1000
+醋	cou
 騲	cou
 鰽	cou
 麤	cou
@@ -4071,7 +4072,7 @@ min_phrase_weight: 100
 䠞	cuk
 䩳	cuk
 亍	cuk
-促	cuk	1000
+促	cuk
 俶	cuk
 俶	suk
 俶	tik
@@ -4083,7 +4084,7 @@ min_phrase_weight: 100
 搐	cuk
 敊	cuk
 斶	cuk
-束	cuk	1000
+束	cuk
 樕	cuk
 樕	sok
 歜	cuk
@@ -4091,34 +4092,34 @@ min_phrase_weight: 100
 滀	cuk
 琡	cuk
 琡	zyut
-畜	cuk	1000
+畜	cuk
 瘯	cuk
-矗	cuk	1000
-簇	cuk	1000
+矗	cuk
+簇	cuk
 簌	cuk
-蓄	cuk	1000
+蓄	cuk
 蔌	cuk
 蔟	cuk
 触	cuk
 触	zuk
 觫	cuk
 觸	cuk	0%
-觸	zuk	1000
+觸	zuk
 諔	cuk
 諔	suk
 豖	cuk
 豖	doek
 踧	cuk
 踧	dik
-蹙	cuk	500
+蹙	cuk
 蹴	cuk
 蹵	cuk
-速	cuk	1000
+速	cuk
 遫	cuk
 鄐	cuk
 顣	cuk
 餗	cuk
-齪	cuk	500
+齪	cuk
 齱	cuk
 齱	zau
 龊	cuk
@@ -4167,19 +4168,19 @@ min_phrase_weight: 100
 䳷	cung
 丛	cung
 从	cung
-充	cung	1000
-冢	cung	1000
+充	cung
+冢	cung
 冲	cung
-匆	cung	1000
-叢	cung	1000
+匆	cung
+叢	cung
 埇	cung
 埇	jung
 埇	tung
-塚	cung	500
+塚	cung
 宠	cung
-寵	cung	1000
-從	cung	1000
-從	sung	1000
+寵	cung
+從	cung
+從	sung
 從	zung	0%
 忡	cung
 怱	cung
@@ -4190,19 +4191,19 @@ min_phrase_weight: 100
 慒	zou
 憃	cung
 憃	zung
-憧	cung	1000
+憧	cung
 憧	tung	0%
 揰	cung
 摐	cung
-松	cung	1000
+松	cung
 枞	cung
 樅	cung
-沖	cung	1000
+沖	cung
 浺	cung
-涌	cung	500
-涌	jung	500
-淙	cung	500
-淙	zung	500
+涌	cung
+涌	jung
+淙	cung
+淙	zung
 漎	cung
 漎	sung
 潀	cung
@@ -4220,22 +4221,22 @@ min_phrase_weight: 100
 翀	zung
 聦	cung
 聪	cung
-聰	cung	1000
+聰	cung
 苁	cung
 茺	cung
-葱	cung	1000
+葱	cung
 蓯	cung
 蔥	cung
 藂	cung
-虫	cung	500
-虫	wai	500
-蟲	cung	1000
-衝	cung	1000
-衷	cung	1000
+虫	cung
+虫	wai
+蟲	cung
+衝	cung
+衷	cung
 衷	zung	0%
 賨	cung
-重	cung	1000
-重	zung	1000
+重	cung
+重	zung
 銃	cung
 鏦	cung
 铳	cung
@@ -4264,42 +4265,42 @@ min_phrase_weight: 100
 䣝	cyu
 䣝	tou
 伫	cyu
-佇	cyu	500
+佇	cyu
 储	cyu
-儲	cyu	1000
+儲	cyu
 処	cyu
 处	cyu
 宁	cyu
 幮	cyu
-曙	cyu	1000
+曙	cyu
 曙	syu	0%
-杵	cyu	1000
+杵	cyu
 杼	cyu
-柱	cyu	1000
+柱	cyu
 楮	cyu
 橱	cyu
-櫥	cyu	1000
+櫥	cyu
 滁	cyu
 砫	cyu
 砫	zyu
 竚	cyu
 紵	cyu
 纻	cyu
-署	cyu	1000
+署	cyu
 署	syu	0%
 羜	cyu
 芧	cyu
 芧	seoi
 芧	zeoi
 苎	cyu
-苧	cyu	500
-處	cyu	1000
+苧	cyu
+處	cyu
 處	syu	0%
-褚	cyu	500
-貯	cyu	1000
+褚	cyu
+貯	cyu
 贮	cyu
 蹰	cyu
-躇	cyu	500
+躇	cyu
 躕	cyu
 麆	cyu
 㒰	cyun
@@ -4324,26 +4325,26 @@ min_phrase_weight: 100
 䞼	zan
 䞼	zat
 䰖	cyun
-串	cyun	1000
-串	gwaan	0
+串	cyun
+串	gwaan	0%
 传	cyun
 佺	cyun
-傳	cyun	1000
-傳	zyun	1000
-全	cyun	1000
+傳	cyun
+傳	zyun
+全	cyun
 刌	cyun
-吋	cyun	1000
-喘	cyun	1000
+吋	cyun
+喘	cyun
 圌	cyun
 圌	seoi
-存	cyun	1000
-寸	cyun	1000
+存	cyun
+寸	cyun
 巑	cyun
-川	cyun	1000
-忖	cyun	500
+川	cyun
+忖	cyun
 恮	cyun
-惴	cyun	500
-惴	zeoi	500
+惴	cyun
+惴	zeoi
 撺	cyun
 攅	cyun
 攒	cyun
@@ -4351,7 +4352,7 @@ min_phrase_weight: 100
 攛	cyun
 攢	cyun
 攢	zaan
-村	cyun	1000
+村	cyun
 椽	cyun
 欑	cyun
 欑	zaan
@@ -4359,29 +4360,29 @@ min_phrase_weight: 100
 氚	cyun
 汆	cyun
 汆	tan
-泉	cyun	1000
-爨	cyun	500
+泉	cyun
+爨	cyun
 牷	cyun
 玔	cyun
-痊	cyun	1000
-穿	cyun	1000
+痊	cyun
+穿	cyun
 窜	cyun
-竄	cyun	1000
+竄	cyun
 筌	cyun
 縓	cyun
 縓	jyun
-舛	cyun	500
-荃	cyun	500
+舛	cyun
+荃	cyun
 荈	cyun
-詮	cyun	500
+詮	cyun
 譐	cyun
 诠	cyun
 跧	cyun
 踆	cyun
 踆	seon
 踆	zeon
-蹲	cyun	1000
-蹲	deon	1000
+蹲	cyun
+蹲	deon
 蹿	cyun
 躥	cyun
 輇	cyun
@@ -4389,11 +4390,11 @@ min_phrase_weight: 100
 遄	cyun
 邨	cyun
 醛	cyun
-釧	cyun	500
+釧	cyun
 鉆	cyun
 鉆	kim
 鉆	zyun
-銓	cyun	500
+銓	cyun
 鋑	cyun
 鋑	zeon
 钏	cyun
@@ -4414,12 +4415,12 @@ min_phrase_weight: 100
 䱣	cyut
 䱣	zeot
 卒	cyut	0%
-卒	zeot	1000
-咄	cyut	500
-咄	deot	500
+卒	zeot
+咄	cyut
+咄	deot
 捽	cyut
 捽	zeot
-撮	cyut	500
+撮	cyut
 椊	cyut
 椊	zyut
 猝	cyut
@@ -4429,7 +4430,7 @@ min_phrase_weight: 100
 踤	seoi
 踤	zeot
 𠾼	cyut
-打	daa	1000
+打	daa
 㐲	daai
 㗣	daai
 㗣	taai
@@ -4471,12 +4472,12 @@ min_phrase_weight: 100
 䲦	daai
 傣	daai
 傣	taai
-呆	daai	1000
-呆	ngoi	1000
-大	daai	1000
+呆	daai
+呆	ngoi
+大	daai
 带	daai
-帶	daai	1000
-戴	daai	1000
+帶	daai
+戴	daai
 歺	daai
 汏	daai
 獃	daai
@@ -4516,7 +4517,7 @@ min_phrase_weight: 100
 䱋	daam
 䱋	gung
 儋	daam
-啖	daam	500
+啖	daam
 啗	daam
 噉	daam
 噉	gam	1000
@@ -4524,31 +4525,31 @@ min_phrase_weight: 100
 嚪	taam
 憺	daam
 担	daam
-擔	daam	1000
-氮	daam	500
-淡	daam	1000
-淡	taam	501
-湛	daam	500
-湛	zaam	500
-澹	daam	500
-澹	taam	500
+擔	daam
+氮	daam
+淡	daam
+淡	taam
+湛	daam
+湛	zaam
+澹	daam
+澹	taam
 甔	daam
 眈	daam
-石	daam	200
-石	sek	1000
+石	daam	4%
+石	sek
 禫	daam
 禫	taam
 窞	daam
 紞	daam
-耽	daam	1000
+耽	daam
 聃	daam
 胆	daam
-膽	daam	1000
+膽	daam
 萏	daam
 賧	daam
 賧	zin
 贱	daam
-躭	daam	500
+躭	daam
 酖	daam
 酖	zam
 霮	daam
@@ -4570,25 +4571,25 @@ min_phrase_weight: 100
 䐷	daan
 䒟	daan
 䜥	daan
-丹	daan	1000
-但	daan	1000
+丹	daan
+但	daan
 僤	daan
 勯	daan
 匰	daan
 单	daan
-單	daan	1000
-單	sin	200
+單	daan
+單	sin	4%
 弹	daan
 弹	taan
-彈	daan	1000
-彈	taan	1000
+彈	daan
+彈	taan
 惮	daan
-憚	daan	500
+憚	daan
 掸	daan
 掸	sin
 撣	daan
 撣	sin
-旦	daan	1000
+旦	daan
 殚	daan
 殫	daan
 狚	daan
@@ -4597,12 +4598,12 @@ min_phrase_weight: 100
 癉	daan
 癉	taan
 箪	daan
-簞	daan	500
+簞	daan
 繵	daan
-蛋	daan	1000
+蛋	daan
 蜑	daan
 襌	daan
-誕	daan	1000
+誕	daan
 诞	daan
 郸	daan
 鄲	daan
@@ -4634,18 +4635,18 @@ min_phrase_weight: 100
 傝	taap
 匒	daap
 嚃	daap
-搭	daap	1000
+搭	daap
 沓	daap
 畣	daap
-疊	daap	501
-疊	dip	1000
-瘩	daap	500
-答	daap	1000
+疊	daap
+疊	dip
+瘩	daap
+答	daap
 耷	daap
 荅	daap
 褡	daap
-踏	daap	1000
-蹋	daap	500
+踏	daap
+蹋	daap
 遝	daap
 錔	daap
 錔	taap
@@ -4664,19 +4665,19 @@ min_phrase_weight: 100
 妲	daat
 妲	taan
 怛	daat
-撻	daat	501
-撻	taat	1000
+撻	daat
+撻	taat
 笪	daat
 繨	daat
 荙	daat
 薘	daat
-躂	daat	500
-躂	taat	500
+躂	daat
+躂	taat
 达	daat
-達	daat	1000
+達	daat
 達	taat	0%
 鐽	daat
-靼	daat	500
+靼	daat
 𢴈	daat
 㛒	daau
 㛒	zaau
@@ -4704,75 +4705,75 @@ min_phrase_weight: 100
 䣌	dai
 䱥	dai
 䱥	zaai
-低	dai	1000
+低	dai
 埭	dai
 埭	doi
 墆	dai
 墆	dit
-娣	dai	500
-娣	tai	500
+娣	dai
+娣	tai
 嵽	dai
 嵽	dit
-帝	dai	1000
-底	dai	1000
-弟	dai	1000
+帝	dai
+底	dai
+弟	dai
 弟	tai	0%
 弤	dai
 彽	dai
-悌	dai	500
-悌	tai	500
+悌	dai
+悌	tai
 提	dai	0%
-提	tai	1000
+提	tai
 揥	dai
 揥	tai
 揥	zaai
 杕	dai
 柢	dai
-棣	dai	500
-氐	dai	500
+棣	dai
+氐	dai
 渧	dai
-牴	dai	500
+牴	dai
 睼	dai
 睼	tai
-砥	dai	500
-砥	zi	500
+砥	dai
+砥	zi
 碲	dai
 磾	dai
 禘	dai
 笫	dai
 笫	zi
-第	dai	1000
-締	dai	1000
+第	dai
+締	dai
 締	tai	0%
 缔	dai
 羝	dai
 胝	dai
 胝	zi
-蒂	dai	1000
+蒂	dai
 蝃	dai
 螮	dai
 袛	dai
 袛	zi
 觝	dai
-詆	dai	500
-諦	dai	500
+詆	dai
+諦	dai
 诋	dai
 谛	dai
 踶	dai
 踶	tai
 軧	dai
 递	dai
-逮	dai	1000
+逮	dai
 逮	doi	0%
-遞	dai	1000
+遞	dai
 遰	dai
 遰	sai
-邸	dai	500
+邸	dai
 阺	dai
 隶	dai
 隷	dai
 隷	lai
-隸	dai	1000
+隸	dai
 隸	lai	0%
 鞮	dai
 鷤	dai
@@ -4781,11 +4782,11 @@ min_phrase_weight: 100
 㝶	dak
 㥁	dak
 䙸	dak
-得	dak	1000
-德	dak	1000
+得	dak
+德	dak
 悳	dak
 淂	dak
-特	dak	1000
+特	dak
 犆	dak
 犆	dat
 犆	zik
@@ -4836,13 +4837,13 @@ min_phrase_weight: 100
 撴	dan
 炖	dan
 炖	deon
-燉	dan	500
-燉	deon	500
+燉	dan
+燉	deon
 礅	dan
 礅	deon
 趸	dan
 蹾	dan
-躉	dan	500
+躉	dan
 𣎴	dan
 㲪	dang
 㽅	dang
@@ -4852,25 +4853,25 @@ min_phrase_weight: 100
 䠬	dang
 䮴	dang
 䳾	dang
-凳	dang	1000
+凳	dang
 噔	dang
 墱	dang
 崂	dang
 嶗	dang
 嶗	lou
-嶝	dang	500
+嶝	dang
 戥	dang
 櫈	dang
 灯	dang
-燈	dang	1000
-登	dang	1000
-磴	dang	500
-等	dang	1000
+燈	dang
+登	dang
+磴	dang
+等	dang
 簦	dang
 豋	dang
-蹬	dang	500
+蹬	dang
 邓	dang
-鄧	dang	1000
+鄧	dang
 鐙	dang
 镫	dang
 㗳	dap
@@ -4901,11 +4902,11 @@ min_phrase_weight: 100
 𦖿	dap
 䩢	dat
 䩢	dik
-凸	dat	1000
+凸	dat
 凸	gu	0%
 怢	dat
 揬	dat
-突	dat	1000
+突	dat
 腯	dat
 葖	dat
 蟘	dat
@@ -4916,52 +4917,52 @@ min_phrase_weight: 100
 㪷	dau
 㿡	dau
 䬦	dau
-兜	dau	1000
+兜	dau
 哣	dau
 唗	dau
 唞	dau
 唞	tau
-抖	dau	1000
-斗	dau	1000
+抖	dau
+斗	dau
 枓	dau
 枓	zyu
 梪	dau
 浢	dau
-痘	dau	1000
+痘	dau
 窦	dau
-竇	dau	500
+竇	dau
 篼	dau
 糾	dau	0%
-糾	gau	1000
+糾	gau
 脰	dau
 荳	dau
 蔸	dau
-蚪	dau	500
+蚪	dau
 讀	dau	0%
-讀	duk	1000
-豆	dau	1000
-赳	dau	1000
-赳	gau	1000
-逗	dau	1000
+讀	duk
+豆	dau
+赳	dau
+赳	gau
+逗	dau
 郖	dau
 鈄	dau
 鋀	dau
 钭	dau
-陡	dau	1000
+陡	dau
 餖	dau
 饾	dau
-鬥	dau	1000
+鬥	dau
 鬦	dau
 鬪	dau
 鬭	dau
 𠻼	dau
 𢭃	dau
 嗲	de
-爹	de	500
+爹	de
 哋	dei	10000
 哋	di
-地	dei	1000
-地	deng	200
+地	dei
+地	deng
 墬	dei
 墬	zeoi
 㣙	dek
@@ -4971,27 +4972,27 @@ min_phrase_weight: 100
 㰅	zak
 䊮	dek
 䨀	dek
-笛	dek	1000
+笛	dek
 篴	dek
 篴	dik
 籴	dek
 糴	dek
 埞	deng	1000
 掟	deng	1000
-定	deng	501
-定	ding	1000
+定	deng
+定	ding
 疔	deng
 疔	ding
 矴	deng
 矴	ding
-訂	deng	501
-訂	ding	1000
-釘	deng	1000
+訂	deng
+訂	ding
+釘	deng
 釘	ding	0%
 钉	deng
 钉	ding
-頂	deng	501
-頂	ding	1000
+頂	deng
+頂	ding
 顶	deng
 顶	ding
 㒛	deoi
@@ -5037,19 +5038,19 @@ min_phrase_weight: 100
 䭔	deoi
 䯟	deoi
 兌	deoi
-兑	deoi	1000
+兑	deoi
 嚉	deoi
-堆	deoi	1000
+堆	deoi
 堆	zeoi	0%
 对	deoi
-對	deoi	1000
+對	deoi
 怼	deoi
 怼	zeoi
 憝	deoi
 懟	deoi
 懟	zeoi
 敦	deoi	0%
-敦	deon	1000
+敦	deon
 碓	deoi
 祋	deoi
 祋	doi
@@ -5064,7 +5065,7 @@ min_phrase_weight: 100
 鐓	deoi
 鐓	deon
 队	deoi
-隊	deoi	1000
+隊	deoi
 駾	deoi
 駾	teoi
 𠂤	deoi
@@ -5083,33 +5084,33 @@ min_phrase_weight: 100
 伅	deon
 吨	deon
 吨	zeon
-噸	deon	1000
-囤	deon	500
-囤	tyun	500
+噸	deon
+囤	deon
+囤	tyun
 惇	deon
-沌	deon	500
-盹	deon	500
+沌	deon
+盹	deon
 蜳	deon
-諄	deon	500
-諄	zeon	500
-遁	deon	500
+諄	deon
+諄	zeon
+遁	deon
 遯	deon
-鈍	deon	1000
+鈍	deon
 钝	deon
 镦	deon
-頓	deon	1000
+頓	deon
 頓	duk	0%
 顿	deon
 顿	duk
 𥫱	deon
 㘞	deot
 柮	deot
-掉	deu	501
-掉	diu	1000
+掉	deu	4%
+掉	diu
 掉	zaau	0%
-調	deu	501
-調	diu	1000
-調	tiu	1000
+調	deu	4%
+調	diu
+調	tiu
 啲	di	10000
 啲	dit
 㢩	dik
@@ -5124,26 +5125,26 @@ min_phrase_weight: 100
 䨤	dik
 䯼	dik
 䴞	dik
-嘀	dik	500
-嫡	dik	500
+嘀	dik
+嫡	dik
 掦	dik
 敌	dik
-敵	dik	1000
+敵	dik
 旳	dik
 浟	dik
 浟	jau
 涤	dik
-滌	dik	1000
-滴	dik	1000
-狄	dik	500
+滌	dik
+滴	dik
+狄	dik
 玓	dik
 甋	dik
-的	dik	1000
+的	dik
 籊	dik
 籊	tik
-翟	dik	500
-翟	zaak	500
-荻	dik	500
+翟	dik
+翟	zaak
+荻	dik
 菂	dik
 藋	dik
 藋	diu
@@ -5154,12 +5155,12 @@ min_phrase_weight: 100
 豴	dik
 蹢	dik
 蹢	zaak
-迪	dik	1000
+迪	dik
 適	dik	0%
-適	sik	1000
+適	sik
 鍉	dik
 鍉	si
-鏑	dik	500
+鏑	dik
 镝	dik
 靮	dik
 鸐	dik
@@ -5174,15 +5175,15 @@ min_phrase_weight: 100
 䍄	dim
 坫	dim
 墊	dim	0%
-墊	din	1000
-墊	zin	501
-店	dim	1000
-惦	dim	1000
+墊	din
+墊	zin
+店	dim
+惦	dim
 扂	dim
 掂	dim
 敁	dim
 点	dim
-玷	dim	500
+玷	dim
 痁	dim
 磹	dim
 磹	taam
@@ -5190,7 +5191,7 @@ min_phrase_weight: 100
 踮	dim
 阽	dim
 阽	jim
-點	dim	1000
+點	dim
 𠶧	dim
 㒹	din
 㙉	din
@@ -5199,28 +5200,28 @@ min_phrase_weight: 100
 㹠	din
 㹠	tyun
 䓦	din
-佃	din	500
-佃	tin	500
+佃	din
+佃	tin
 傎	din
-典	din	1000
+典	din
 垫	din
-奠	din	500
+奠	din
 巅	din
 巓	din
-巔	din	500
-殿	din	1000
+巔	din
+殿	din
 淀	din
-滇	din	500
-滇	tin	500
-澱	din	1000
+滇	din
+滇	tin
+澱	din
 电	din
-甸	din	1000
+甸	din
 痶	din
 瘨	din
 癜	din
 癫	din
-癲	din	500
-碘	din	500
+癲	din
+碘	din
 蕇	din
 蜔	din
 蹎	din
@@ -5228,10 +5229,10 @@ min_phrase_weight: 100
 鈿	tin
 钿	din
 钿	tin
-電	din	1000
-靛	din	500
+電	din
+靛	din
 顚	din
-顛	din	1000
+顛	din
 颠	din
 齻	din
 㓅	ding
@@ -5243,35 +5244,35 @@ min_phrase_weight: 100
 䟓	ding
 䵺	ding
 䵺	ting
-丁	ding	1000
+丁	ding
 丁	zaang	0%
-丁	zang	0
-仃	ding	500
-叮	ding	1000
+丁	zang	0%
+仃	ding
+叮	ding
 啶	ding
 圢	ding
 圢	ting
 椗	ding
-汀	ding	500
-汀	ting	500
+汀	ding
+汀	ting
 濎	ding
 濎	ting
 玎	ding
-盯	ding	1000
+盯	ding
 碇	ding
 耵	ding
 耵	ting
 艼	ding
 薡	ding
 订	ding
-酊	ding	500
-錠	ding	500
+酊	ding
+錠	ding
 锭	ding
 靪	ding
 顁	ding
 飣	ding
 饤	ding
-鼎	ding	1000
+鼎	ding
 㑙	dip
 㜼	dip
 㜼	zaat
@@ -5295,7 +5296,7 @@ min_phrase_weight: 100
 叠	dip
 啑	dip
 啑	saap
-喋	dip	500
+喋	dip
 堞	dip
 惵	dip
 揲	dip
@@ -5303,16 +5304,16 @@ min_phrase_weight: 100
 揲	sit
 楪	dip
 楪	jip
-牒	dip	500
-碟	dip	1000
+牒	dip
+碟	dip
 艓	dip
 蜨	dip
-蝶	dip	1000
+蝶	dip
 褋	dip
-褶	dip	500
-褶	zaap	500
-褶	zip	500
-諜	dip	1000
+褶	dip
+褶	zaap
+褶	zip
+諜	dip
 谍	dip
 蹀	dip
 鍱	dip
@@ -5336,7 +5337,7 @@ min_phrase_weight: 100
 柣	dit
 瓞	dit
 眣	dit
-秩	dit	1000
+秩	dit
 紩	dit
 紩	zat
 絰	dit
@@ -5350,10 +5351,10 @@ min_phrase_weight: 100
 螲	zat
 袟	dit
 詄	dit
-跌	dit	1000
-軼	dit	500
-軼	jat	500
-迭	dit	500
+跌	dit
+軼	dit
+軼	jat
+迭	dit
 㓮	diu
 㚋	diu
 㚋	niu
@@ -5375,23 +5376,23 @@ min_phrase_weight: 100
 䥫	diu
 䥫	tit
 䳂	diu
-丟	diu	1000
+丟	diu
 丢	diu
-凋	diu	1000
-刁	diu	500
-叼	diu	1000
-吊	diu	1000
+凋	diu
+刁	diu
+叼	diu
+吊	diu
 屌	diu
-弔	diu	1000
-彫	diu	500
-彫	tiu	500
+弔	diu
+彫	diu
+彫	tiu
 扚	diu
 琱	diu
 盄	diu
-碉	diu	500
+碉	diu
 窎	diu
-窕	diu	500
-窕	tiu	500
+窕	diu
+窕	tiu
 窵	diu
 罀	diu
 蓧	diu
@@ -5401,8 +5402,8 @@ min_phrase_weight: 100
 誂	tiu
 调	diu
 调	tiu
-貂	diu	500
-釣	diu	1000
+貂	diu
+釣	diu
 銚	diu
 銚	jiu
 銚	siu
@@ -5411,7 +5412,7 @@ min_phrase_weight: 100
 钓	diu
 铥	diu
 铫	diu
-雕	diu	1000
+雕	diu
 鯛	diu
 鲷	diu
 鵰	diu
@@ -5438,25 +5439,25 @@ min_phrase_weight: 100
 䴱	to
 亸	do
 刴	do
-剁	do	500
-剁	doek	500
+剁	do
+剁	doek
 嚲	do
 垛	do
 垜	do
 埵	do
 堕	do
-墮	do	1000
+墮	do
 墮	fai	0%
 墯	do
 墯	fai
-多	do	1000
+多	do
 嶞	do
-惰	do	1000
-朵	do	1000
+惰	do
+朵	do
 朵	doe	0%
-跺	do	500
+跺	do
 躱	do
-躲	do	1000
+躲	do
 陊	do
 鬌	do
 𥞛	do
@@ -5471,7 +5472,7 @@ min_phrase_weight: 100
 䐁	doek
 䐁	duk
 䐁	zaa
-啄	doek	1000
+啄	doek
 啄	doeng	0%
 啅	doek
 噣	doek
@@ -5480,46 +5481,46 @@ min_phrase_weight: 100
 斲	doek
 椓	doek
 涿	doek
-琢	doek	1000
+琢	doek
 諑	doek
 诼	doek
 𡁷	doeng
 㻖	doi
 䒫	doi
-代	doi	1000
+代	doi
 偫	doi
 偫	zi
-岱	doi	500
+岱	doi
 帒	doi
-待	doi	1000
+待	doi
 怠	doi	0%
-怠	toi	1000
+怠	toi
 殆	doi	0%
-殆	toi	1000
-玳	doi	500
+殆	toi
+玳	doi
 瑇	doi
 紿	doi
 绐	doi
 蝳	doi
-袋	doi	1000
+袋	doi
 迨	doi
 酨	doi
 酨	zoi
 靆	doi
-黛	doi	1000
+黛	doi
 㡯	dok
 㡯	dou
 㡯	saam
 㡯	zak
 剫	dok
-度	dok	1000
-度	dou	1000
+度	dok
+度	dou
 襗	dok
 襗	jik
 襗	zaak
-踱	dok	1000
-鐸	dok	500
-鐸	nok	500
+踱	dok
+鐸	dok
+鐸	nok
 铎	dok
 㼕	dong
 㽆	dong
@@ -5527,7 +5528,7 @@ min_phrase_weight: 100
 䣣	dong
 䦒	dong
 党	dong
-噹	dong	500
+噹	dong
 婸	dong
 宕	dong
 当	dong
@@ -5536,10 +5537,10 @@ min_phrase_weight: 100
 戙	dong
 戙	dung
 挡	dong
-擋	dong	1000
+擋	dong
 攩	dong
 档	dong
-檔	dong	1000
+檔	dong
 欓	dong
 潒	dong
 玚	dong
@@ -5547,8 +5548,8 @@ min_phrase_weight: 100
 璗	dong
 璫	dong
 瓽	dong
-當	dong	1000
-盪	dong	1000
+當	dong
+盪	dong
 盪	tong	0%
 砀	dong
 碭	dong
@@ -5558,10 +5559,10 @@ min_phrase_weight: 100
 艡	dong
 荡	dong
 菪	dong
-蕩	dong	1000
+蕩	dong
 蟷	dong
 裆	dong
-襠	dong	500
+襠	dong
 讜	dong
 谠	dong
 踼	dong
@@ -5570,7 +5571,7 @@ min_phrase_weight: 100
 逿	tong
 钂	dong
 钂	tong
-黨	dong	1000
+黨	dong
 鼞	dong
 鼞	tong
 㓃	dou
@@ -5590,49 +5591,49 @@ min_phrase_weight: 100
 䩲	dou
 䬰	dou
 䬰	siu
-倒	dou	1000
-刀	dou	1000
-到	dou	1000
-叨	dou	500
-叨	tou	500
+倒	dou
+刀	dou
+到	dou
+叨	dou
+叨	tou
 喥	dou
-嘟	dou	500
-堵	dou	1000
+嘟	dou
+堵	dou
 壔	dou
-妒	dou	1000
+妒	dou
 妬	dou
 导	dou
-導	dou	1000
+導	dou
 岛	dou
-島	dou	1000
+島	dou
 帾	dou
 忉	dou
 忉	tou
-悼	dou	1000
+悼	dou
 捣	dou
 捯	dou
-搗	dou	1000
+搗	dou
 擣	dou
 斁	dou
 斁	jik
-杜	dou	1000
+杜	dou
 氘	dou
-渡	dou	1000
+渡	dou
 焘	dou
 焘	tou
 燾	dou
 燾	tou
 盗	dou
-盜	dou	1000
-睹	dou	1000
+盜	dou
+睹	dou
 禂	dou
 禂	tou
 禱	dou	0%
-禱	tou	1000
+禱	tou
 秺	dou
 稌	dou
 稌	tou
-稻	dou	1000
+稻	dou
 纛	dou
 纛	duk
 翿	dou
@@ -5640,15 +5641,15 @@ min_phrase_weight: 100
 舠	dou
 艔	dou
 芏	dou
-蠹	dou	500
+蠹	dou
 覩	dou
-賭	dou	1000
+賭	dou
 赌	dou
-蹈	dou	1000
+蹈	dou
 蹈	tou	0%
-道	dou	1000
-都	dou	1000
-鍍	dou	500
+道	dou
+都	dou
+鍍	dou
 镀	dou
 闍	dou
 闍	se
@@ -5671,22 +5672,22 @@ min_phrase_weight: 100
 厾	duk
 叾	duk
 椟	duk
-櫝	duk	500
+櫝	duk
 殰	duk
-毒	duk	1000
+毒	duk
 渎	duk
-瀆	duk	500
+瀆	duk
 牍	duk
-牘	duk	500
+牘	duk
 犊	duk
-犢	duk	500
+犢	duk
 独	duk
-獨	duk	1000
+獨	duk
 皾	duk
-督	duk	1000
+督	duk
 碡	duk
 笃	duk
-篤	duk	500
+篤	duk
 裻	duk
 襡	duk
 襡	suk
@@ -5697,7 +5698,7 @@ min_phrase_weight: 100
 韣	duk
 髑	duk
 黩	duk
-黷	duk	500
+黷	duk
 𡰪	duk
 𢽴	duk
 𦢌	duk
@@ -5721,31 +5722,31 @@ min_phrase_weight: 100
 东	dung
 侗	dung
 侗	tung
-冬	dung	1000
+冬	dung
 冻	dung
-凍	dung	1000
+凍	dung
 动	dung
-動	dung	1000
-咚	dung	1000
+動	dung
+咚	dung
 垌	dung
 垌	tung
 峒	dung
 峒	tung
 崠	dung
-恫	dung	500
-恫	tung	500
+恫	dung
+恫	tung
 恸	dung
-慟	dung	500
-懂	dung	1000
+慟	dung
+懂	dung
 挏	dung
 挏	tung
-東	dung	1000
+東	dung
 柊	dung
 柊	zung
 栋	dung
-棟	dung	1000
+棟	dung
 氡	dung
-洞	dung	1000
+洞	dung
 涷	dung
 湩	dung
 炵	dung
@@ -5753,22 +5754,22 @@ min_phrase_weight: 100
 畽	dung
 畽	teon
 硐	dung
-胴	dung	500
-董	dung	1000
+胴	dung
+董	dung
 蕫	dung
 蝀	dung
 衕	dung
 衕	tung
-踵	dung	500
-踵	zung	500
+踵	dung
+踵	zung
 迵	dung
 鮦	dung
 鮦	tung
 鮦	zau
 鶇	dung
 鸫	dung
-鼕	dung	500
-鼕	tung	500
+鼕	dung
+鼕	tung
 㫁	dyun
 㱭	dyun
 䠪	dyun
@@ -5779,31 +5780,31 @@ min_phrase_weight: 100
 剬	zai
 断	dyun
 断	tyun
-斷	dyun	1000
-斷	tyun	501
+斷	dyun
+斷	tyun
 椴	dyun
-段	dyun	1000
+段	dyun
 毈	dyun
 毈	wo
 煅	dyun
 煆	dyun
 煆	haa
-短	dyun	1000
+短	dyun
 碫	dyun
-端	dyun	1000
+端	dyun
 簖	dyun
 籪	dyun
-緞	dyun	500
+緞	dyun
 缎	dyun
 耑	dyun
 耑	zyun
 腶	dyun
-鍛	dyun	1000
+鍛	dyun
 鍜	dyun
 锻	dyun
 㣞	dyut
 夺	dyut
-奪	dyut	1000
+奪	dyut
 敓	dyut
 罬	dyut
 罬	zyut
@@ -5817,13 +5818,13 @@ min_phrase_weight: 100
 㩛	faa
 㩛	tyun
 㳸	faa
-化	faa	1000
+化	faa
 擭	faa
 擭	wok
 杹	faa
-花	faa	1000
+花	faa
 華	faa	0%
-華	waa	1000
+華	waa
 蘤	faa
 㕒	faai
 㕒	waai
@@ -5844,20 +5845,20 @@ min_phrase_weight: 100
 䘗	gwan
 䘗	pui
 䠊	faai
-傀	faai	500
-傀	gwai	500
+傀	faai
+傀	gwai
 哙	faai
 噲	faai
 块	faai
-塊	faai	1000
-快	faai	1000
+塊	faai
+快	faai
 磈	faai
-筷	faai	1000
+筷	faai
 𫂈	faai
-拂	faak	500
-拂	fat	500
+拂	faak
+拂	fat
 沸	faak	0%
-沸	fai	1000
+沸	fai
 㕨	faan
 㖧	faan
 㠶	faan
@@ -5888,61 +5889,61 @@ min_phrase_weight: 100
 䴊	faan
 䴊	gon
 䴊	zi
-凡	faan	1000
+凡	faan
 凢	faan
-反	faan	1000
+反	faan
 墦	faan
-帆	faan	1000
+帆	faan
 幡	faan
 旛	faan
-梵	faan	500
-樊	faan	500
-氾	faan	1000
+梵	faan
+樊	faan
+氾	faan
 汎	faan
-泛	faan	1000
+泛	faan
 瀿	faan
 烦	faan
-煩	faan	1000
+煩	faan
 燔	faan
-犯	faan	1000
+犯	faan
 璠	faan
 畈	faan
 畨	faan
-番	faan	1000
+番	faan
 番	pun	0%
 矾	faan
-礬	faan	500
+礬	faan
 笲	faan
 笵	faan
-範	faan	1000
-繁	faan	1000
+範	faan
+繁	faan
 繙	faan
 羳	faan
-翻	faan	1000
+翻	faan
 膰	faan
-范	faan	500
-蕃	faan	500
+范	faan
+蕃	faan
 薠	faan
-藩	faan	500
+藩	faan
 蘩	faan
 蟠	faan
 蟠	pun
 蠜	faan
 覂	faan
 覂	fung
-販	faan	1000
+販	faan
 贩	faan
 蹯	faan
 軓	faan
 軬	faan
 轓	faan
-返	faan	1000
+返	faan
 釩	faan
 鋄	faan
 鐇	faan
 钒	faan
 颿	faan
-飯	faan	1000
+飯	faan
 饭	faan
 鷭	faan
 𠆩	faan
@@ -5977,13 +5978,13 @@ min_phrase_weight: 100
 发	faat
 沷	faat
 沷	fat
-法	faat	1000
+法	faat
 珐	faat
-琺	faat	500
-發	faat	1000
-砝	faat	500
-砝	fat	500
-髮	faat	1000
+琺	faat
+發	faat
+砝	faat
+砝	fat
+髮	faat
 𠵽	faat
 㕻	faau
 㕻	fu
@@ -6027,19 +6028,19 @@ min_phrase_weight: 100
 䶐	fai
 俷	fai
 俷	fei
-吠	fai	1000
+吠	fai
 废	fai
 廃	fai
-廢	fai	1000
-徽	fai	1000
+廢	fai
+徽	fai
 怫	fai
 怫	fat
 挥	fai
-揮	fai	1000
+揮	fai
 撝	fai
 昲	fai
 晖	fai
-暉	fai	1000
+暉	fai
 楎	fai
 楎	wan
 櫠	fai
@@ -6047,27 +6048,27 @@ min_phrase_weight: 100
 煇	wai
 疿	fai
 疿	fei
-痱	fai	500
-痱	fei	500
+痱	fai
+痱	fei
 癈	fai
 翬	fai
-肺	fai	1000
+肺	fai
 芾	fai
 芾	fat
 虧	fai	0%
-虧	kwai	1000
+虧	kwai
 袆	fai
 袚	fai
 袚	fat
 褘	fai
 费	fai
-輝	fai	1000
+輝	fai
 辉	fai
 鐨	fai
 镄	fai
 隳	fai
 鰴	fai
-麾	fai	500
+麾	fai
 瞓	fan	1000
 㓩	fan
 㓩	hin
@@ -6104,24 +6105,24 @@ min_phrase_weight: 100
 僨	fan
 分	fan
 勋	fan
-勛	fan	1000
+勛	fan
 勳	fan
-吩	fan	1000
+吩	fan
 噴	fan	0%
-噴	pan	1000
+噴	pan
 坆	fan
 坟	fan
-墳	fan	1000
+墳	fan
 奋	fan
-奮	fan	1000
+奮	fan
 妢	fan
-婚	fan	1000
+婚	fan
 幩	fan
-忿	fan	1000
+忿	fan
 惛	fan
 愤	fan
-憤	fan	1000
-昏	fan	1000
+憤	fan
+昏	fan
 曛	fan
 枌	fan
 棔	fan
@@ -6130,16 +6131,16 @@ min_phrase_weight: 100
 歕	fan
 歕	pan
 殙	fan
-氛	fan	1000
-汾	fan	500
+氛	fan
+汾	fan
 涽	fan
 濆	fan
 濆	pan
 瀵	fan
 焄	fan
-焚	fan	1000
+焚	fan
 熏	fan
-燻	fan	500
+燻	fan
 獯	fan
 痻	fan
 痻	man
@@ -6149,10 +6150,10 @@ min_phrase_weight: 100
 窨	jam
 籸	fan
 籸	saam
-粉	fan	1000
+粉	fan
 粪	fan
-糞	fan	1000
-紛	fan	1000
+糞	fan
+紛	fan
 緡	fan
 緡	man
 纁	fan
@@ -6163,20 +6164,20 @@ min_phrase_weight: 100
 羵	fan
 翂	fan
 臐	fan
-芬	fan	1000
+芬	fan
 荤	fan
-葷	fan	500
+葷	fan
 蒶	fan
 蕡	fan
-薰	fan	1000
+薰	fan
 蚡	fan
-訓	fan	1000
+訓	fan
 训	fan
 豮	fan
 豶	fan
 轒	fan
 酚	fan
-醺	fan	500
+醺	fan
 閽	fan
 阍	fan
 雰	fan
@@ -6205,8 +6206,8 @@ min_phrase_weight: 100
 䨚	fat
 䬍	fat
 䴯	fat
-乏	fat	1000
-伐	fat	1000
+乏	fat
+伐	fat
 刜	fat
 咈	fat
 唿	fat
@@ -6220,13 +6221,13 @@ min_phrase_weight: 100
 巿	fat
 巿	si
 帗	fat
-弗	fat	1000
-彿	fat	1000
-忽	fat	1000
-惚	fat	1000
+弗	fat
+彿	fat
+忽	fat
+惚	fat
 昒	fat
 曶	fat
-氟	fat	500
+氟	fat
 淴	fat
 狒	fat
 狒	fei
@@ -6235,20 +6236,20 @@ min_phrase_weight: 100
 祓	fat
 笏	fat
 笰	fat
-筏	fat	500
+筏	fat
 紱	fat
-紼	fat	500
+紼	fat
 绂	fat
 绋	fat
 罚	fat
-罰	fat	1000
+罰	fat
 艴	fat
 芴	fat
 芴	mat
 茀	fat
 茷	fat
 茷	pui
-閥	fat	500
+閥	fat
 阀	fat
 韍	fat
 韨	fat
@@ -6257,21 +6258,21 @@ min_phrase_weight: 100
 魆	jyut
 黻	fat
 𦡆	fat
-剖	fau	1000
+剖	fau
 剖	pau	0%
-否	fau	1000
+否	fau
 否	pei	0%
 峊	fau
 復	fau	0%
-復	fuk	1000
-浮	fau	1000
+復	fuk
+浮	fau
 涪	fau
 烰	fau
 琈	fau
 稃	fau
 稃	fu
 紑	fau
-缶	fau	500
+缶	fau
 罘	fau
 罦	fau
 罦	fu
@@ -6280,12 +6281,12 @@ min_phrase_weight: 100
 蜉	fau
 裒	fau
 裒	pau
-覆	fau	1000
-覆	fuk	1000
-阜	fau	500
+覆	fau
+覆	fuk
+阜	fau
 鴀	fau
 𧌓	fau
-啡	fe	1000
+啡	fe
 啡	fei	0%
 㥱	fei
 㫵	fei
@@ -6297,14 +6298,14 @@ min_phrase_weight: 100
 䩁	fei
 䬠	fei
 剕	fei
-匪	fei	1000
+匪	fei
 厞	fei
-妃	fei	1000
+妃	fei
 婓	fei
 屝	fei
 悱	fei
-扉	fei	1000
-斐	fei	500
+扉	fei
+斐	fei
 朏	fei
 棐	fei
 榧	fei
@@ -6312,20 +6313,20 @@ min_phrase_weight: 100
 篚	fei
 緋	fei
 绯	fei
-翡	fei	1000
-肥	fei	1000
+翡	fei
+肥	fei
 胐	fei
 腓	fei
-菲	fei	1000
-蜚	fei	500
+菲	fei
+蜚	fei
 蜰	fei
 裶	fei
 誹	fei
 诽	fei
 陫	fei
-霏	fei	500
-非	fei	1000
-飛	fei	1000
+霏	fei
+非	fei
+飛	fei
 飞	fei
 馡	fei
 騑	fei
@@ -6351,28 +6352,28 @@ min_phrase_weight: 100
 䌀	fo
 䍫	fo
 䍫	to
-伙	fo	1000
+伙	fo
 吙	fo
 吙	hoe
 堁	fo
-夥	fo	1000
-棵	fo	1000
+夥	fo
+棵	fo
 棵	po	0%
-火	fo	1000
-科	fo	1000
+火	fo
+科	fo
 稞	fo
-窠	fo	500
-窠	wo	500
+窠	fo
+窠	wo
 窾	fo
 窾	fun
-蝌	fo	500
-課	fo	1000
+蝌	fo
+課	fo
 课	fo
-貨	fo	1000
+貨	fo
 货	fo
 鈥	fo
 钬	fo
-顆	fo	1000
+顆	fo
 颗	fo
 騍	fo
 骒	fo
@@ -6388,7 +6389,7 @@ min_phrase_weight: 100
 彏	fok
 戄	fok
 攉	fok
-攫	fok	500
+攫	fok
 玃	fok
 矍	fok
 臛	fok
@@ -6403,7 +6404,7 @@ min_phrase_weight: 100
 钁	fok
 钁	kyut
 镢	fok
-霍	fok	1000
+霍	fok
 㑂	fong
 㑂	pong
 㕫	fong
@@ -6428,48 +6429,48 @@ min_phrase_weight: 100
 䌙	fong
 䢍	fong
 䲱	fong
-仿	fong	1000
-倣	fong	500
+仿	fong
+倣	fong
 况	fong
 匚	fong
-坊	fong	1000
-妨	fong	1000
+坊	fong
+妨	fong
 巟	fong
-幌	fong	500
-彷	fong	1000
+幌	fong
+彷	fong
 彷	pong	0%
 怳	fong
-恍	fong	1000
-慌	fong	1000
-房	fong	1000
-放	fong	1000
-方	fong	1000
+恍	fong
+慌	fong
+房	fong
+放	fong
+方	fong
 昉	fong
-晃	fong	1000
+晃	fong
 枋	fong
 榥	fong
 汸	fong
 汸	pong
-況	fong	1000
+況	fong
 滉	fong
 熀	fong
 瓬	fong
 瓬	ling
 皝	fong
-紡	fong	1000
+紡	fong
 絖	fong
 絖	kong
 絖	kwong
 纺	fong
-肓	fong	500
-肪	fong	1000
-舫	fong	500
-芳	fong	1000
-荒	fong	1000
+肓	fong
+肪	fong
+舫	fong
+芳	fong
+荒	fong
 衁	fong
-訪	fong	1000
+訪	fong
 詤	fong
-謊	fong	1000
+謊	fong
 访	fong
 谎	fong
 貺	fong
@@ -6477,11 +6478,11 @@ min_phrase_weight: 100
 邡	fong
 鈁	fong
 钫	fong
-防	fong	1000
+防	fong
 髣	fong
 魴	fong
 鲂	fong
-戲	fu	0
+戲	fu	0%
 戲	hei	1
 㐻	fu
 㐻	mou
@@ -6547,51 +6548,51 @@ min_phrase_weight: 100
 䴣	fu
 䴸	fu
 䵾	fu
-乎	fu	1000
+乎	fu
 乎	wu	0%
-仆	fu	500
-仆	puk	500
-付	fu	1000
-伕	fu	500
-俘	fu	1000
+仆	fu
+仆	puk
+付	fu
+伕	fu
+俘	fu
 俛	fu
 俛	min
-俯	fu	1000
+俯	fu
 偩	fu
-傅	fu	1000
+傅	fu
 凫	fu
 刳	fu
-副	fu	1000
-呼	fu	1000
-咐	fu	1000
-唬	fu	500
+副	fu
+呼	fu
+咐	fu
+唬	fu
 嘸	fu
 嘸	mou
 垺	fu
 垺	pau
-夫	fu	1000
+夫	fu
 妇	fu
-婦	fu	1000
-孚	fu	500
-孵	fu	1000
-富	fu	1000
+婦	fu
+孚	fu
+孵	fu
+富	fu
 尃	fu
 幠	fu
 库	fu
-府	fu	1000
-庫	fu	1000
+府	fu
+庫	fu
 弣	fu
 戽	fu
-扶	fu	1000
+扶	fu
 抚	fu
 拊	fu
 挎	fu
 挎	kwaa
-撫	fu	1000
-敷	fu	1000
-斧	fu	1000
+撫	fu
+敷	fu
+斧	fu
 枎	fu
-枯	fu	1000
+枯	fu
 枹	fu
 柎	fu
 桴	fu
@@ -6602,33 +6603,33 @@ min_phrase_weight: 100
 泭	fu
 滏	fu
 滹	fu
-父	fu	1000
-琥	fu	500
-甫	fu	1000
+父	fu
+琥	fu
+甫	fu
 甫	pou	0%
 痡	fu
 痡	pou
 盙	fu
 砆	fu
 祔	fu
-符	fu	1000
+符	fu
 箍	fu
 箍	ku
 簠	fu
 絝	fu
 肤	fu
 胕	fu
-脯	fu	500
-脯	pou	500
-腐	fu	1000
-腑	fu	500
+脯	fu
+脯	pou
+腐	fu
+腑	fu
 膍	fu
 膍	pei
-膚	fu	1000
+膚	fu
 膴	fu
 膴	mou
-芙	fu	500
-苦	fu	1000
+芙	fu
+苦	fu
 苻	fu
 荴	fu
 莆	fu
@@ -6636,7 +6637,7 @@ min_phrase_weight: 100
 莩	fu
 莩	piu
 虍	fu
-虎	fu	1000
+虎	fu
 虖	fu
 蚨	fu
 蚹	fu
@@ -6646,39 +6647,39 @@ min_phrase_weight: 100
 袴	fu
 裤	fu
 褔	fu
-褲	fu	1000
-訃	fu	500
+褲	fu
+訃	fu
 謼	fu
 讣	fu
-負	fu	1000
-賦	fu	1000
+負	fu
+賦	fu
 賻	fu
 负	fu
 赋	fu
 赙	fu
-赴	fu	1000
+赴	fu
 趺	fu
 跗	fu
 軵	fu
 軵	jung
-輔	fu	1000
+輔	fu
 辅	fu
 郙	fu
 郛	fu
 鄜	fu
-釜	fu	500
+釜	fu
 鈇	fu
-附	fu	1000
+附	fu
 頫	fu
 颫	fu
-駙	fu	500
+駙	fu
 驸	fu
-骷	fu	500
+骷	fu
 鮒	fu
 鲋	fu
 鳧	fu
 鳺	fu
-麩	fu	500
+麩	fu
 麱	fu
 麸	fu
 黼	fu
@@ -6707,15 +6708,15 @@ min_phrase_weight: 100
 䵋	fui
 䵋	kui
 喙	fui
-奎	fui	500
-奎	kwai	500
-恢	fui	1000
-悔	fui	1000
+奎	fui
+奎	kwai
+恢	fui
+悔	fui
 悝	fui
-晦	fui	500
+晦	fui
 櫆	fui
 洧	fui
-灰	fui	1000
+灰	fui
 痏	fui
 痗	fui
 痗	mui
@@ -6728,13 +6729,13 @@ min_phrase_weight: 100
 虺	wai
 襘	fui
 襘	kui
-詼	fui	500
-誨	fui	1000
+詼	fui
+誨	fui
 诙	fui
 诲	fui
 豗	fui
 賄	fui	0%
-賄	kui	1000
+賄	kui
 贿	fui
 闠	fui
 闠	gwai
@@ -6743,7 +6744,7 @@ min_phrase_weight: 100
 靧	fui
 顪	fui
 顪	wai
-魁	fui	500
+魁	fui
 鮪	fui
 鲔	fui
 𠧩	fui
@@ -6765,25 +6766,25 @@ min_phrase_weight: 100
 复	fuk
 宓	fuk
 宓	mat
-幅	fuk	1000
-服	fuk	1000
+幅	fuk
+服	fuk
 洑	fuk
-福	fuk	1000
+福	fuk
 箙	fuk
-腹	fuk	1000
+腹	fuk
 茯	fuk
 葍	fuk
 蕧	fuk
 虙	fuk
-蝠	fuk	1000
+蝠	fuk
 蝮	fuk
-袱	fuk	1000
-複	fuk	1000
+袱	fuk
+複	fuk
 輹	fuk
-輻	fuk	1000
+輻	fuk
 辐	fuk
 鍑	fuk
-馥	fuk	500
+馥	fuk
 鰒	fuk
 鳆	fuk
 鴔	fuk
@@ -6803,19 +6804,19 @@ min_phrase_weight: 100
 䥗	fun
 䲌	fun
 喚	fun	0%
-喚	wun	1000
+喚	wun
 嚾	fun
 宽	fun
-寬	fun	1000
+寬	fun
 懽	fun
 梡	fun
 欢	fun
 欵	fun
-款	fun	1000
-歡	fun	1000
+款	fun
+歡	fun
 獾	fun
-盥	fun	500
-盥	gun	500
+盥	fun
+盥	gun
 窽	fun
 臗	fun
 讙	fun
@@ -6851,57 +6852,57 @@ min_phrase_weight: 100
 䩼	fung
 䵄	fung
 丰	fung
-俸	fung	500
+俸	fung
 冯	fung
 凤	fung
 唪	fung
 夆	fung
-奉	fung	1000
+奉	fung
 妦	fung
-封	fung	1000
-峯	fung	1000
+封	fung
+峯	fung
 峰	fung
 崶	fung
 摓	fung
 枫	fung
-楓	fung	1000
+楓	fung
 沣	fung
 渢	fung
 灃	fung
-烽	fung	1000
+烽	fung
 犎	fung
 甮	fung
 疯	fung
-瘋	fung	1000
-縫	fung	1000
+瘋	fung
+縫	fung
 缝	fung
 葑	fung
 蓬	fung	0%
-蓬	pung	1000
+蓬	pung
 蘴	fung
-蜂	fung	1000
+蜂	fung
 蠭	fung
-諷	fung	1000
+諷	fung
 讽	fung
-豐	fung	1000
+豐	fung
 賵	fung
 赗	fung
-逢	fung	1000
+逢	fung
 酆	fung
-鋒	fung	1000
+鋒	fung
 锋	fung
-風	fung	1000
+風	fung
 飌	fung
 风	fung
-馮	fung	500
-馮	pang	500
-鳳	fung	1000
+馮	fung
+馮	pang
+鳳	fung
 麷	fung
 䦢	fut
 濶	fut
 蛞	fut
 蛞	kut
-闊	fut	1000
+闊	fut
 阔	fut
 㗎	gaa	1000
 㗇	gaa
@@ -6919,26 +6920,26 @@ min_phrase_weight: 100
 䑝	gaa
 䕒	gaa
 䴥	gaa
-伽	gaa	500
-伽	ke	500
-假	gaa	1000
-傢	gaa	1000
-價	gaa	1000
-加	gaa	1000
-咖	gaa	1000
+伽	gaa
+伽	ke
+假	gaa
+傢	gaa
+價	gaa
+加	gaa
+咖	gaa
 咖	kaa	0%
-嘉	gaa	1000
+嘉	gaa
 嘎	gaa
 嘏	gaa
 嘏	gu
 噶	gaa
-嫁	gaa	1000
-家	gaa	1000
-家	gu	0
+嫁	gaa
+家	gaa
+家	gu	0%
 尕	gaa
 幏	gaa
 斝	gaa
-架	gaa	1000
+架	gaa
 枷	gaa
 椵	gaa
 榎	gaa
@@ -6953,23 +6954,23 @@ min_phrase_weight: 100
 瘕	haa
 癿	gaa
 癿	ke
-稼	gaa	1000
+稼	gaa
 笳	gaa
 耞	gaa
-茄	gaa	1000
-茄	ke	1000
+茄	gaa
+茄	ke
 葭	gaa
-袈	gaa	500
+袈	gaa
 豭	gaa
-賈	gaa	1000
-賈	gu	200
+賈	gaa
+賈	gu
 贾	gaa
 贾	gu
 跏	gaa
-迦	gaa	500
+迦	gaa
 鎵	gaa
 镓	gaa
-駕	gaa	1000
+駕	gaa
 驾	gaa
 鴐	gaa
 𠺢	gaa
@@ -6993,47 +6994,47 @@ min_phrase_weight: 100
 䲸	gaai
 䳶	gaai
 䳶	haai
-介	gaai	1000
+介	gaai
 价	gaai
-佳	gaai	1000
-偕	gaai	1000
+佳	gaai
+偕	gaai
 喈	gaai
 堦	gaai
 妎	gaai
 妎	hai
-尬	gaai	500
-屆	gaai	1000
+尬	gaai
+屆	gaai
 届	gaai
 廨	gaai
 廨	haai
 悈	gaai
 懈	gaai	0%
-懈	haai	1000
-戒	gaai	1000
+懈	haai
+戒	gaai
 楷	gaai	0%
-楷	kaai	1000
+楷	kaai
 檞	gaai
 檞	haai
 湝	gaai
 犗	gaai
 玠	gaai
-界	gaai	1000
-疥	gaai	500
+界	gaai
+疥	gaai
 痎	gaai
-皆	gaai	1000
+皆	gaai
 秸	gaai
-芥	gaai	500
+芥	gaai
 薢	gaai
 蚧	gaai
 蝔	gaai
-街	gaai	1000
-解	gaai	1000
+街	gaai
+解	gaai
 解	haai	0%
 觧	gaai
-誡	gaai	1000
+誡	gaai
 诫	gaai
 阶	gaai
-階	gaai	1000
+階	gaai
 骱	gaai
 骱	haai
 𠝹	gaai
@@ -7045,9 +7046,9 @@ min_phrase_weight: 100
 䪂	gaak
 仡	gaak
 仡	ngat
-咯	gaak	500
+咯	gaak
 咯	lo	1000
-咯	lok	500
+咯	lok
 嗝	gaak
 圪	gaak
 圪	ngat
@@ -7059,23 +7060,23 @@ min_phrase_weight: 100
 曱	gaat
 曱	gat
 曱	zaat
-格	gaak	1000
+格	gaak
 滆	gaak
 翮	gaak
 翮	hat
-胳	gaak	1000
+胳	gaak
 胳	lok	0%
-膈	gaak	500
+膈	gaak
 茖	gaak
 茖	gok
 觡	gaak
 鎘	gaak
 镉	gaak
-隔	gaak	1000
-革	gaak	1000
-革	gaap	200
+隔	gaak
+革	gaak
+革	gaap
 革	gik	0%
-骼	gaak	1000
+骼	gaak
 鬲	gaak
 鬲	lik
 𠺝	gaak
@@ -7106,21 +7107,21 @@ min_phrase_weight: 100
 减	gaam
 尲	gaam
 尴	gaam
-尷	gaam	500
+尷	gaam
 椷	gaam
-橄	gaam	1000
+橄	gaam
 橄	gam	0%
 淦	gaam
 淦	gam
-減	gaam	1000
+減	gaam
 监	gaam
-監	gaam	1000
-緘	gaam	500
-緘	zin	500
+監	gaam
+緘	gaam
+緘	zin
 缄	gaam
 鉴	gaam
-鑑	gaam	1000
-鑒	gaam	1000
+鑑	gaam
+鑒	gaam
 揀	gaan	3
 㢙	gaan
 㢙	kaan
@@ -7138,41 +7139,41 @@ min_phrase_weight: 100
 䰙	gei
 䰙	ngaai
 堿	gaan
-奸	gaan	1000
-姦	gaan	500
+奸	gaan
+姦	gaan
 拣	gaan
 枧	gaan
-柬	gaan	1000
+柬	gaan
 梘	gaan
 橺	gaan
 涧	gaan
-澗	gaan	500
+澗	gaan
 瞷	gaan
 硷	gaan
 碱	gaan
 筧	gaan
 筧	gan
 简	gaan
-簡	gaan	1000
-繭	gaan	500
-艱	gaan	1000
+簡	gaan
+繭	gaan
+艱	gaan
 茧	gaan
 茧	gin
-菅	gaan	500
+菅	gaan
 葌	gaan
 蕑	gaan
 襉	gaan
 襺	gaan
 襺	gin
-諫	gaan	1000
+諫	gaan
 谏	gaan
 鐧	gaan
 閒	gaan	0%
-閒	haan	1000
-間	gaan	1000
+閒	haan
+間	gaan
 间	gaan
 鹻	gaan
-鹼	gaan	500
+鹼	gaan
 𢵧	gaan
 㪅	gaang
 㪅	sing
@@ -7184,10 +7185,10 @@ min_phrase_weight: 100
 浭	gaang
 浭	gang
 畊	gaang
-耕	gaang	1000
+耕	gaang
 耕	gang	0%
-逕	gaang	500
-逕	ging	500
+逕	gaang
+逕	ging
 𨁈	gaang
 㕅	gaap
 㝓	gaap
@@ -7204,23 +7205,23 @@ min_phrase_weight: 100
 䲯	kaap
 唊	gaap
 夹	gaap
-夾	gaap	1000
-夾	gap	501
-夾	gep	501
-夾	gip	501
+夾	gaap
+夾	gap
+夾	gep
+夾	gip
 岬	gaap
 搿	gaap
 梜	gaap
 浹	gaap
 浹	zip
-甲	gaap	1000
-胛	gaap	500
+甲	gaap
+胛	gaap
 舺	gaap
 荚	gaap
-莢	gaap	500
-蛤	gaap	500
-蛤	gap	500
-蛤	haa	500
+莢	gaap
+蛤	gaap
+蛤	gap
+蛤	haa
 蛱	gaap
 蛺	gaap
 袷	gaap
@@ -7228,17 +7229,17 @@ min_phrase_weight: 100
 跲	gaap
 郏	gaap
 郟	gaap
-鉀	gaap	500
+鉀	gaap
 鋏	gaap
 钾	gaap
 铗	gaap
 鞈	gaap
 韐	gaap
-頰	gaap	1000
-頰	haap	200
+頰	gaap
+頰	haap
 颊	gaap
 鴿	gaap	0%
-鴿	gap	1000
+鴿	gap
 鵊	gaap
 㔕	gaat
 㔕	kaau
@@ -7247,8 +7248,8 @@ min_phrase_weight: 100
 䢀	gaat
 甴	gaat
 甴	zaat	1000
-軋	gaat	500
-軋	zaat	500
+軋	gaat
+軋	zaat
 轧	gaat
 轧	zaat
 釓	gaat
@@ -7303,33 +7304,33 @@ min_phrase_weight: 100
 䲫	gaau
 䲫	kaau
 䴔	gaau
-交	gaau	1000
+交	gaau
 佼	gaau
-姣	gaau	500
-姣	haau	500
+姣	gaau
+姣	haau
 搅	gaau
 撹	gaau
 敎	gaau
-教	gaau	1000
+教	gaau
 斠	gaau
 斠	gau
 斠	gok
-校	gaau	1000
-校	haau	1000
+校	gaau
+校	haau
 滘	gaau
 漖	gaau
-狡	gaau	1000
+狡	gaau
 珓	gaau
-皎	gaau	1000
+皎	gaau
 窌	gaau
-窖	gaau	500
+窖	gaau
 筊	gaau
-絞	gaau	500
+絞	gaau
 绞	gaau
 胶	gaau
-膠	gaau	1000
+膠	gaau
 茭	gaau
-蛟	gaau	500
+蛟	gaau
 覐	gaau
 覐	gok
 覚	gaau
@@ -7337,19 +7338,19 @@ min_phrase_weight: 100
 觉	gaau
 觉	gok
 跤	gaau
-較	gaau	1000
+較	gaau
 轇	gaau
 较	gaau
-郊	gaau	1000
-酵	gaau	500
-酵	haau	500
+郊	gaau
+酵	gaau
+酵	haau
 鉸	gaau
 铰	gaau
-餃	gaau	1000
+餃	gaau
 饺	gaau
 骹	gaau
 骹	haau
-鮫	gaau	500
+鮫	gaau
 鲛	gaau
 鵁	gaau
 偈	gai	1000
@@ -7373,7 +7374,7 @@ min_phrase_weight: 100
 笄	gai
 筀	gai
 紒	gai
-繼	gai	1000
+繼	gai
 继	gai
 罽	gai
 蓟	gai
@@ -7381,11 +7382,11 @@ min_phrase_weight: 100
 蘮	gai
 蟿	gai
 蟿	kai
-計	gai	1000
+計	gai
 計	gei	0%
 计	gai
-雞	gai	1000
-髻	gai	500
+雞	gai
+髻	gai
 鷄	gai
 鸡	gai
 枅	gai
@@ -7413,30 +7414,30 @@ min_phrase_weight: 100
 䛓	gam
 䛓	ham
 䲺	gam
-今	gam	1000
+今	gam
 僸	gam
 冚	gam
 冚	ham	1000
 冚	kam
 凎	gam
-噤	gam	500
-噤	kam	500
+噤	gam
+噤	kam
 坅	gam
 坅	jam
-感	gam	1000
+感	gam
 揿	gam
 搇	gam
 搇	kam
 撳	gam
-敢	gam	1000
-柑	gam	500
+敢	gam
+柑	gam
 泔	gam
 澉	gam
 灨	gam
-甘	gam	1000
-疳	gam	500
-禁	gam	1000
-禁	kam	501
+甘	gam
+疳	gam
+禁	gam
+禁	kam
 紟	gam
 紟	kam
 紺	gam
@@ -7444,11 +7445,11 @@ min_phrase_weight: 100
 苷	gam
 衿	gam
 衿	kam
-贛	gam	500
-贛	gung	500
+贛	gam
+贛	gung
 赣	gam
-金	gam	1000
-錦	gam	1000
+金	gam
+錦	gam
 锦	gam
 鰔	gam
 鰔	zam
@@ -7475,18 +7476,18 @@ min_phrase_weight: 100
 䵤	gan
 仅	gan
 伒	gan
-僅	gan	1000
+僅	gan
 哏	gan
 堇	gan
 墐	gan
 峎	gan
 峎	jan
 巹	gan
-巾	gan	1000
+巾	gan
 廑	gan
 廑	kan
-斤	gan	1000
-根	gan	1000
+斤	gan
+根	gan
 槿	gan
 殣	gan
 瑾	gan
@@ -7494,23 +7495,23 @@ min_phrase_weight: 100
 瘽	kan
 硍	gan
 笕	gan
-筋	gan	1000
+筋	gan
 紧	gan
-艮	gan	500
+艮	gan
 艰	gan
 茛	gan
 茛	loeng
 茛	long
 菫	gan
 蓳	gan
-覲	gan	500
+覲	gan
 觐	gan
 觔	gan
-謹	gan	1000
+謹	gan
 谨	gan
-跟	gan	1000
-近	gan	1000
-近	kan	501
+跟	gan
+近	gan
+近	kan
 釿	gan
 靳	gan
 饉	gan
@@ -7523,25 +7524,25 @@ min_phrase_weight: 100
 䱍	gang
 䱎	gang
 䱭	gang
-亙	gang	500
+亙	gang
 埂	gang
 堩	gang
-庚	gang	1000
-梗	gang	500
-梗	gwaang	500
+庚	gang
+梗	gang
+梗	gwaang
 焿	gang
 熲	gang
 熲	gwing
 熲	wing
 秔	gang
 稉	gang
-粳	gang	500
+粳	gang
 綆	gang
 緪	gang
 绠	gang
 羮	gang
-羹	gang	1000
-耿	gang	500
+羹	gang
+耿	gang
 賡	gang
 赓	gang
 郠	gang
@@ -7570,25 +7571,25 @@ min_phrase_weight: 100
 䛟	gap
 䧻	gap
 及	gap	0%
-及	kap	1000
+及	kap
 合	gap	0%
-合	hap	1000
-岌	gap	500
-岌	kap	500
+合	hap
+岌	gap
+岌	kap
 峆	gap
 峆	hap
 忣	gap
-急	gap	1000
+急	gap
 芨	gap
 蓋	gap	0%
-蓋	goi	1000
+蓋	goi
 蓋	hap	0%
-蓋	koi	1000
+蓋	koi
 郃	gap
 郃	hap
-閤	gap	500
-閤	gok	500
-閤	hap	500
+閤	gap
+閤	gok
+閤	hap
 頜	gap
 頜	hap
 颌	gap
@@ -7608,26 +7609,26 @@ min_phrase_weight: 100
 佶	git
 吃	gat	0%
 吃	hat	0%
-吃	hek	1000
-吃	jaak	501
-吉	gat	1000
+吃	hek
+吃	jaak	4%
+吉	gat
 咭	gat
 咭	kaat
 咭	kat
 咭	kit
 姞	gat
-疙	gat	500
-紇	gat	500
-紇	hat	500
+疙	gat
+紇	gat
+紇	hat
 纥	gat
 肐	gat
 虼	gat
 蛣	gat
 蛣	kit
 訖	gat	0%
-訖	ngat	1000
-詰	gat	500
-詰	kit	500
+訖	ngat
+詰	gat
+詰	kit
 讫	gat
 讫	ngat
 诘	gat
@@ -7663,8 +7664,8 @@ min_phrase_weight: 100
 䰘	hip
 䰘	laau
 䲥	gau
-久	gau	1000
-九	gau	1000
+久	gau
+九	gau
 倃	gau
 傋	gau
 冓	gau
@@ -7672,18 +7673,18 @@ min_phrase_weight: 100
 勼	kau
 厩	gau
 句	gau	0%
-句	geoi	1000
-咎	gau	500
-咎	gou	500
+句	geoi
+咎	gau
+咎	gou
 嚿	gau
-垢	gau	1000
+垢	gau
 夂	gau
 夂	ji
 夂	zi
 够	gau
-夠	gau	1000
+夠	gau
 姤	gau
-媾	gau	500
+媾	gau
 岣	gau
 岣	keoi
 廄	gau
@@ -7695,28 +7696,28 @@ min_phrase_weight: 100
 搆	kau
 摎	gau
 摎	lau
-救	gau	1000
+救	gau
 旧	gau
 朻	gau
 构	gau
 构	kau
-枸	gau	500
-枸	geoi	500
-柩	gau	500
-構	gau	1000
-構	kau	1000
+枸	gau
+枸	geoi
+柩	gau
+構	gau
+構	kau
 樛	gau
 沟	gau
 泃	gau
 泃	geoi
 泃	keoi
 溝	gau	0%
-溝	kau	1000
-灸	gau	1000
-狗	gau	1000
-玖	gau	1000
-疚	gau	500
-究	gau	1000
+溝	kau
+灸	gau
+狗	gau
+玖	gau
+疚	gau
+究	gau
 笱	gau
 篝	gau
 簼	gau
@@ -7725,43 +7726,43 @@ min_phrase_weight: 100
 緱	kau
 纠	gau
 耇	gau
-舊	gau	1000
+舊	gau
 芶	gau
-苟	gau	1000
+苟	gau
 茍	gau
 袧	gau
 覯	gau
 觏	gau
-詬	gau	500
-詬	hau	500
+詬	gau
+詬	hau
 诟	gau
 诟	hau
-購	gau	1000
-購	kau	1000
+購	gau
+購	kau
 购	gau
-遘	gau	500
+遘	gau
 鈎	gau	0%
-鈎	ngau	1000
+鈎	ngau
 钩	gau
 钩	ngau
 阄	gau
 雊	gau
 韝	gau
-韭	gau	500
+韭	gau
 韮	gau
 鬮	gau
-鳩	gau	1000
+鳩	gau
 鳩	kau	0%
 鸠	gau
 鸠	kau
 龜	gau	0%
-龜	gwai	1000
+龜	gwai
 龜	gwan	0%
 龟	gau
 龟	gwai
 龟	gwan
 龜	gau	0%
-龜	gwai	1000
+龜	gwai
 龜	gwan	0%
 𠴰	gau
 𨳊	gau
@@ -7814,67 +7815,67 @@ min_phrase_weight: 100
 䢳	gei
 䩭	gei
 丌	gei
-乩	gei	500
+乩	gei
 伎	gei
 倛	gei
 倛	hei
 其	gei	0%
-其	kei	1000
-几	gei	500
+其	kei
+几	gei
 刉	gei
 剞	gei
 叽	gei
 唭	gei
 唭	kei
-嘰	gei	500
-基	gei	1000
-奇	gei	1000
-奇	kei	1000
-妓	gei	500
-姬	gei	1000
-寄	gei	1000
+嘰	gei
+基	gei
+奇	gei
+奇	kei
+妓	gei
+姬	gei
+寄	gei
 屺	gei
 屺	hei
-己	gei	1000
-幾	gei	1000
+己	gei
+幾	gei
 庋	gei
 庋	gwai
 庪	gei
 庪	gwai
-忌	gei	1000
+忌	gei
 忮	gei
 忮	zi
 惎	gei
-技	gei	1000
+技	gei
 掎	gei
 敧	gei
-既	gei	1000
+既	gei
 旣	gei
 朞	gei
 期	gei	0%
-期	kei	1000
+期	kei
 机	gei
-杞	gei	500
-機	gei	1000
+杞	gei
+機	gei
 洎	gei
-犄	gei	500
+犄	gei
 玑	gei
-璣	gei	500
+璣	gei
 畸	gei	0%
-畸	kei	1000
+畸	kei
 畿	gei
 矶	gei
-磯	gei	500
+磯	gei
 禨	gei
 稘	gei
 穊	gei
-箕	gei	500
-紀	gei	1000
+箕	gei
+紀	gei
 纪	gei
 羁	gei
 羇	gei
-羈	gei	1000
-肌	gei	1000
+羈	gei
+肌	gei
 芑	gei
 芑	hei
 芰	gei
@@ -7882,13 +7883,13 @@ min_phrase_weight: 100
 虮	gei
 蟣	gei
 覊	gei
-覬	gei	500
+覬	gei
 觊	gei
 觭	gei
 觭	kei
-記	gei	1000
+記	gei
 誋	gei
-譏	gei	500
+譏	gei
 讥	gei
 记	gei
 跽	gei
@@ -7899,12 +7900,12 @@ min_phrase_weight: 100
 錤	gei
 鐖	gei
 鞿	gei
-飢	gei	500
-饑	gei	1000
+飢	gei
+饑	gei
 饥	gei
 騎	gei	0%
-騎	ke	1000
-騎	kei	200
+騎	ke
+騎	kei	4%
 骩	gei
 鬾	gei
 鵋	gei
@@ -7916,12 +7917,12 @@ min_phrase_weight: 100
 𧝞	gei
 擏	geng
 擏	king
-鏡	geng	1000
+鏡	geng
 镜	geng
-頸	geng	1000
+頸	geng
 颈	geng
 驚	geng	0%
-驚	ging	1000
+驚	ging
 麠	geng
 麠	ging
 𢠃	geng
@@ -7947,28 +7948,28 @@ min_phrase_weight: 100
 䶚	geoi
 举	geoi
 俱	geoi	0%
-俱	keoi	1000
-倨	geoi	500
+俱	keoi
+倨	geoi
 倶	geoi
 偊	geoi
 偊	jyu
-具	geoi	1000
+具	geoi
 啹	geoi
 啹	goe
 啹	koe
 寠	geoi
 寠	lau
 寠	leoi
-居	geoi	1000
+居	geoi
 屦	geoi
 屨	geoi
 岠	geoi
 崌	geoi
-巨	geoi	1000
+巨	geoi
 惧	geoi
-懼	geoi	1000
+懼	geoi
 据	geoi
-據	geoi	1000
+據	geoi
 柜	geoi
 椇	geoi
 椐	geoi
@@ -7977,12 +7978,12 @@ min_phrase_weight: 100
 榉	geoi
 櫸	geoi
 澽	geoi
-炬	geoi	1000
+炬	geoi
 犋	geoi
 琚	geoi
-瞿	geoi	500
-瞿	keoi	500
-矩	geoi	1000
+瞿	geoi
+瞿	keoi
+矩	geoi
 秬	geoi
 窭	geoi
 窭	lau
@@ -7992,9 +7993,9 @@ min_phrase_weight: 100
 粔	geoi
 腒	geoi
 腒	keoi
-舉	geoi	1000
-苣	geoi	500
-莒	geoi	500
+舉	geoi
+苣	geoi
+莒	geoi
 萭	geoi
 萭	jyu
 蒟	geoi
@@ -8007,25 +8008,25 @@ min_phrase_weight: 100
 豦	geoi
 豦	keoi
 距	geoi	0%
-距	keoi	1000
+距	keoi
 踞	geoi
 踽	geoi
 躆	geoi
-遽	geoi	500
+遽	geoi
 醵	geoi
 醵	koek
 鉅	geoi
-鋸	geoi	1000
-鋸	goe	501
+鋸	geoi
+鋸	goe
 鐻	geoi
 鐻	keoi
 钜	geoi
 锯	geoi
-颶	geoi	1000
+颶	geoi
 飓	geoi
 駏	geoi
 鶋	geoi
-齲	geoi	500
+齲	geoi
 龋	geoi
 喼	gep
 喼	gip
@@ -8043,21 +8044,21 @@ min_phrase_weight: 100
 䁶	gik
 䓧	gik
 䩯	gik
-亟	gik	500
-亟	kei	500
+亟	gik
+亟	kei
 击	gik
 墼	gik
-戟	gik	500
+戟	gik
 撠	gik
 撽	gik
-擊	gik	1000
+擊	gik
 极	gik
 极	kap
-棘	gik	500
-極	gik	1000
+棘	gik
+極	gik
 殛	gik
 毄	gik
-激	gik	1000
+激	gik
 衱	gik
 衱	gip
 襋	gik
@@ -8068,22 +8069,22 @@ min_phrase_weight: 100
 㐸	him
 䯡	gim
 俭	gim
-儉	gim	1000
-兼	gim	1000
+儉	gim
+兼	gim
 剑	gim
-劍	gim	1000
+劍	gim
 捡	gim
 搛	gim
-撿	gim	1000
+撿	gim
 检	gim
 檐	gim
 檐	jam
 檐	jim
-檢	gim	1000
+檢	gim
 睑	gim
 瞼	gim
 瞼	lim
-縑	gim	500
+縑	gim
 缣	gim
 蒹	gim
 鰜	gim
@@ -8124,23 +8125,23 @@ min_phrase_weight: 100
 䵛	gin
 䵛	hin
 䶬	gin
-件	gin	1000
-健	gin	1000
+件	gin
+健	gin
 坚	gin
-堅	gin	1000
+堅	gin
 寋	gin
 幵	gin
 幵	hin
-建	gin	1000
+建	gin
 楗	gin
 楗	kin
-毽	gin	1000
-毽	jin	1000
+毽	gin
+毽	jin
 犍	gin
-肩	gin	1000
-腱	gin	500
+肩	gin
+腱	gin
 菺	gin
-見	gin	1000
+見	gin
 見	jin	0%
 见	gin
 謇	gin
@@ -8150,7 +8151,7 @@ min_phrase_weight: 100
 趼	jin
 蹇	gin
 鈃	gin
-鍵	gin	1000
+鍵	gin
 键	gin
 靬	gin
 鞬	gin
@@ -8169,16 +8170,16 @@ min_phrase_weight: 100
 䓳	haan
 䔔	ging
 䜘	ging
-京	ging	1000
+京	ging
 俓	ging
 倞	ging
 倞	loeng
-兢	ging	500
+兢	ging
 刭	ging
 剄	ging
 劲	ging
-勁	ging	1000
-境	ging	1000
+勁	ging
+境	ging
 墇	ging
 墇	zoeng
 婛	ging
@@ -8186,41 +8187,41 @@ min_phrase_weight: 100
 幜	ging
 弳	ging
 径	ging
-徑	ging	1000
+徑	ging
 惊	ging
-憬	ging	1000
+憬	ging
 憬	gwing	0%
 憼	ging
-敬	ging	1000
-景	ging	1000
+敬	ging
+景	ging
 景	jing	0%
 桱	ging
 殑	ging
 殑	king
 泾	ging
-涇	ging	500
+涇	ging
 獍	ging
 璚	ging
 璚	king
 璟	ging
 痉	ging
-痙	ging	1000
-矜	ging	500
-矜	gwaan	500
-矜	gwan	500
+痙	ging
+矜	ging
+矜	gwaan
+矜	gwan
 竞	ging
-竟	ging	1000
-競	ging	1000
-經	ging	1000
+竟	ging
+競	ging
+經	ging
 经	ging
 脛	ging
 脛	hing
 荆	ging
-荊	ging	1000
-莖	ging	1000
-莖	hang	1000
+荊	ging
+莖	ging
+莖	hang
 蟼	ging
-警	ging	1000
+警	ging
 迳	ging
 鵛	ging
 鶁	ging
@@ -8233,14 +8234,14 @@ min_phrase_weight: 100
 䂶	gip
 刦	gip
 刧	gip
-劫	gip	1000
+劫	gip
 抾	gip
 抾	keoi
-澀	gip	1000
-澀	saap	1000
+澀	gip
+澀	saap
 澀	sap	0%
 狹	gip	0%
-狹	haap	1000
+狹	haap
 硤	gip
 硤	haap
 陜	gip
@@ -8255,21 +8256,21 @@ min_phrase_weight: 100
 䥛	git
 䩤	git
 䩤	kit
-傑	git	1000
-拮	git	500
+傑	git
+拮	git
 撷	git
 撷	kit
 擷	git
 擷	kit
-杰	git	500
-桀	git	500
+杰	git
+桀	git
 榤	git
 洁	git
 滐	git
-潔	git	1000
+潔	git
 竭	git	0%
-竭	kit	1000
-結	git	1000
+竭	kit
+結	git
 結	lit	0%
 絜	git
 絜	kit
@@ -8277,8 +8278,8 @@ min_phrase_weight: 100
 袺	git
 襭	git
 襭	kit
-頡	git	500
-頡	kit	500
+頡	git
+頡	kit
 颉	git
 颉	kit
 鮚	git
@@ -8294,16 +8295,16 @@ min_phrase_weight: 100
 侥	giu
 侥	hiu
 僥	giu	0%
-僥	hiu	1000
+僥	hiu
 僥	jiu	0%
 儌	giu
 儌	hiu
-叫	giu	1000
+叫	giu
 呌	giu
 嘂	giu
 噭	giu
 娇	giu
-嬌	giu	1000
+嬌	giu
 嬓	giu
 峤	giu
 峤	kiu
@@ -8313,18 +8314,18 @@ min_phrase_weight: 100
 徼	jiu
 憍	giu
 撟	giu
-撬	giu	500
-撬	hiu	500
+撬	giu
+撬	hiu
 敿	giu
 浇	giu
 浇	hiu
-澆	giu	1000
+澆	giu
 澆	hiu	0%
 皦	giu
 矫	giu
-矯	giu	1000
+矯	giu
 矯	kiu	0%
-繳	giu	1000
+繳	giu
 繳	zoek	0%
 缴	giu
 蟜	giu
@@ -8332,9 +8333,9 @@ min_phrase_weight: 100
 譥	giu
 蹻	giu
 蹻	hiu
-轎	giu	1000
+轎	giu
 轿	giu
-驕	giu	1000
+驕	giu
 骄	giu
 鱎	giu
 鷮	giu
@@ -8350,12 +8351,12 @@ min_phrase_weight: 100
 㢦	go
 㤎	go
 个	go
-個	go	1000
-哥	go	1000
+個	go
+哥	go
 哿	go
 哿	ho
 旮	go
-歌	go	1000
+歌	go
 渮	go
 牁	go
 牁	o
@@ -8373,7 +8374,7 @@ min_phrase_weight: 100
 䖼	goek
 屩	goek
 脚	goek
-腳	goek	1000
+腳	goek
 𪨗	goek
 㛨	goeng
 㩀	goeng
@@ -8385,27 +8386,27 @@ min_phrase_weight: 100
 䱟	goeng
 䲔	goeng
 䲔	king
-僵	goeng	1000
+僵	goeng
 唴	goeng
-姜	goeng	500
+姜	goeng
 強	goeng	0%
-強	koeng	1000
+強	koeng
 彊	goeng
 彊	koeng
 橿	goeng
 殭	goeng
-疆	goeng	1000
+疆	goeng
 礓	goeng
 糨	goeng
 繮	goeng
 缰	goeng
-羌	goeng	1000
+羌	goeng
 羗	goeng
 蔃	goeng
 蔃	koeng
-薑	goeng	1000
+薑	goeng
 蜣	goeng
-韁	goeng	500
+韁	goeng
 㨟	goi
 㱯	goi
 㱯	ngoi
@@ -8420,7 +8421,7 @@ min_phrase_weight: 100
 䶣	ngoi
 侅	goi
 垓	goi
-改	goi	1000
+改	goi
 盖	goi
 盖	koi
 祴	goi
@@ -8430,9 +8431,9 @@ min_phrase_weight: 100
 荄	goi
 葢	goi
 葢	koi
-該	goi	1000
+該	goi
 该	goi
-賅	goi	500
+賅	goi
 賌	goi
 赅	goi
 阣	goi
@@ -8453,24 +8454,24 @@ min_phrase_weight: 100
 䫦	haap
 䫦	koi
 傕	gok
-各	gok	1000
+各	gok
 埆	gok
 埆	kok
 捔	gok
 搁	gok
-擱	gok	1000
+擱	gok
 桷	gok
 玨	gok
 硌	gok
 硌	lok
 袼	gok
-角	gok	1000
+角	gok
 角	luk	0%
 郝	gok
 郝	kok
 鉻	gok
 铬	gok
-閣	gok	1000
+閣	gok
 阁	gok
 㶥	gon
 㶥	soeng
@@ -8479,30 +8480,30 @@ min_phrase_weight: 100
 䯎	gon
 䵟	gon
 乹	gon
-乾	gon	1000
+乾	gon
 乾	kin	0%
-干	gon	1000
-幹	gon	1000
+干	gon
+幹	gon
 旰	gon
 旰	hon
-杆	gon	1000
-桿	gon	1000
-榦	gon	1000
+杆	gon
+桿	gon
+榦	gon
 榦	hon	0%
 漧	gon
 玕	gon
 皯	gon
 矸	gon
 秆	gon
-稈	gon	500
-竿	gon	1000
+稈	gon
+竿	gon
 筸	gon
 簳	gon
-肝	gon	1000
+肝	gon
 虷	gon
 虷	hon
 赶	gon
-趕	gon	1000
+趕	gon
 酐	gon
 酐	hong
 骭	gon
@@ -8529,23 +8530,23 @@ min_phrase_weight: 100
 亢	kong
 冈	gong
 刚	gong
-剛	gong	1000
+剛	gong
 堈	gong
 堽	gong
 岗	gong
-岡	gong	1000
+岡	gong
 崗	gong
-扛	gong	1000
+扛	gong
 扛	kong	0%
 摃	gong
 杠	gong
 棡	gong
-槓	gong	1000
-槓	gung	1000
+槓	gong
+槓	gung
 槓	lung	0%
-江	gong	1000
+江	gong
 洚	gong
-港	gong	1000
+港	gong
 犅	gong
 瓨	gong
 疘	gong
@@ -8554,37 +8555,37 @@ min_phrase_weight: 100
 矼	kung
 碙	gong
 絳	gong
-綱	gong	1000
+綱	gong
 纲	gong
 绛	gong
-缸	gong	1000
+缸	gong
 罁	gong
 罡	gong
 耩	gong
 耩	kau
-肛	gong	1000
+肛	gong
 肮	gong
 肮	hong
 舡	gong
 舡	syun
 茳	gong
-講	gong	1000
+講	gong
 讲	gong
 豇	gong
 釭	gong
-鋼	gong	1000
+鋼	gong
 钢	gong
-降	gong	1000
-降	hong	1000
+降	gong
+降	hong
 顜	gong
 𧊵	gong
 㓣	got
 㓣	zak
 䈓	got
 䈓	haap
-割	got	1000
+割	got
 嶱	got
-葛	got	1000
+葛	got
 輵	got
 轕	got
 㚏	gou
@@ -8595,30 +8596,30 @@ min_phrase_weight: 100
 㰏	gou
 㾸	gou
 䆁	gou
-告	gou	1000
-告	guk	1000
+告	gou
+告	guk
 暠	gou
 杲	gou
 槀	gou
-槁	gou	500
+槁	gou
 槔	gou
 槹	gou
 櫜	gou
 皋	gou
-皓	gou	500
-皓	hou	500
+皓	gou
+皓	hou
 睾	gou
 稾	gou
-稿	gou	1000
-篙	gou	500
-糕	gou	1000
+稿	gou
+篙	gou
+糕	gou
 縞	gou
 缟	gou
-羔	gou	1000
-膏	gou	1000
+羔	gou
+膏	gou
 臯	gou
 藁	gou
-誥	gou	500
+誥	gou
 诰	gou
 郜	gou
 鋯	gou
@@ -8626,12 +8627,12 @@ min_phrase_weight: 100
 鎬	hou
 锆	gou
 餻	gou
-高	gou	1000
+高	gou
 鼛	gou
 𣉞	gou
 𣓌	gou
 𦤎	gou
-果	gu	0
+果	gu	0%
 果	gwo	1
 㚉	gu
 㼋	gu
@@ -8645,61 +8646,61 @@ min_phrase_weight: 100
 䓢	gu
 䧸	gu
 䧸	zing
-估	gu	1000
-僱	gu	1000
-古	gu	1000
-呱	gu	500
-呱	gwaa	500
-呱	waa	500
-咕	gu	500
-固	gu	1000
+估	gu
+僱	gu
+古	gu
+呱	gu
+呱	gwaa
+呱	waa
+咕	gu
+固	gu
 堌	gu
-姑	gu	1000
-孤	gu	1000
+姑	gu
+孤	gu
 崮	gu
-故	gu	1000
+故	gu
 柧	gu
-沽	gu	500
+沽	gu
 泒	gu
-牯	gu	500
+牯	gu
 狜	gu
 痼	gu
 皷	gu
 盬	gu
-瞽	gu	500
+瞽	gu
 稒	gu
 箛	gu
 罛	gu
-罟	gu	500
+罟	gu
 羖	gu
-股	gu	1000
+股	gu
 胍	gu
 胍	gwaa
 臌	gu
 苽	gu
 菇	gu
-菰	gu	500
+菰	gu
 蛄	gu
 蛊	gu
 蛌	gu
-蠱	gu	500
+蠱	gu
 觚	gu
-詁	gu	500
+詁	gu
 诂	gu
 軱	gu
-辜	gu	1000
+辜	gu
 酤	gu
-鈷	gu	500
+鈷	gu
 錮	gu
 钴	gu
 锢	gu
-雇	gu	500
+雇	gu
 頋	gu
-顧	gu	1000
+顧	gu
 顾	gu
-鴣	gu	500
+鴣	gu
 鸪	gu
-鼓	gu	1000
+鼓	gu
 鼔	gu
 𦍩	gu
 𦙶	gu
@@ -8745,9 +8746,9 @@ min_phrase_weight: 100
 唃	guk
 喾	guk
 嚳	guk
-局	guk	1000
+局	guk
 挶	guk
-掬	guk	500
+掬	guk
 梏	guk
 梮	guk
 椈	guk
@@ -8757,37 +8758,37 @@ min_phrase_weight: 100
 瀔	guk
 焅	guk
 牿	guk
-穀	guk	1000
+穀	guk
 糓	guk
-菊	guk	1000
+菊	guk
 蘜	guk
 諊	guk
-谷	guk	1000
+谷	guk
 谷	juk	0%
 趜	guk
-跼	guk	500
+跼	guk
 踘	guk
 軗	guk
 軗	syu
 輂	guk
-轂	guk	500
+轂	guk
 鋊	guk
 鋊	juk
 鋦	guk
 锔	guk
-鞠	guk	1000
+鞠	guk
 鞫	guk
 頊	guk
 頊	juk
 顼	guk
 顼	juk
 鵠	guk	0%
-鵠	huk	1000
+鵠	huk
 鹄	guk
 鹄	huk
 麯	guk
-麴	guk	500
-麴	kuk	500
+麴	guk
+麴	kuk
 㐫	gun
 㐫	hung
 㐫	zung
@@ -8807,20 +8808,20 @@ min_phrase_weight: 100
 䩪	gun
 䲘	gun
 䲘	sung
-倌	gun	500
-冠	gun	1000
-官	gun	1000
+倌	gun
+冠	gun
+官	gun
 悺	gun
-斡	gun	500
-斡	waat	500
-斡	wat	500
+斡	gun
+斡	waat
+斡	wat
 朊	gun
 朊	jyun
-棺	gun	500
+棺	gun
 毌	gun
 毌	kwun
 涫	gun
-灌	gun	1000
+灌	gun
 爟	gun
 琯	gun
 瓘	gun
@@ -8829,20 +8830,20 @@ min_phrase_weight: 100
 礶	gun
 祼	gun
 筦	gun
-管	gun	1000
-罐	gun	1000
+管	gun
+罐	gun
 脘	gun
 舘	gun
-莞	gun	500
-莞	wun	500
+莞	gun
+莞	wun
 覌	gun
-觀	gun	1000
+觀	gun
 观	gun
-貫	gun	1000
+貫	gun
 贯	gun
 錧	gun
 鑵	gun
-館	gun	1000
+館	gun
 馆	gun
 鸛	gun
 鹳	gun
@@ -8871,46 +8872,46 @@ min_phrase_weight: 100
 䰸	gung
 䲲	gung
 䳍	gung
-供	gung	1000
-公	gung	1000
-共	gung	1000
-功	gung	1000
+供	gung
+公	gung
+共	gung
+功	gung
 唝	gung
 嗊	gung
 嗊	hung
 塨	gung
 宫	gung
-宮	gung	1000
-工	gung	1000
+宮	gung
+工	gung
 巩	gung
 廾	gung
 廾	jaa
 廾	je
-弓	gung	1000
-恭	gung	1000
-拱	gung	1000
+弓	gung
+恭	gung
+拱	gung
 拲	gung
-攻	gung	1000
+攻	gung
 栱	gung
 涳	gung
 涳	hung
 珙	gung
 紅	gung	0%
-紅	hung	1000
+紅	hung
 芎	gung
 芎	hung
 芎	kung
-蚣	gung	1000
+蚣	gung
 蛬	gung
-貢	gung	1000
+貢	gung
 贡	gung
-躬	gung	1000
+躬	gung
 躳	gung
 輁	gung
-鞏	gung	1000
+鞏	gung
 魟	gung
 魟	hung
-龔	gung	500
+龔	gung
 龚	gung
 𡎴	gung
 𫚉	gung
@@ -8922,20 +8923,20 @@ min_phrase_weight: 100
 㶽	gwaa
 䈑	gwaa
 䫚	gwaa
-卦	gwaa	1000
+卦	gwaa
 呙	gwaa
 咼	gwaa
 咼	waa
-寡	gwaa	1000
+寡	gwaa
 挂	gwaa
-掛	gwaa	1000
-掛	kwaa	501
-瓜	gwaa	1000
+掛	gwaa
+掛	kwaa	4%
+瓜	gwaa
 絓	gwaa
 緺	gwaa
 罣	gwaa
-褂	gwaa	500
-褂	kwaa	500
+褂	gwaa
+褂	kwaa
 詿	gwaa
 诖	gwaa
 騧	gwaa
@@ -8972,20 +8973,20 @@ min_phrase_weight: 100
 䳏	gwaai
 䶯	gwaai
 䶯	kwaai
-乖	gwaai	1000
+乖	gwaai
 夬	gwaai
-怪	gwaai	1000
+怪	gwaai
 恠	gwaai
-拐	gwaai	1000
-枴	gwaai	1000
+拐	gwaai
+枴	gwaai
 柺	gwaai
 罫	gwaai
 罫	waa
 蒯	gwaai
 𧊅	gwaai
 掴	gwaak
-摑	gwaak	500
-摑	gwok	500
+摑	gwaak
+摑	gwok
 㙥	gwaan
 㙥	waan
 㙥	wat
@@ -9004,21 +9005,21 @@ min_phrase_weight: 100
 丱	gwaan
 关	gwaan
 惯	gwaan
-慣	gwaan	1000
+慣	gwaan
 掼	gwaan
 摜	gwaan
 擐	gwaan
 瘝	gwaan
-綸	gwaan	500
-綸	gwan	500
-綸	leon	500
+綸	gwaan
+綸	gwan
+綸	leon
 躀	gwaan
 躀	kwaang
 躀	kwong
 関	gwaan
 闗	gwaan
-關	gwaan	1000
-鰥	gwaan	500
+關	gwaan
+鰥	gwaan
 鳏	gwaan
 𨶹	gwaan
 㧦	gwaang
@@ -9031,7 +9032,7 @@ min_phrase_weight: 100
 俇	gwong
 俇	hong
 逛	gwaang	0%
-逛	kwaang	1000
+逛	kwaang
 㑮	gwaat
 㑮	waan
 㓉	gwaat
@@ -9058,12 +9059,12 @@ min_phrase_weight: 100
 䴜	waai
 䴜	wai
 䴜	wun
-刮	gwaat	1000
+刮	gwaat
 劀	gwaat
 劀	wat
 捖	gwaat
 捖	jyun
-颳	gwaat	500
+颳	gwaat
 㑧	gwai
 㧔	gwai
 㧔	tim
@@ -9087,30 +9088,30 @@ min_phrase_weight: 100
 匦	gwai
 匭	gwai
 匮	gwai
-匱	gwai	500
+匱	gwai
 厬	gwai
-圭	gwai	1000
+圭	gwai
 垝	gwai
 妫	gwai
 姽	gwai
 媯	gwai
 嬀	gwai
-季	gwai	1000
+季	gwai
 宄	gwai
 嶡	gwai
 嶡	kyut
 廆	gwai
 廆	wai
 归	gwai
-悸	gwai	500
+悸	gwai
 撌	gwai
 晷	gwai
 朹	gwai
 朹	kau
-桂	gwai	1000
+桂	gwai
 樻	gwai
-櫃	gwai	1000
-歸	gwai	1000
+櫃	gwai
+歸	gwai
 氿	gwai
 沩	gwai
 溈	gwai
@@ -9119,10 +9120,10 @@ min_phrase_weight: 100
 炅	gwai
 炅	gwing
 珪	gwai
-瑰	gwai	1000
+瑰	gwai
 痵	gwai
-癸	gwai	1000
-皈	gwai	500
+癸	gwai
+皈	gwai
 瞆	gwai
 瞆	kui
 瞶	gwai
@@ -9130,34 +9131,34 @@ min_phrase_weight: 100
 硅	gwai
 篑	gwai
 簋	gwai
-簣	gwai	500
+簣	gwai
 籄	gwai
 蒉	gwai
 蕢	gwai
 蘬	gwai
-詭	gwai	1000
+詭	gwai
 诡	gwai
-貴	gwai	1000
+貴	gwai
 贵	gwai
-跪	gwai	1000
-蹶	gwai	500
-蹶	kyut	500
-軌	gwai	1000
+跪	gwai
+蹶	gwai
+蹶	kyut
+軌	gwai
 轨	gwai
 邽	gwai
 鐀	gwai
-閨	gwai	1000
+閨	gwai
 闺	gwai
-餽	gwai	500
+餽	gwai
 饋	gwai
 馈	gwai
 騩	gwai
 騩	kwai
-鬼	gwai	1000
+鬼	gwai
 鮭	gwai
 鯚	gwai
-鱖	gwai	500
-鱖	kyut	500
+鱖	gwai
+鱖	kyut
 鲑	gwai
 鳜	gwai
 㯻	gwan
@@ -9165,22 +9166,22 @@ min_phrase_weight: 100
 䜇	gwan
 䵪	gwan
 军	gwan
-君	gwan	1000
-均	gwan	1000
+君	gwan
+均	gwan
 均	kwan	0%
 均	wan	0%
-崑	gwan	500
-崑	kwan	500
+崑	gwan
+崑	kwan
 掍	gwan
 掍	wan
 昆	gwan	0%
-昆	kwan	1000
+昆	kwan
 晜	gwan
 晜	kwan
-棍	gwan	1000
+棍	gwan
 滚	gwan
 滚	kwan
-滾	gwan	1000
+滾	gwan
 滾	kwan	0%
 焜	gwan
 珺	gwan
@@ -9188,8 +9189,8 @@ min_phrase_weight: 100
 皲	gwan
 皸	gwan
 睔	gwan
-筠	gwan	500
-筠	wan	500
+筠	gwan
+筠	wan
 緄	gwan
 縜	gwan
 縜	wan
@@ -9201,18 +9202,18 @@ min_phrase_weight: 100
 蜫	gwan
 衮	gwan
 袀	gwan
-袞	gwan	500
+袞	gwan
 袬	gwan
 裈	gwan
 裷	gwan
 裷	jyun
 褌	gwan
-軍	gwan	1000
+軍	gwan
 輥	gwan
 辊	gwan
-郡	gwan	1000
-鈞	gwan	500
-鈞	kwan	500
+郡	gwan
+鈞	gwan
+鈞	kwan
 銁	gwan
 錕	gwan
 钧	gwan
@@ -9228,13 +9229,13 @@ min_phrase_weight: 100
 麇	kwan
 厷	gwang
 渹	gwang
-肱	gwang	500
+肱	gwang
 薨	gwang
 觥	gwang
 觵	gwang
 訇	gwang
 輷	gwang
-轟	gwang	1000
+轟	gwang
 轰	gwang
 鍧	gwang
 頵	gwang
@@ -9248,24 +9249,24 @@ min_phrase_weight: 100
 㭾	gwat
 㻕	gwat
 㾶	gwat
-倔	gwat	1000
-崛	gwat	1000
+倔	gwat
+崛	gwat
 愲	gwat
 憰	gwat
 憰	kyut
 扢	gwat
 扢	ngat
-掘	gwat	1000
+掘	gwat
 榾	gwat
-橘	gwat	500
+橘	gwat
 汩	gwat
 淈	gwat
-滑	gwat	1000
-滑	waat	1000
+滑	gwat
+滑	waat
 縎	gwat
 蓇	gwat
 镼	gwat
-骨	gwat	1000
+骨	gwat
 鶌	gwat
 鶻	gwat
 鶻	wat
@@ -9316,7 +9317,7 @@ min_phrase_weight: 100
 闅	gwik
 闅	man
 阒	gwik
-隙	gwik	1000
+隙	gwik
 馘	gwik
 鵙	gwik
 鵙	kyut
@@ -9341,7 +9342,7 @@ min_phrase_weight: 100
 扃	gwing
 檾	gwing
 泂	gwing
-炯	gwing	500
+炯	gwing
 烱	gwing
 煚	gwing
 絅	gwing
@@ -9349,7 +9350,7 @@ min_phrase_weight: 100
 詗	gwing
 詗	hing
 诇	gwing
-迥	gwing	500
+迥	gwing
 顈	gwing
 顈	king
 駉	gwing
@@ -9368,26 +9369,26 @@ min_phrase_weight: 100
 婐	o
 婐	wo
 惈	gwo
-戈	gwo	1000
+戈	gwo
 挝	gwo
 挝	zaa
 撾	gwo
 撾	zaa
 涡	gwo
 涡	wo
-渦	gwo	500
-渦	wo	500
+渦	gwo
+渦	wo
 猓	gwo
 簻	gwo
 粿	gwo
 菓	gwo
 薖	gwo
 蜾	gwo
-裹	gwo	1000
+裹	gwo
 褁	gwo
 輠	gwo
 过	gwo
-過	gwo	1000
+過	gwo
 錁	gwo
 锞	gwo
 餜	gwo
@@ -9409,44 +9410,44 @@ min_phrase_weight: 100
 嘓	gwok
 囯	gwok
 国	gwok
-國	gwok	1000
+國	gwok
 墎	gwok
 崞	gwok
 帼	gwok
-幗	gwok	500
-廓	gwok	500
-廓	kwok	500
+幗	gwok
+廓	gwok
+廓	kwok
 擴	gwok	0%
 擴	kong	0%
-擴	kwok	1000
-擴	kwong	200
+擴	kwok
+擴	kwong
 椁	gwok
-槨	gwok	500
+槨	gwok
 漷	gwok
 漷	kwok
 簂	gwok
 膕	gwok
 蝈	gwok
-蟈	gwok	500
-郭	gwok	1000
+蟈	gwok
+郭	gwok
 霩	gwok
 㤮	gwong
 㤮	kwong
 㫕	gwong
 㫛	gwong
-光	gwong	1000
-廣	gwong	1000
+光	gwong
+廣	gwong
 桄	gwong
 洸	gwong
 犷	gwong
-獷	gwong	500
+獷	gwong
 礦	gwong	0%
-礦	kwong	1000
+礦	kwong
 穬	gwong
 穬	kong
 穬	kwong
-胱	gwong	500
-誑	gwong	500
+胱	gwong
+誑	gwong
 诳	gwong
 銧	gwong
 鑛	gwong
@@ -9469,40 +9470,40 @@ min_phrase_weight: 100
 䣺	gyun
 䩰	gyun
 䳌	gyun
-倦	gyun	1000
-券	gyun	1000
-券	hyun	1000
-卷	gyun	1000
+倦	gyun
+券	gyun
+券	hyun
+卷	gyun
 卷	kyun	0%
 圈	gyun	0%
-圈	hyun	1000
+圈	hyun
 埢	gyun
-娟	gyun	500
+娟	gyun
 婘	gyun
 婘	kyun
 帣	gyun
 悁	gyun
 懁	gyun
 懁	hyun
-捐	gyun	1000
-捲	gyun	1000
-涓	gyun	500
-狷	gyun	500
+捐	gyun
+捲	gyun
+涓	gyun
+狷	gyun
 獧	gyun
 琄	gyun
 琄	jyun
 瓹	gyun
-眷	gyun	500
+眷	gyun
 睊	gyun
 睠	gyun
 絭	gyun
-絹	gyun	1000
+絹	gyun
 绢	gyun
 罥	gyun
 菤	gyun
 蠲	gyun
 身	gyun	0%
-身	san	1000
+身	san
 鄄	gyun
 鞙	gyun
 鞙	jyun
@@ -9512,7 +9513,7 @@ min_phrase_weight: 100
 駽	hyun
 鬳	gyun
 鬳	jin
-鵑	gyun	1000
+鵑	gyun
 鹃	gyun
 劂	gyut
 劂	kyut
@@ -9528,29 +9529,29 @@ min_phrase_weight: 100
 㰺	kwaai
 䪗	haa
 䫗	haa
-下	haa	1000
+下	haa
 厦	haa
 吓	haa
 吓	haak
-哈	haa	1000
+哈	haa
 哈	haai	0%
 哈	kaa	0%
-夏	haa	1000
+夏	haa
 岈	haa
 岈	ngaa
-廈	haa	1000
-暇	haa	1000
-瑕	haa	500
+廈	haa
+暇	haa
+瑕	haa
 芐	haa
 芐	wu
 蕸	haa
 虾	haa
-蝦	haa	1000
+蝦	haa
 赮	haa
-遐	haa	500
+遐	haa
 閜	haa
 閜	ho
-霞	haa	1000
+霞	haa
 颬	haa
 騢	haa
 鰕	haa
@@ -9581,57 +9582,57 @@ min_phrase_weight: 100
 叡	jeoi
 咳	haai	0%
 咳	hoi	0%
-咳	kat	1000
+咳	kat
 咳	koi	0%
 嗐	haai
 嚡	haai
-孩	haai	1000
+孩	haai
 孩	hoi	0%
 嶰	haai
-揩	haai	500
-械	haai	1000
+揩	haai
+械	haai
 澥	haai
 瀣	haai
 獬	haai
 繲	haai
 薤	haai
-蟹	haai	1000
+蟹	haai
 蠏	haai
 觟	haai
 觟	waa
-諧	haai	1000
+諧	haai
 谐	haai
-邂	haai	500
-鞋	haai	1000
+邂	haai
+鞋	haai
 韰	haai
-駭	haai	1000
+駭	haai
 駭	hoi	0%
 駴	haai
 骇	haai
-骸	haai	1000
+骸	haai
 骸	hoi	0%
 齘	haai
 龤	haai
 𩋘	haai
 𩋧	haai
-克	haak	200
-克	hak	1000
-刻	haak	200
-刻	hak	1000
-剋	haak	500
-剋	hak	500
-喀	haak	1000
+克	haak
+克	hak
+刻	haak
+刻	hak
+剋	haak
+剋	hak
+喀	haak
 喀	kaa	0%
 喀	kak	0%
-嚇	haak	1000
-客	haak	1000
+嚇	haak
+客	haak
 諕	haak
 赩	haak
 赩	sik
-赫	haak	500
-赫	hak	500
-黑	haak	200
-黑	hak	1000
+赫	haak
+赫	hak
+黑	haak
+黑	hak
 喊	haam	1000
 喊	ham	0%
 㖃	haam
@@ -9669,40 +9670,40 @@ min_phrase_weight: 100
 䱤	haam
 䲗	haam
 䶟	haam
-函	haam	1000
-咸	haam	1000
-啣	haam	1000
+函	haam
+咸	haam
+啣	haam
 啣	ham	0%
 嗛	haam
 嗛	him
 嗛	hip
 壏	haam
-嵌	haam	500
-嵌	ham	500
+嵌	haam
+嵌	ham
 撖	haam
 撖	hon
 槛	haam
 槛	laam
-檻	haam	500
-檻	laam	500
-涵	haam	1000
+檻	haam
+檻	laam
+涵	haam
 莰	haam
 莰	ham
 衔	haam
 諴	haam
 豏	haam
-銜	haam	1000
+銜	haam
 銜	ham	0%
 闞	haam
 闞	ham
 阚	haam
 阚	ham
-陷	haam	1000
+陷	haam
 陷	ham	0%
-餡	haam	1000
+餡	haam
 馅	haam
 鬫	haam
-鹹	haam	1000
+鹹	haam
 麙	haam
 麙	ngaam
 慳	haan	1000
@@ -9715,16 +9716,16 @@ min_phrase_weight: 100
 僩	haan
 娴	haan
 嫺	haan
-嫻	haan	500
+嫻	haan
 憪	haan
 掔	haan
 撊	haan
 痫	haan
 癇	haan
 瞯	haan
-閑	haan	500
+閑	haan
 闲	haan
-限	haan	1000
+限	haan
 鷳	haan
 鷴	haan
 鹇	haan
@@ -9737,17 +9738,17 @@ min_phrase_weight: 100
 䂔	haang
 䪫	haang
 䰢	haang
-吭	haang	500
-吭	hong	500
-坑	haang	1000
+吭	haang
+吭	hong
+坑	haang
 夯	haang
 夯	hang
 桁	haang
 桁	hang
 桁	hong
-行	haang	501
-行	hang	1000
-行	hong	1000
+行	haang
+行	hang
+行	hong
 誙	haang
 誙	hang
 阬	haang
@@ -9776,23 +9777,23 @@ min_phrase_weight: 100
 侠	haap
 侠	hap
 俠	haap	0%
-俠	hap	1000
-匣	haap	500
-呷	haap	500
-嗑	haap	500
-嗑	hap	500
+俠	hap
+匣	haap
+呷	haap
+嗑	haap
+嗑	hap
 峡	haap
-峽	haap	1000
+峽	haap
 挟	haap
 挟	hip
 挾	haap	0%
-挾	hip	1000
+挾	hip
 掐	haap
 柙	haap
-狎	haap	500
+狎	haap
 狭	haap
-盒	haap	501
-盒	hap	1000
+盒	haap
+盒	hap
 硖	haap
 祫	haap
 箧	haap
@@ -9816,22 +9817,22 @@ min_phrase_weight: 100
 䳧	haau
 傚	haau
 効	haau
-吼	haau	1000
-吼	hau	501
-哮	haau	500
+吼	haau
+吼	hau
+哮	haau
 嗃	haau
 嗃	hok
 嘐	haau
 墝	haau
-孝	haau	1000
+孝	haau
 尻	haau
-巧	haau	1000
-巧	kiu	501
+巧	haau
+巧	kiu	4%
 恔	haau
-拷	haau	500
+拷	haau
 攷	haau
-效	haau	1000
-敲	haau	1000
+效	haau
+敲	haau
 斆	haau
 栲	haau
 毃	haau
@@ -9840,7 +9841,7 @@ min_phrase_weight: 100
 洨	ngaau
 烋	haau
 烋	jau
-烤	haau	1000
+烤	haau
 熇	haau
 熇	hok
 熇	huk
@@ -9848,7 +9849,7 @@ min_phrase_weight: 100
 痚	haau
 硗	haau
 磽	haau
-考	haau	1000
+考	haau
 薧	haau
 薧	hou
 虓	haau
@@ -9875,27 +9876,27 @@ min_phrase_weight: 100
 䲒	ngai
 傒	hai
 傒	hoi
-兮	hai	1000
+兮	hai
 匸	hai
-奚	hai	500
+奚	hai
 徯	hai
 檕	hai
 盻	hai
 禊	hai
-系	hai	1000
-繫	hai	1000
+系	hai
+繫	hai
 肹	hai
 螇	hai
 謑	hai
 貕	hai
-蹊	hai	500
+蹊	hai
 郋	hai
 閪	hai
 騱	hai
 鼷	hai
 𡚦	hai
 可	hak	0.01
-可	ho	1000
+可	ho
 㦦	hak
 㵺	hak
 㵺	pai
@@ -9927,41 +9928,41 @@ min_phrase_weight: 100
 䨡	ham
 䶃	ham
 凵	ham
-勘	ham	500
-含	ham	1000
+勘	ham
+含	ham
 唅	ham
 唅	ngam
 唅	ngan
-坎	ham	500
-坩	ham	500
+坎	ham
+坩	ham
 埳	ham
-堪	ham	1000
+堪	ham
 墈	ham
 崁	ham
 嵁	ham
 憨	ham
-憾	ham	1000
-戡	ham	500
+憾	ham
+戡	ham
 扻	ham
 扻	zit
-撼	ham	1000
+撼	ham
 欿	ham
 歁	ham
 歁	zam
 焓	ham
 琀	ham
-瞰	ham	1000
+瞰	ham
 矙	ham
-砍	ham	1000
+砍	ham
 磡	ham
-蚶	ham	500
+蚶	ham
 蜭	ham
 谽	ham
 轗	ham
 邯	ham
 邯	hon
-酣	ham	1000
-頷	ham	1000
+酣	ham
+頷	ham
 顄	ham
 顉	ham
 顉	jam
@@ -9978,23 +9979,23 @@ min_phrase_weight: 100
 䦥	kok
 佷	han
 垦	han
-墾	han	1000
-很	han	1000
-恨	han	1000
+墾	han
+很	han
+恨	han
 恳	han
 悭	han
-懇	han	1000
+懇	han
 拫	han
 拫	hang
-狠	han	1000
-痕	han	1000
+狠	han
+痕	han
 絎	han
 絎	hong
 绗	han
 绗	hong
 豤	han
-齦	han	500
-齦	ngan	500
+齦	han
+齦	ngan
 龈	han
 龈	ngan
 㔰	hang
@@ -10009,29 +10010,29 @@ min_phrase_weight: 100
 䓷	hang
 䛭	hang
 䯒	hang
-亨	hang	1000
+亨	hang
 亨	paang	0%
-倖	hang	1000
+倖	hang
 哼	hang
 哼	hng
 哼	ng
-啃	hang	1000
+啃	hang
 啈	hang
 姮	hang
 婞	hang
-幸	hang	1000
-恆	hang	1000
+幸	hang
+恆	hang
 恒	hang
-悻	hang	500
+悻	hang
 揯	hang
 摼	hang
-杏	hang	1000
+杏	hang
 涬	hang
 牼	hang
 珩	hang
 硁	hang
 硜	hang
-肯	hang	1000
+肯	hang
 肯	hoi	0%
 胻	hang
 脝	hang
@@ -10039,10 +10040,10 @@ min_phrase_weight: 100
 荇	hang
 莕	hang
 蘅	hang
-衡	hang	1000
+衡	hang
 衡	waang	0%
 踁	hang
-鏗	hang	500
+鏗	hang
 铿	hang
 㛍	hap
 㤲	hap
@@ -10064,50 +10065,50 @@ min_phrase_weight: 100
 匼	hap
 匼	o
 帢	hap
-恰	hap	1000
+恰	hap
 搕	hap
 榼	hap
 欱	hap
 欱	hot
-溘	hap	500
+溘	hap
 烚	hap
 烚	saap
-盍	hap	500
-瞌	hap	1000
-磕	hap	500
+盍	hap
+瞌	hap
+磕	hap
 鉿	hap
 铪	hap
-闔	hap	500
+闔	hap
 阖	hap
 㔠	hat
 㮝	hat
 䎢	hat
-乞	hat	1000
-劾	hat	500
+乞	hat
+劾	hat
 忔	hat
 忔	ngat
 搳	hat
-核	hat	1000
-核	wat	1000
-檄	hat	500
-瞎	hat	1000
+核	hat
+核	wat
+檄	hat
+瞎	hat
 礉	hat
 籺	hat
 舝	hat
 覈	hat
 覡	hat
 觋	hat
-轄	hat	500
+轄	hat
 辖	hat
-迄	hat	500
-迄	ngat	500
-閡	hat	500
-閡	ngoi	500
+迄	hat
+迄	ngat
+閡	hat
+閡	ngoi
 阂	hat
 麧	hat
-黠	hat	500
-黠	kit	500
-黠	waat	500
+黠	hat
+黠	kit
+黠	waat
 齕	hat
 龁	hat
 㗋	hau
@@ -10134,16 +10135,16 @@ min_phrase_weight: 100
 䯌	hau
 䯨	hau
 䯨	kok
-侯	hau	1000
-候	hau	1000
-厚	hau	1000
-口	hau	1000
-后	hau	1000
-喉	hau	1000
+侯	hau
+候	hau
+厚	hau
+口	hau
+后	hau
+喉	hau
 垕	hau
 堠	hau
-後	hau	1000
-猴	hau	1000
+後	hau
+猴	hau
 瘊	hau
 睺	hau
 篌	hau
@@ -10154,7 +10155,7 @@ min_phrase_weight: 100
 茩	hau
 蓲	hau
 蓲	jau
-逅	hau	500
+逅	hau
 郈	hau
 鄇	hau
 銗	hau
@@ -10232,70 +10233,70 @@ min_phrase_weight: 100
 䳢	hei
 䳢	kei
 俙	hei
-僖	hei	500
+僖	hei
 僛	hei
 呬	hei
 唏	hei
-喜	hei	1000
-嗨	hei	500
-嗨	hoi	500
-嘻	hei	1000
-嘿	hei	1000
-器	hei	1000
+喜	hei
+嗨	hei
+嗨	hoi
+嘻	hei
+嘿	hei
+器	hei
 嚱	hei
 囍	hei
 塈	hei
 塈	kei
 娸	hei
 媐	hei
-嬉	hei	1000
+嬉	hei
 屎	hei	0%
-屎	si	1000
+屎	si
 岂	hei
 巇	hei
-希	hei	1000
+希	hei
 弃	hei
 悕	hei
 憇	hei
-憩	hei	1000
+憩	hei
 戏	hei
 戱	hei
 晞	hei
-曦	hei	500
-棄	hei	1000
+曦	hei
+棄	hei
 榿	hei
 榿	kei
 欷	hei
-欺	hei	1000
+欺	hei
 气	hei
-氣	hei	1000
-汽	hei	1000
+氣	hei
+汽	hei
 浠	hei
 炁	hei
 烯	hei
-熙	hei	500
-熹	hei	500
+熙	hei
+熹	hei
 爔	hei
 牺	hei
-犧	hei	1000
+犧	hei
 狶	hei
 甈	hei
 睎	hei
-禧	hei	500
-稀	hei	1000
+禧	hei
+稀	hei
 羛	hei
 羛	ji
-羲	hei	1000
+羲	hei
 蟢	hei
 諆	hei
 譆	hei
-豈	hei	1000
+豈	hei
 豈	hoi	0%
 豨	hei
-起	hei	1000
+起	hei
 醯	hei
 釐	hei	0%
-釐	lei	1000
+釐	lei
 餼	hei
 饩	hei
 魌	hei
@@ -10305,7 +10306,7 @@ min_phrase_weight: 100
 喫	hek
 喫	jaak
 輕	heng	0%
-輕	hing	1000
+輕	hing
 轻	heng
 轻	hing
 㗾	heoi
@@ -10328,36 +10329,36 @@ min_phrase_weight: 100
 佢	heoi
 佢	keoi	100000
 冔	heoi
-去	heoi	1000
-吁	heoi	500
+去	heoi
+吁	heoi
 呴	heoi
-咻	heoi	500
-咻	jau	500
+咻	heoi
+咻	jau
 喣	heoi
 嘘	heoi
-噓	heoi	500
+噓	heoi
 圩	heoi
 圩	jyu
 圩	wai
-墟	heoi	1000
+墟	heoi
 姁	heoi
 旴	heoi
 昫	heoi
-栩	heoi	500
+栩	heoi
 欨	heoi
 歔	heoi
-煦	heoi	500
-煦	jyu	500
+煦	heoi
+煦	jyu
 盱	heoi
 虚	heoi
-虛	heoi	1000
+虛	heoi
 訏	heoi
-許	heoi	1000
+許	heoi
 詡	heoi
 许	heoi
 诩	heoi
-迂	heoi	500
-迂	jyu	500
+迂	heoi
+迂	jyu
 鄦	heoi
 驉	heoi
 魖	heoi
@@ -10384,17 +10385,17 @@ min_phrase_weight: 100
 忺	him
 慊	him
 慊	hip
-欠	him	1000
+欠	him
 歉	him	0%
-歉	hip	1000
+歉	hip
 猃	him
 獫	him
 玁	him
 芡	him
-謙	him	1000
+謙	him
 谦	him
 险	him
-險	him	1000
+險	him
 㗔	hin
 㧛	hin
 㫫	hin
@@ -10427,8 +10428,8 @@ min_phrase_weight: 100
 岍	hin
 幰	hin
 愆	hin
-憲	hin	1000
-掀	hin	1000
+憲	hin
+掀	hin
 搴	hin
 攐	hin
 攓	hin
@@ -10437,27 +10438,27 @@ min_phrase_weight: 100
 杴	jan
 汧	hin
 牵	hin
-牽	hin	1000
+牽	hin
 献	hin
-獻	hin	1000
+獻	hin
 祅	hin
 縴	hin
 繾	hin
 缱	hin
 蚬	hin
 蜆	hin
-衍	hin	1000
-衍	jin	1000
+衍	hin
+衍	jin
 褰	hin
-譴	hin	500
+譴	hin
 谴	hin
-軒	hin	500
+軒	hin
 轩	hin
-遣	hin	1000
+遣	hin
 韅	hin
 顕	hin
-顯	hin	1000
-騫	hin	1000
+顯	hin
+騫	hin
 骞	hin
 鶱	hin
 㷫	hing	1000
@@ -10468,27 +10469,27 @@ min_phrase_weight: 100
 䋜	hing
 䋯	hing
 䋯	kaai
-兄	hing	1000
+兄	hing
 兴	hing
-卿	hing	1000
+卿	hing
 夐	hing
 庆	hing
-慶	hing	1000
+慶	hing
 敻	hing
 敻	hyun
 氢	hing
-氫	hing	500
+氫	hing
 矎	hing
 矎	hyun
-磬	hing	500
+磬	hing
 綮	hing
 綮	kai
-罄	hing	500
+罄	hing
 胫	hing
-興	hing	1000
+興	hing
 謦	hing
 鑋	hing
-馨	hing	1000
+馨	hing
 㙝	hip
 㢵	hip
 㢵	sip
@@ -10503,22 +10504,22 @@ min_phrase_weight: 100
 劦	hip
 勰	hip
 协	hip
-協	hip	1000
+協	hip
 叶	hip
 嗋	hip
-怯	hip	1000
+怯	hip
 惬	hip
-愜	hip	500
+愜	hip
 拹	hip
 胁	hip
-脅	hip	1000
-歇	hit	1000
+脅	hip
+歇	hit
 猲	hit
 猲	hot
 蝎	hit
 蝎	hot
-蠍	hit	500
-蠍	kit	500
+蠍	hit
+蠍	kit
 㕺	hiu
 㚠	hiu
 㠉	hiu
@@ -10536,19 +10537,19 @@ min_phrase_weight: 100
 哓	hiu
 嘵	hiu
 嚣	hiu
-囂	hiu	1000
+囂	hiu
 晓	hiu
-曉	hiu	1000
+曉	hiu
 枭	hiu
 枵	hiu
-梟	hiu	500
+梟	hiu
 歊	hiu
 獟	hiu
 獢	hiu
 窍	hiu
 窍	kiu
-竅	hiu	500
-竅	kiu	500
+竅	hiu
+竅	kiu
 繑	hiu
 繑	kiu
 膮	hiu
@@ -10557,7 +10558,7 @@ min_phrase_weight: 100
 虈	hiu
 趬	hiu
 跷	hiu
-蹺	hiu	500
+蹺	hiu
 鄡	hiu
 驍	hiu
 骁	hiu
@@ -10575,44 +10576,44 @@ min_phrase_weight: 100
 䏜	ho
 䘔	ho
 䘔	kaa
-何	ho	1000
-呵	ho	1000
+何	ho
+呵	ho
 嗬	ho
-坷	ho	500
+坷	ho
 岢	ho
-河	ho	1000
-苛	ho	1000
-荷	ho	1000
+河	ho
+苛	ho
+荷	ho
 蚵	ho
 訶	ho
 诃	ho
-賀	ho	1000
+賀	ho
 贺	ho
-靴	hoe	500
+靴	hoe
 㗽	hoeng
 㿝	hoeng
 䊑	hoeng
 䬕	hoeng
 乡	hoeng
-享	hoeng	1000
-向	hoeng	1000
+享	hoeng
+向	hoeng
 响	hoeng
-嚮	hoeng	1000
-晌	hoeng	500
+嚮	hoeng
+晌	hoeng
 曏	hoeng
 膷	hoeng
 芗	hoeng
 薌	hoeng
 蠁	hoeng
-鄉	hoeng	1000
+鄉	hoeng
 鄕	hoeng
-響	hoeng	1000
+響	hoeng
 飨	hoeng
-餉	hoeng	1000
+餉	hoeng
 饗	hoeng
 饟	hoeng
 饷	hoeng
-香	hoeng	1000
+香	hoeng
 㚊	hoi
 㝩	hoi
 㤥	hoi
@@ -10623,31 +10624,31 @@ min_phrase_weight: 100
 䁗	hoi
 䇋	hoi
 䇋	waai
-亥	hoi	1000
+亥	hoi
 儗	hoi
 儗	ji
 凯	hoi
-凱	hoi	1000
+凱	hoi
 凱	ngoi	0%
 剀	hoi
-剴	hoi	500
+剴	hoi
 咍	hoi
 垲	hoi
 塏	hoi
-害	hoi	1000
+害	hoi
 害	hot	0%
 嵦	hoi
 开	hoi
 恺	hoi
 愷	hoi
-氦	hoi	500
-海	hoi	1000
+氦	hoi
+海	hoi
 磑	hoi
 磑	wui
 醢	hoi
 鎧	hoi
 铠	hoi
-開	hoi	1000
+開	hoi
 闓	hoi
 闿	hoi
 頦	hoi
@@ -10664,17 +10665,17 @@ min_phrase_weight: 100
 嗀	hok
 壳	hok
 学	hok
-學	hok	1000
+學	hok
 斈	hok
-殼	hok	1000
+殼	hok
 澩	hok
 矐	hok
 矐	kok
 翯	hok
 觷	hok
-貉	hok	500
-貉	mak	500
-鶴	hok	1000
+貉	hok
+貉	mak
+鶴	hok
 鷽	hok
 鸴	hok
 鹤	hok
@@ -10706,31 +10707,31 @@ min_phrase_weight: 100
 䮧	hon
 䳚	hon
 䳚	hot
-侃	hon	500
-刊	hon	1000
+侃	hon
+刊	hon
 刋	hon
 咹	hon
-寒	hon	1000
-悍	hon	500
+寒	hon
+悍	hon
 扞	hon
 捍	hon
-旱	hon	1000
+旱	hon
 暵	hon
 汉	hon
-汗	hon	1000
-汗	hong	0
+汗	hon
+汗	hong	0%
 涆	hon
-漢	hon	1000
-瀚	hon	500
-焊	hon	500
+漢	hon
+瀚	hon
+焊	hon
 熯	hon
 犴	hon
 犴	ngon
 甝	hon
-看	hon	1000
+看	hon
 睅	hon
-罕	hon	1000
-翰	hon	500
+罕	hon
+翰	hon
 蔊	hon
 螒	hon
 衎	hon
@@ -10741,14 +10742,14 @@ min_phrase_weight: 100
 銲	hon
 閈	hon
 闬	hon
-韓	hon	1000
+韓	hon
 韩	hon
 頇	hon
 顸	hon
 馯	hon
 駻	hon
 鶾	hon
-鼾	hon	1000
+鼾	hon
 𫘣	hon
 㑌	hong
 㟟	hong
@@ -10775,33 +10776,33 @@ min_phrase_weight: 100
 䯑	hong
 䲳	hong
 劻	hong
-匡	hong	1000
-巷	hong	1000
-康	hong	1000
+匡	hong
+巷	hong
+康	hong
 恇	hong
-慷	hong	1000
+慷	hong
 慷	hung	0%
 慷	kong	0%
-杭	hong	1000
-框	hong	1000
-框	kwaang	1000
+杭	hong
+框	hong
+框	kwaang
 椌	hong
 沆	hong
 洭	hong
 漮	hong
-炕	hong	500
-炕	kong	500
-烘	hong	501
-烘	hung	1000
-眶	hong	1000
-眶	kwaang	1000
+炕	hong
+炕	kong
+烘	hong
+烘	hung
+眶	hong
+眶	kwaang
 穅	hong
 笐	hong
-筐	hong	1000
+筐	hong
 筐	kwaang	0%
-糠	hong	500
-腔	hong	1000
-航	hong	1000
+糠	hong
+腔	hong
+航	hong
 蚢	hong
 衖	hong
 衖	lung
@@ -10809,13 +10810,13 @@ min_phrase_weight: 100
 诓	hong
 迒	hong
 鏮	hong
-項	hong	1000
+項	hong
 頏	hong
 项	hong
 颃	hong
-骯	hong	501
+骯	hong
 骯	ngong	0%
-骯	ong	1000
+骯	ong
 𠵉	hong
 𣚺	hong
 㓭	hot
@@ -10828,14 +10829,14 @@ min_phrase_weight: 100
 㿣	hot
 䫘	hot
 䶎	hot
-喝	hot	1000
+喝	hot
 嵑	hot
 嵑	kit
 暍	hot
-曷	hot	500
+曷	hot
 毼	hot
-渴	hot	1000
-褐	hot	500
+渴	hot
+褐	hot
 鞨	hot
 鶡	hot
 鹖	hot
@@ -10861,34 +10862,34 @@ min_phrase_weight: 100
 䪽	hou
 䯫	hou
 号	hou
-嗥	hou	500
+嗥	hou
 嚆	hou
-嚎	hou	500
-壕	hou	500
-好	hou	1000
+嚎	hou
+壕	hou
+好	hou
 昊	hou
 昦	hou
-毫	hou	1000
-浩	hou	1000
+毫	hou
+浩	hou
 淏	hou
 滈	hou
 澔	hou
-濠	hou	500
+濠	hou
 灏	hou
 灝	hou
-犒	hou	500
+犒	hou
 皜	hou
 皞	hou
 秏	hou
-耗	hou	1000
+耗	hou
 茠	hou
 茠	jau
-蒿	hou	500
+蒿	hou
 薃	hou
 薅	hou
-號	hou	1000
-蠔	hou	1000
-豪	hou	1000
+號	hou
+蠔	hou
+豪	hou
 镐	hou
 顥	hou
 颢	hou
@@ -10913,16 +10914,16 @@ min_phrase_weight: 100
 䧼	huk
 勖	huk
 勖	juk
-勗	huk	500
-勗	juk	500
-哭	huk	1000
+勗	huk
+勗	juk
+哭	huk
 嘝	huk
 斛	huk
 槲	huk
 瀫	huk
 縠	huk
 觳	huk
-酷	huk	1000
+酷	huk
 㒑	hung
 㒑	kui
 㒑	wak
@@ -10944,49 +10945,49 @@ min_phrase_weight: 100
 䫹	hung
 䫹	kyun
 䲨	hung
-倥	hung	500
-兇	hung	1000
-凶	hung	1000
-匈	hung	1000
+倥	hung
+兇	hung
+凶	hung
+匈	hung
 吽	hung
 吽	ngau
-哄	hung	1000
+哄	hung
 哅	hung
-孔	hung	1000
-崆	hung	500
+孔	hung
+崆	hung
 忷	hung
 忼	hung
-恐	hung	1000
+恐	hung
 恟	hung
 悾	hung
-控	hung	1000
-汞	hung	500
+控	hung
+汞	hung
 汹	hung
-洪	hung	1000
-洶	hung	1000
+洪	hung
+洶	hung
 澒	hung
 灴	hung
-熊	hung	1000
+熊	hung
 穹	hung	0%
-穹	kung	1000
-空	hung	1000
+穹	kung
+空	hung
 箜	hung
 篊	hung
 红	hung
 胷	hung
-胸	hung	1000
+胸	hung
 荭	hung
 葒	hung
 蕻	hung
-虹	hung	1000
-訌	hung	500
+虹	hung
+訌	hung
 讧	hung
 谼	hung
 閧	hung
-雄	hung	1000
+雄	hung
 鞚	hung
-鬨	hung	500
-鴻	hung	1000
+鬨	hung
+鴻	hung
 鸿	hung
 黉	hung
 黌	hung
@@ -11003,9 +11004,9 @@ min_phrase_weight: 100
 䳦	kwaan
 儇	hyun
 劝	hyun
-勸	hyun	1000
+勸	hyun
 咺	hyun
-喧	hyun	1000
+喧	hyun
 埙	hyun
 塤	hyun
 壎	hyun
@@ -11021,13 +11022,13 @@ min_phrase_weight: 100
 楥	hyun
 楥	jyun
 楦	hyun
-渲	hyun	1000
-渲	syun	1000
+渲	hyun
+渲	syun
 烜	hyun
 煊	hyun
 煖	hyun
 煖	nyun
-犬	hyun	1000
+犬	hyun
 犭	hyun
 甽	hyun
 甽	zan
@@ -11037,13 +11038,13 @@ min_phrase_weight: 100
 眴	seon
 禢	hyun
 禤	hyun
-絢	hyun	1000
+絢	hyun
 絢	seon	0%
 綣	hyun
 绚	hyun
 绻	hyun
 翾	hyun
-萱	hyun	500
+萱	hyun
 萲	hyun
 虇	hyun
 蠉	hyun
@@ -11066,11 +11067,11 @@ min_phrase_weight: 100
 狘	hyut
 狘	jyut
 瞲	hyut
-血	hyut	1000
+血	hyut
 廿	jaa	1000
-廿	je	500
-廿	nim	500
-也	jaa	1000
+廿	je
+廿	nim
+也	jaa
 卄	jaa
 卄	je
 吔	jaak
@@ -11094,14 +11095,14 @@ min_phrase_weight: 100
 勩	ji
 抴	jai
 抴	zai
-拽	jai	500
-拽	jit	500
-曳	jai	500
+拽	jai
+拽	jit
+曳	jai
 枍	jai
 枻	jai
 枻	sit
 泄	jai	0%
-泄	sit	1000
+泄	sit
 洩	jai
 洩	sit
 詍	jai
@@ -11119,16 +11120,16 @@ min_phrase_weight: 100
 䕃	jam
 䕃	zaam
 乑	jam
-任	jam	1000
+任	jam
 冘	jam
 冘	jau
-吟	jam	1000
-吟	ngam	501
+吟	jam
+吟	ngam	4%
 呥	jam
 呥	jim
 喑	jam
-壬	jam	1000
-妊	jam	500
+壬	jam
+妊	jam
 婬	jam
 崟	jam
 嵚	jam
@@ -11137,35 +11138,35 @@ min_phrase_weight: 100
 廞	jam
 恁	jam
 愔	jam
-欽	jam	1000
+欽	jam
 歆	jam
-淫	jam	500
+淫	jam
 瘖	jam
-簷	jam	200
-簷	jim	1000
-簷	sim	1000
+簷	jam	4%
+簷	jim
+簷	sim
 紝	jam
 纴	jam
 腍	jam
 腍	nam
-荏	jam	500
+荏	jam
 荫	jam
-蔭	jam	1000
+蔭	jam
 衽	jam
 袵	jam
-賃	jam	1000
+賃	jam
 赁	jam
 銋	jam
 鑫	jam
 钦	jam
 阴	jam
-陰	jam	1000
+陰	jam
 隂	jam
 霒	jam
 霠	jam
-霪	jam	500
-音	jam	1000
-飪	jam	1000
+霪	jam
+音	jam
+飪	jam
 饪	jam
 饮	jam
 鵀	jam
@@ -11175,97 +11176,97 @@ min_phrase_weight: 100
 㶏	zaan
 䄄	jan
 䄄	zaan
-人	jan	1000
-仁	jan	1000
-仞	jan	500
+人	jan
+仁	jan
+仞	jan
 仭	jan
 儿	jan
-刃	jan	500
-印	jan	1000
-印	ngan	501
+刃	jan
+印	jan
+印	ngan	4%
 听	jan
 听	teng
 听	ting
-因	jan	1000
+因	jan
 垔	jan
 垽	jan
 垽	ngan
 堙	jan
-夤	jan	500
-姻	jan	1000
-孕	jan	1000
-寅	jan	1000
+夤	jan
+姻	jan
+孕	jan
+寅	jan
 屻	jan
 廴	jan
-引	jan	1000
-忍	jan	1000
+引	jan
+忍	jan
 忻	jan
-恩	jan	1000
-慇	jan	500
+恩	jan
+慇	jan
 憖	jan
 戭	jan
 戭	jin
 昕	jan
 朄	jan
 檃	jan
-欣	jan	1000
+欣	jan
 歅	jan
 殥	jan
-殷	jan	1000
+殷	jan
 殷	jin	0%
-氤	jan	500
+氤	jan
 洇	jan
-湮	jan	500
-湮	jin	500
+湮	jan
+湮	jin
 濦	jan
 炘	jan
 焮	jan
 牣	jan
 猌	jan
-甄	jan	1000
+甄	jan
 甄	zan	0%
 瘾	jan
 癊	jan
-癮	jan	1000
+癮	jan
 盺	jan
 禋	jan
-紉	jan	500
+紉	jan
 絪	jan
 縯	jan
 縯	jin
 纫	jan
 肕	jan
 肕	ngan
-胤	jan	500
+胤	jan
 舋	jan
 舋	lang
-茵	jan	500
+茵	jan
 荵	jan
-蚓	jan	500
+蚓	jan
 螾	jan
 衅	jan
 裀	jan
 訒	jan
 訢	jan
 認	jan	0%
-認	jing	1000
+認	jing
 諲	jan
 讔	jan
 讱	jan
-軔	jan	500
+軔	jan
 轫	jan
 酳	jan
-釁	jan	500
+釁	jan
 銦	jan
 铟	jan
 锨	jan
 闉	jan
 陻	jan
 隐	jan
-隱	jan	1000
+隱	jan
 靷	jan
-韌	jan	500
-韌	ngan	500
+韌	jan
+韌	ngan
 韧	jan
 駰	jan
 骃	jan
@@ -11274,12 +11275,12 @@ min_phrase_weight: 100
 㗱	jap
 㗱	zap
 俋	jap
-入	jap	1000
+入	jap
 唈	jap
 悒	jap
 挹	jap
-揖	jap	500
-泣	jap	1000
+揖	jap
+泣	jap
 浥	jap
 湆	jap
 湆	nap
@@ -11288,39 +11289,39 @@ min_phrase_weight: 100
 潝	kap
 熠	jap
 熤	jap
-翕	jap	500
+翕	jap
 裛	jap
-邑	jap	1000
+邑	jap
 㳑	jat
 㳑	zaat
-一	jat	1000
+一	jat
 丨	jat
 丨	kwan
 佚	jat
 佾	jat
 劮	jat
-壹	jat	1000
-壹	jik	0
+壹	jat
+壹	jik	0%
 弌	jat
-掖	jat	500
-掖	jik	500
-日	jat	1000
-汨	jat	500
-汨	mik	500
+掖	jat
+掖	jik
+日	jat
+汨	jat
+汨	mik
 泆	jat
 液	jat	0%
-液	jik	1000
-溢	jat	1000
+液	jik
+溢	jat
 肸	jat
-腋	jat	500
-腋	jik	500
-腋	jit	500
+腋	jat
+腋	jik
+腋	jit
 艗	jat
 艗	jik
 衵	jat
 衵	nik
 轶	jat
-逸	jat	1000
+逸	jat
 鈤	jat
 鎰	jat
 镒	jat
@@ -11336,62 +11337,62 @@ min_phrase_weight: 100
 㳜	zaau
 䋴	jau
 䋴	zaau
-丘	jau	1000
+丘	jau
 丣	jau
-休	jau	1000
+休	jau
 优	jau
-佑	jau	1000
+佑	jau
 侑	jau
-優	jau	1000
+優	jau
 卣	jau
-又	jau	1000
-友	jau	1000
-右	jau	1000
+又	jau
+友	jau
+右	jau
 呦	jau
 嚘	jau
 囮	jau
 囮	ngo
 囿	jau
 坵	jau
-宥	jau	500
-尤	jau	1000
-幼	jau	1000
-幽	jau	1000
+宥	jau
+尤	jau
+幼	jau
+幽	jau
 庥	jau
 庮	jau
 忧	jau
 怞	jau
 怞	zau
 怮	jau
-悠	jau	1000
-憂	jau	1000
+悠	jau
+憂	jau
 懮	jau
-揉	jau	1000
+揉	jau
 攸	jau
 斿	jau
-有	jau	1000
+有	jau
 朽	jau	0%
-朽	nau	1000
-柔	jau	1000
-柚	jau	1000
+朽	nau
+柔	jau
+柚	jau
 柚	zuk	0%
 楢	jau
 楺	jau
 槱	jau
 櫌	jau
 沋	jau
-油	jau	1000
+油	jau
 泑	jau
-游	jau	1000
+游	jau
 煣	jau
-牖	jau	500
+牖	jau
 犹	jau
 狖	jau
-猶	jau	1000
-猷	jau	500
-由	jau	1000
+猶	jau
+猷	jau
+由	jau
 疣	jau
-祐	jau	500
+祐	jau
 禸	jau
 糅	jau
 糅	nau
@@ -11401,107 +11402,107 @@ min_phrase_weight: 100
 纋	jau
 羑	jau
 耰	jau
-莠	jau	500
+莠	jau
 莸	jau
 葇	jau
 蕕	jau
 蘨	jau
-蚯	jau	500
+蚯	jau
 蚰	jau
 蚴	jau
 蝣	jau
 褎	jau
 褎	zau
 訧	jau
-誘	jau	1000
+誘	jau
 诱	jau
 貅	jau
-蹂	jau	500
+蹂	jau
 輮	jau
 輶	jau
 逌	jau
-遊	jau	1000
+遊	jau
 邮	jau
-邱	jau	500
-郵	jau	1000
+邱	jau
+郵	jau
 鄾	jau
-酉	jau	1000
-釉	jau	500
-鈾	jau	500
+酉	jau
+釉	jau
+鈾	jau
 銪	jau
 铀	jau
 铕	jau
-鞣	jau	500
+鞣	jau
 髹	jau
-魷	jau	1000
+魷	jau
 鯈	jau
 鯈	tiu
 鱿	jau
 鵂	jau
 鸺	jau
 麀	jau
-黝	jau	500
-鼬	jau	500
+黝	jau
+鼬	jau
 𠀉	jau
 𤍕	jau
 嘢	je	1000
 㭨	je
-偌	je	500
-冶	je	1000
+偌	je
+冶	je
 喏	je
 埜	je
-夜	je	1000
+夜	je
 射	je	0%
 射	jik	0%
-射	se	1000
-惹	je	1000
+射	se
+惹	je
 捓	je
 揶	je
-椰	je	1000
+椰	je
 歋	je
 歋	ji
 渃	je
 渃	joek
 爷	je
-爺	je	1000
+爺	je
 玡	je
-琊	je	500
-耶	je	1000
+琊	je
+耶	je
 若	je	0%
-若	joek	1000
-野	je	1000
+若	joek
+野	je
 影	jeng	0%
-影	jing	1000
-贏	jeng	1000
-贏	jing	1000
+影	jing
+贏	jeng
+贏	jing
 赢	jeng
 赢	jing
-佯	jeoi	500
-佯	joeng	500
+佯	jeoi
+佯	joeng
 擩	jeoi
 擩	jyu
 枘	jeoi
 桵	jeoi
 橤	jeoi
 汭	jeoi
-睿	jeoi	500
+睿	jeoi
 緌	jeoi
 繠	jeoi
 芮	jeoi
-蕊	jeoi	1000
+蕊	jeoi
 蕤	jeoi
 蚋	jeoi
 蜹	jeoi
-裔	jeoi	1000
+裔	jeoi
 銳	jeoi
-鋭	jeoi	1000
+鋭	jeoi
 锐	jeoi
 撋	jeon
 撋	no
 润	jeon
-潤	jeon	1000
+潤	jeon
 膶	jeon
-閏	jeon	1000
+閏	jeon
 闰	jeon
 㖇	ji
 㖇	mei
@@ -11525,20 +11526,20 @@ min_phrase_weight: 100
 䭲	zi
 义	ji
 亄	ji
-二	ji	1000
-以	ji	1000
+二	ji
+以	ji
 以	jyu	0%
 仪	ji
-伊	ji	1000
+伊	ji
 佁	ji
 佴	ji
 佴	noi
 侇	ji
-依	ji	1000
-倚	ji	1000
+依	ji
+倚	ji
 偯	ji
-儀	ji	1000
-兒	ji	1000
+儀	ji
+兒	ji
 兒	ngai	0%
 刵	ji
 劓	ji
@@ -11546,48 +11547,48 @@ min_phrase_weight: 100
 匜	ji
 医	ji
 台	ji	0%
-台	toi	1000
+台	toi
 吚	ji
 咡	ji
 咡	mai
-咦	ji	1000
+咦	ji
 咿	ji
 唲	ji
 唲	waa
-噫	ji	1000
-圯	ji	500
-夷	ji	500
+噫	ji
+圯	ji
+夷	ji
 她	ji	0%
-她	taa	1000
-姨	ji	1000
+她	taa
+姨	ji
 嫛	ji
-宜	ji	1000
+宜	ji
 宧	ji
 尒	ji
 尔	ji
 崺	ji
 嶷	ji
 嶷	jik
-已	ji	1000
+已	ji
 廙	ji
 异	ji
 弍	ji
-彝	ji	500
-怡	ji	1000
-意	ji	1000
-懿	ji	500
+彝	ji
+怡	ji
+意	ji
+懿	ji
 扆	ji
 拟	ji
-擬	ji	1000
+擬	ji
 施	ji	0%
-施	si	1000
-旖	ji	500
-易	ji	1000
-易	jik	1000
+施	si
+旖	ji
+易	ji
+易	jik
 栘	ji
 栭	ji
 桋	ji
-椅	ji	1000
+椅	ji
 椸	ji
 樲	ji
 欹	ji
@@ -11599,45 +11600,45 @@ min_phrase_weight: 100
 洏	ji
 洟	ji
 洟	tai
-洱	ji	500
-漪	ji	500
+洱	ji
+漪	ji
 潩	ji
-爾	ji	1000
+爾	ji
 狋	ji
 狋	ngan
 猗	ji
 珥	ji
 珥	nei
 瑿	ji
-異	ji	1000
-疑	ji	1000
+異	ji
+疑	ji
 痍	ji
 瘗	ji
 瘞	ji
 瘱	ji
 皑	ji
 皑	ngoi
-皚	ji	500
-皚	ngoi	500
+皚	ji
+皚	ngoi
 眱	ji
-矣	ji	1000
+矣	ji
 祎	ji
 禕	ji
-移	ji	1000
+移	ji
 箷	ji
 簃	ji
-綺	ji	500
+綺	ji
 繄	ji
 绮	ji
 羠	ji
-義	ji	1000
-而	ji	1000
+義	ji
+而	ji
 耏	ji
-耳	ji	1000
+耳	ji
 聏	ji
-肄	ji	500
-肄	si	500
-胰	ji	500
+肄	ji
+肄	si
+胰	ji
 胹	ji
 臑	ji
 臑	jyu
@@ -11649,39 +11650,39 @@ min_phrase_weight: 100
 薾	ji
 薿	ji
 蛇	ji	0%
-蛇	se	1000
+蛇	se
 蛜	ji
 螔	ji
 衈	ji
 衈	nei
-衣	ji	1000
+衣	ji
 衪	ji
 袘	ji
 袲	ji
 觺	ji
 訑	ji
 詒	ji
-誼	ji	1000
-議	ji	1000
+誼	ji
+議	ji
 议	ji
 诒	ji
 谊	ji
 貤	ji
-貳	ji	1000
-貽	ji	1000
+貳	ji
+貽	ji
 贰	ji
 贻	ji
 輀	ji
 轙	ji
 轙	ngai
 迆	ji
-迤	ji	500
+迤	ji
 迩	ji
 迻	ji
-邇	ji	500
+邇	ji
 郼	ji
 酏	ji
-醫	ji	1000
+醫	ji
 鉯	ji
 鉺	ji
 銥	ji
@@ -11695,12 +11696,12 @@ min_phrase_weight: 100
 陑	ji
 陭	ji
 陭	kei
-頤	ji	500
+頤	ji
 颐	ji
 食	ji	0%
 食	sik	5
 食	zi	0%
-飴	ji	500
+飴	ji
 饐	ji
 饴	ji
 駬	ji
@@ -11722,56 +11723,56 @@ min_phrase_weight: 100
 𫍙	ji
 䦧	jik
 䦧	zik
-亦	jik	1000
+亦	jik
 亿	jik
-億	jik	1000
+億	jik
 圛	jik
 垼	jik
 埸	jik
-奕	jik	500
+奕	jik
 峄	jik
 嶧	jik
 帟	jik
-弈	jik	1000
+弈	jik
 弋	jik
-役	jik	1000
+役	jik
 忆	jik
 怿	jik
-憶	jik	1000
+憶	jik
 懌	jik
-抑	jik	1000
+抑	jik
 杙	jik
 檍	jik
 澺	jik
 瀷	jik
 燚	jik
 燡	jik
-疫	jik	1000
-益	jik	1000
-睪	jik	500
+疫	jik
+益	jik
+睪	jik
 繶	jik
-繹	jik	500
+繹	jik
 绎	jik
 翊	jik
-翌	jik	1000
-翼	jik	1000
+翌	jik
+翼	jik
 肊	jik
 膉	jik
 膱	jik
 膱	zik
-臆	jik	500
+臆	jik
 芅	jik
-蜴	jik	1000
+蜴	jik
 蝪	jik
-譯	jik	1000
+譯	jik
 译	jik
-逆	jik	1000
-逆	ngaak	501
+逆	jik
+逆	ngaak	4%
 醳	jik
 醳	sik
 醷	jik
 阋	jik
-驛	jik	500
+驛	jik
 驿	jik
 鬩	jik
 鶂	jik
@@ -11782,7 +11783,7 @@ min_phrase_weight: 100
 鹢	jik
 黓	jik
 黓	jit
-益	jik	1000
+益	jik
 𡄯	jik
 㤿	jim
 䀋	jim
@@ -11790,22 +11791,22 @@ min_phrase_weight: 100
 䀋	zim
 严	jim
 俨	jim
-俺	jim	500
-儼	jim	500
-冉	jim	1000
+俺	jim
+儼	jim
+冉	jim
 剡	jim
 剡	sim
 剦	jim
 厌	jim
 厣	jim
-厭	jim	1000
+厭	jim
 厴	jim
 噞	jim
-嚴	jim	1000
+嚴	jim
 壛	jim
-奄	jim	500
+奄	jim
 姌	jim
-嫌	jim	1000
+嫌	jim
 嬮	jim
 崦	jim
 广	jim
@@ -11814,17 +11815,17 @@ min_phrase_weight: 100
 懨	jim
 扊	jim
 揜	jim
-染	jim	1000
+染	jim
 橪	jim
 檿	jim
 淊	jim
-淹	jim	1000
+淹	jim
 渰	jim
 灩	jim
-炎	jim	1000
-焰	jim	1000
+炎	jim
+焰	jim
 焱	jim
-燄	jim	500
+燄	jim
 爓	jim
 琰	jim
 盐	jim
@@ -11834,7 +11835,7 @@ min_phrase_weight: 100
 艳	jim
 艶	jim
 艷	jim
-苒	jim	500
+苒	jim
 蚎	jim
 蚒	jim
 蚺	jim
@@ -11843,29 +11844,29 @@ min_phrase_weight: 100
 蛅	zim
 裺	jim
 豓	jim
-豔	jim	1000
+豔	jim
 酓	jim
 酽	jim
-醃	jim	500
-醃	jip	500
+醃	jim
+醃	jip
 釅	jim
 閆	jim
 閹	jim
-閻	jim	500
+閻	jim
 闫	jim
 阉	jim
 阎	jim
 隒	jim
 顩	jim
 餍	jim
-饜	jim	500
+饜	jim
 騐	jim
-驗	jim	1000
+驗	jim
 验	jim
-髯	jim	500
+髯	jim
 魇	jim
-魘	jim	500
-鹽	jim	1000
+魘	jim
+鹽	jim
 黡	jim
 黤	jim
 黶	jim
@@ -11887,32 +11888,32 @@ min_phrase_weight: 100
 伭	jin
 伭	jyun
 俔	jin
-偃	jin	500
+偃	jin
 傿	jin
 兖	jin
-兗	jin	500
+兗	jin
 匽	jin
-咽	jin	1000
-咽	jit	1000
-唁	jin	500
+咽	jin
+咽	jit
+唁	jin
 唌	jin
 喭	jin
 喭	ngon
-嚥	jin	500
-嚥	jit	500
+嚥	jin
+嚥	jit
 埏	jin
-堰	jin	500
-妍	jin	500
-嫣	jin	500
+堰	jin
+妍	jin
+嫣	jin
 嬿	jin
-宴	jin	1000
+宴	jin
 岘	jin
 峴	jin
 巘	jin
-延	jin	1000
-弦	jin	1000
-弦	jyun	200
-彥	jin	500
+延	jin
+弦	jin
+弦	jyun
+彥	jin
 彦	jin
 揅	jin
 揅	ngaan
@@ -11921,47 +11922,47 @@ min_phrase_weight: 100
 沇	jin
 沇	wai
 涀	jin
-涎	jin	500
-演	jin	1000
+涎	jin
+演	jin
 烟	jin
 烻	jin
-焉	jin	1000
-然	jin	1000
-煙	jin	1000
-燃	jin	1000
-燕	jin	1000
+焉	jin
+然	jin
+煙	jin
+燃	jin
+燕	jin
 狿	jin
 现	jin
-現	jin	1000
+現	jin
 甗	jin
 睍	jin
-研	jin	1000
-研	ngaan	501
+研	jin
+研	ngaan	4%
 砚	jin
-硯	jin	500
+硯	jin
 筳	jin
 筳	ting
-筵	jin	1000
-絃	jin	500
+筵	jin
+絃	jin
 綖	jin
-胭	jin	500
+胭	jin
 臙	jin
-舷	jin	500
+舷	jin
 苋	jin
 莚	jin
 莧	jin
-菸	jin	500
+菸	jin
 蔫	jin
 蚿	jin
 蜒	jin
 蝘	jin
-言	jin	1000
-諺	jin	500
+言	jin
+諺	jin
 讌	jin
 讞	jin
 谚	jin
 谳	jin
-賢	jin	1000
+賢	jin
 贤	jin
 躽	jin
 躽	zin
@@ -11975,11 +11976,11 @@ min_phrase_weight: 100
 鋧	jin
 驠	jin
 鰋	jin
-鴛	jin	200
-鴛	jyun	1000
+鴛	jin
+鴛	jyun
 鶠	jin
 鷰	jin
-鼴	jin	500
+鼴	jin
 鼹	jin
 齞	jin
 齴	jin
@@ -11996,62 +11997,62 @@ min_phrase_weight: 100
 䊔	zing
 䣐	jing
 䣐	zing
-仍	jing	1000
+仍	jing
 侀	jing
 偀	jing
-凝	jing	1000
-凝	king	501
-刑	jing	1000
-型	jing	1000
+凝	jing
+凝	king	4%
+刑	jing
+型	jing
 塋	jing
 娙	jing
 婴	jing
 媵	jing
 嫈	jing
-嬰	jing	1000
-嬴	jing	500
+嬰	jing
+嬴	jing
 嶸	jing
 嶸	wing
 应	jing
-形	jing	1000
-應	jing	1000
-扔	jing	1000
+形	jing
+應	jing
+扔	jing
 扔	wing	0%
 撄	jing
 攖	jing
-映	jing	1000
+映	jing
 桜	jing
-楹	jing	500
+楹	jing
 樱	jing
-櫻	jing	1000
+櫻	jing
 滎	jing
 滢	jing
 潆	jing
 濴	jing
 瀅	jing
-瀛	jing	500
+瀛	jing
 瀠	jing
 瀯	jing
 瀴	jing
 熒	jing
-營	jing	1000
-瑛	jing	500
-瑩	jing	1000
+營	jing
+瑛	jing
+瑩	jing
 璎	jing
 瓔	jing
 瘿	jing
 癭	jing
-盈	jing	1000
+盈	jing
 硎	jing
 礽	jing
 籯	jing
-縈	jing	500
-纓	jing	500
+縈	jing
+纓	jing
 缨	jing
-膺	jing	500
+膺	jing
 艿	jing
 艿	naai
-英	jing	1000
+英	jing
 茔	jing
 荥	jing
 荧	jing
@@ -12062,13 +12063,13 @@ min_phrase_weight: 100
 蓥	jing
 蘡	jing
 蝇	jing
-螢	jing	1000
-蠅	jing	1000
+螢	jing
+蠅	jing
 謍	jing
 认	jing
 賏	jing
-迎	jing	1000
-邢	jing	500
+迎	jing
+邢	jing
 鉶	jing
 鎣	jing
 铏	jing
@@ -12077,25 +12078,25 @@ min_phrase_weight: 100
 陾	jing
 霙	jing
 韺	jing
-鷹	jing	1000
-鸚	jing	500
+鷹	jing
+鸚	jing
 鹦	jing
 鹰	jing
 业	jip
 偞	jip
 嘩	jip	0%
-嘩	waa	1000
-孽	jip	500
-孽	jit	500
+嘩	waa
+孽	jip
+孽	jit
 嶪	jip
 擫	jip
 晔	jip
 曄	jip
-業	jip	1000
+業	jip
 殗	jip
 烨	jip
 燁	jip
-葉	jip	1000
+葉	jip
 葉	sip	0%
 蠥	jip
 蠥	jit
@@ -12104,8 +12105,8 @@ min_phrase_weight: 100
 闑	jip
 闑	jit
 靥	jip
-靨	jip	500
-頁	jip	1000
+靨	jip
+頁	jip
 页	jip
 饁	jip
 馌	jip
@@ -12114,7 +12115,7 @@ min_phrase_weight: 100
 㗁	zit
 啮	jit
 啮	ngat
-噎	jit	500
+噎	jit
 嚙	jit
 嚙	ngat
 嚙	ngit
@@ -12130,7 +12131,7 @@ min_phrase_weight: 100
 槷	jit
 櫱	jit
 热	jit
-熱	jit	1000
+熱	jit
 糱	jit
 臬	jit
 臬	nip
@@ -12140,8 +12141,8 @@ min_phrase_weight: 100
 蘗	jit
 蘗	paak
 蠮	jit
-謁	jit	500
-謁	kit	500
+謁	jit
+謁	kit
 钀	jit
 齧	jit
 齧	ngaat
@@ -12157,17 +12158,17 @@ min_phrase_weight: 100
 䬙	jiu
 䬙	ziu
 么	jiu
-么	mo	0
+么	mo	0%
 偠	jiu
 傜	jiu
-吆	jiu	500
+吆	jiu
 喓	jiu
 喓	oe
 垚	jiu
-堯	jiu	1000
-夭	jiu	1000
-妖	jiu	1000
-姚	jiu	500
+堯	jiu
+夭	jiu
+妖	jiu
+姚	jiu
 娆	jiu
 媱	jiu
 嬈	jiu
@@ -12176,18 +12177,18 @@ min_phrase_weight: 100
 尧	jiu
 峣	jiu
 嶢	jiu
-幺	jiu	500
+幺	jiu
 徭	jiu
 愮	jiu
 愰	jiu
 扰	jiu
 抭	jiu
-搖	jiu	1000
+搖	jiu
 摇	jiu
-擾	jiu	1000
+擾	jiu
 曜	jiu
-杳	jiu	500
-杳	miu	500
+杳	jiu
+杳	miu
 榣	jiu
 橈	jiu
 橈	naau
@@ -12198,60 +12199,60 @@ min_phrase_weight: 100
 燿	jiu
 猺	jiu
 珧	jiu
-瑤	jiu	1000
+瑤	jiu
 瑶	jiu
 眑	jiu
-祆	jiu	500
+祆	jiu
 穾	jiu
 窅	jiu
-窈	jiu	500
-窈	miu	500
+窈	jiu
+窈	miu
 窑	jiu
 窔	jiu
-窯	jiu	500
+窯	jiu
 窰	jiu
 筄	jiu
-繞	jiu	1000
+繞	jiu
 绕	jiu
-耀	jiu	1000
-腰	jiu	1000
-舀	jiu	500
+耀	jiu
+腰	jiu
+舀	jiu
 荛	jiu
 葽	jiu
 蕘	jiu
 蛲	jiu
-蟯	jiu	500
-蟯	naau	500
+蟯	jiu
+蟯	naau
 襓	jiu
-要	jiu	1000
-謠	jiu	1000
+要	jiu
+謠	jiu
 谣	jiu
 軺	jiu
 轺	jiu
-遙	jiu	1000
+遙	jiu
 遥	jiu
 遶	jiu
-邀	jiu	1000
+邀	jiu
 陶	jiu	0%
-陶	tou	1000
+陶	tou
 颻	jiu
 飖	jiu
-饒	jiu	1000
+饒	jiu
 饶	jiu
 騕	jiu
 鰩	jiu
 鳐	jiu
-鷂	jiu	500
+鷂	jiu
 鷕	jiu
 鹞	jiu
 𨍳	jiu
 哟	jo
-唷	jo	500
-喲	jo	1000
+唷	jo
+喲	jo
 㜰	joek
 㜰	zoek
-弱	joek	1000
-曰	joek	1000
+弱	joek
+曰	joek
 曰	jyut	0%
 楉	joek
 汋	joek
@@ -12260,40 +12261,40 @@ min_phrase_weight: 100
 瀹	joek
 爚	joek
 疟	joek
-瘧	joek	500
+瘧	joek
 礿	joek
 禴	joek
 箬	joek
 篛	joek
 籥	joek
 籲	joek	0%
-籲	jyu	1000
-約	joek	1000
+籲	jyu
+約	joek
 约	joek
 药	joek
 葯	joek
 蒻	joek
 薬	joek
-藥	joek	1000
+藥	joek
 蘥	joek
-虐	joek	1000
+虐	joek
 謔	joek
 谑	joek
 跃	joek
 跃	tik
-躍	joek	1000
+躍	joek
 躍	tik	0%
 鄀	joek
 鈅	joek
-鑰	joek	1000
+鑰	joek
 钥	joek
 龠	joek
 䄃	joeng
 䄃	zoeng
 䬬	joeng
 䬬	zoeng
-仰	joeng	1000
-仰	ngong	501
+仰	joeng
+仰	ngong	4%
 佒	joeng
 儴	joeng
 养	joeng
@@ -12301,71 +12302,71 @@ min_phrase_weight: 100
 勷	soeng
 卬	joeng
 卬	ngong
-嚷	joeng	1000
+嚷	joeng
 坱	joeng
 垟	joeng
 埌	joeng
 埌	long
 壌	joeng
-壤	joeng	1000
-央	joeng	1000
+壤	joeng
+央	joeng
 姎	joeng
 徉	joeng
-怏	joeng	500
-恙	joeng	500
+怏	joeng
+恙	joeng
 扬	joeng
 抰	joeng
-揚	joeng	1000
-攘	joeng	500
+揚	joeng
+攘	joeng
 旸	joeng
 昜	joeng
 暘	joeng
 杨	joeng
 柍	joeng
 样	joeng
-楊	joeng	1000
-樣	joeng	1000
-殃	joeng	500
-氧	joeng	1000
-泱	joeng	500
-洋	joeng	1000
-漾	joeng	1000
+楊	joeng
+樣	joeng
+殃	joeng
+氧	joeng
+泱	joeng
+洋	joeng
+漾	joeng
 瀁	joeng
 瀼	joeng
 炀	joeng
-烊	joeng	500
-煬	joeng	500
+烊	joeng
+煬	joeng
 獽	joeng
 疡	joeng
 痒	joeng
-瘍	joeng	500
-癢	joeng	1000
+瘍	joeng
+癢	joeng
 禓	joeng
 禳	joeng
-秧	joeng	1000
+秧	joeng
 穰	joeng
-羊	joeng	1000
+羊	joeng
 羕	joeng
 蘘	joeng
 蛘	joeng
 蠰	joeng
-讓	joeng	1000
+讓	joeng
 让	joeng
 躟	joeng
 躟	nong
 酿	joeng
-釀	joeng	1000
+釀	joeng
 鉠	joeng
 鍚	joeng
 钖	joeng
 阳	joeng
-陽	joeng	1000
-鞅	joeng	500
-颺	joeng	500
+陽	joeng
+鞅	joeng
+颺	joeng
 飏	joeng
-養	joeng	1000
+養	joeng
 鬤	joeng
-鴦	joeng	1000
+鴦	joeng
 鸉	joeng
 鸯	joeng
 䏁	joi
@@ -12376,39 +12377,39 @@ min_phrase_weight: 100
 儥	juk
 噢	juk	0%
 噢	jyu	0%
-噢	ou	200
+噢	ou
 堉	juk
 媷	juk
 宍	juk
-峪	juk	500
-峪	jyu	500
+峪	juk
+峪	jyu
 彧	juk
-慾	juk	1000
-旭	juk	500
+慾	juk
+旭	juk
 昱	juk
-欲	juk	1000
-毓	juk	500
-沃	juk	1000
-浴	juk	1000
+欲	juk
+毓	juk
+沃	juk
+浴	juk
 淯	juk
 溽	juk
 澳	juk	0%
-澳	ou	1000
-煜	juk	500
+澳	ou
+煜	juk
 燠	juk
 狱	juk
-獄	juk	1000
-玉	juk	1000
+獄	juk
+玉	juk
 縟	juk
 缛	juk
-肉	juk	1000
-育	juk	1000
+肉	juk
+育	juk
 蓐	juk
 薁	juk
-褥	juk	1000
-辱	juk	1000
+褥	juk
+辱	juk
 逳	juk
-郁	juk	1000
+郁	juk
 郁	jyu	0%
 鄏	juk
 鈺	juk
@@ -12427,78 +12428,78 @@ min_phrase_weight: 100
 㣑	zung
 䇯	jung
 䇯	zung
-佣	jung	1000
-俑	jung	500
+佣	jung
+俑	jung
 傛	jung
-傭	jung	1000
+傭	jung
 冗	jung
-勇	jung	1000
+勇	jung
 喁	jung
 喁	jyu
 嗈	jung
-嗡	jung	1000
+嗡	jung
 噰	jung
 塕	jung
 墉	jung
-壅	jung	500
-宂	jung	500
-容	jung	1000
+壅	jung
+宂	jung
+容	jung
 嵱	jung
-庸	jung	1000
+庸	jung
 廱	jung
-恿	jung	500
+恿	jung
 慂	jung
 慵	jung
-戎	jung	500
+戎	jung
 拥	jung
-擁	jung	1000
+擁	jung
 擁	ung	0%
-榕	jung	1000
+榕	jung
 毧	jung
 氄	jung
-湧	jung	1000
-溶	jung	1000
+湧	jung
+溶	jung
 滃	jung
 滽	jung
 澭	jung
 濃	jung	0%
-濃	nung	1000
+濃	nung
 瀜	jung
 灉	jung
-熔	jung	1000
+熔	jung
 狨	jung
 瑢	jung
-用	jung	1000
-甬	jung	500
+用	jung
+甬	jung
 痈	jung
 癰	jung
-絨	jung	1000
+絨	jung
 绒	jung
 羢	jung
-翁	jung	1000
+翁	jung
 肜	jung
-臃	jung	500
+臃	jung
 茙	jung
-茸	jung	500
-蓉	jung	500
+茸	jung
+蓉	jung
 蓊	jung
 蕹	jung
 蕹	ngung
 蕹	ung
-蛹	jung	500
+蛹	jung
 螉	jung
-融	jung	1000
+融	jung
 螎	jung
 踊	jung
-踴	jung	1000
-邕	jung	500
+踴	jung
+邕	jung
 鄘	jung
 鄘	tong
-鎔	jung	500
+鎔	jung
 鏞	jung
 镕	jung
 镛	jung
-雍	jung	500
+雍	jung
 雝	jung
 顒	jung
 颙	jung
@@ -12522,48 +12523,48 @@ min_phrase_weight: 100
 䰻	jyu
 䰻	zyu
 与	jyu
-乳	jyu	1000
-予	jyu	1000
-于	jyu	1000
+乳	jyu
+予	jyu
+于	jyu
 伃	jyu
 伛	jyu
-余	jyu	1000
+余	jyu
 俁	jyu
-俞	jyu	500
+俞	jyu
 俣	jyu
 傴	jyu
-儒	jyu	1000
+儒	jyu
 兪	jyu
-喻	jyu	1000
+喻	jyu
 噳	jyu
 噳	koek
-嚅	jyu	500
+嚅	jyu
 圄	jyu
 圉	jyu
 女	jyu	0%
-女	neoi	1000
-如	jyu	1000
-妤	jyu	500
+女	neoi
+如	jyu
+妤	jyu
 妪	jyu
-娛	jyu	1000
+娛	jyu
 娱	jyu
-嫗	jyu	1000
+嫗	jyu
 嬬	jyu
-孺	jyu	500
-宇	jyu	1000
-寓	jyu	1000
+孺	jyu
+宇	jyu
+寓	jyu
 屿	jyu
 屿	zeoi
 嵎	jyu
 嶼	jyu	0%
-嶼	zeoi	1000
+嶼	zeoi
 帤	jyu
-庾	jyu	500
-御	jyu	1000
+庾	jyu
+御	jyu
 御	ngaa	0%
-愈	jyu	1000
-愉	jyu	1000
-愚	jyu	1000
+愈	jyu
+愉	jyu
+愚	jyu
 扜	jyu
 扵	jyu
 挐	jyu
@@ -12572,63 +12573,63 @@ min_phrase_weight: 100
 揄	jyu
 敔	jyu
 斞	jyu
-於	jyu	1000
+於	jyu
 於	wu	0%
 旟	jyu
 杅	jyu
 棜	jyu
 楰	jyu
-榆	jyu	500
+榆	jyu
 欤	jyu
 歈	jyu
-歟	jyu	500
+歟	jyu
 毹	jyu
 毹	syu
-汝	jyu	1000
+汝	jyu
 洳	jyu
-淤	jyu	1000
+淤	jyu
 渔	jyu
-渝	jyu	500
+渝	jyu
 湡	jyu
 滪	jyu
-漁	jyu	1000
+漁	jyu
 澦	jyu
-濡	jyu	500
-濡	nyun	500
+濡	jyu
+濡	nyun
 牏	jyu
 牏	tau
 狳	jyu
 玗	jyu
 瑀	jyu
-瑜	jyu	500
+瑜	jyu
 璵	jyu
 畬	jyu
 畬	se
 瘉	jyu
 瘐	jyu
-癒	jyu	1000
-盂	jyu	500
+癒	jyu
+盂	jyu
 睮	jyu
 礜	jyu
-禦	jyu	1000
-禹	jyu	500
+禦	jyu
+禹	jyu
 禺	jyu
 窬	jyu
 窳	jyu
-竽	jyu	500
+竽	jyu
 籹	jyu
 紆	jyu
 纡	jyu
 羭	jyu
-羽	jyu	1000
+羽	jyu
 腴	jyu
-臾	jyu	500
+臾	jyu
 舁	jyu
 舆	jyu
-與	jyu	1000
+與	jyu
 艅	jyu
-茹	jyu	500
-萸	jyu	1000
+茹	jyu
+萸	jyu
 蒘	jyu
 蓣	jyu
 蕍	jyu
@@ -12638,38 +12639,38 @@ min_phrase_weight: 100
 藇	jyu
 藇	zeoi
 蘌	jyu
-虞	jyu	500
+虞	jyu
 蝓	jyu
 蝡	jyu
 蝡	jyun
-蠕	jyu	500
-蠕	jyun	500
+蠕	jyu
+蠕	jyun
 衧	jyu
 袽	jyu
-裕	jyu	1000
+裕	jyu
 褕	jyu
 襦	jyu
-覦	jyu	500
+覦	jyu
 觎	jyu
 誉	jyu
-語	jyu	1000
+語	jyu
 諛	jyu
-諭	jyu	1000
+諭	jyu
 謣	jyu
-譽	jyu	1000
+譽	jyu
 语	jyu
 谀	jyu
 谕	jyu
-豫	jyu	1000
+豫	jyu
 貐	jyu
 踰	jyu
-輿	jyu	1000
+輿	jyu
 轝	jyu
-逾	jyu	1000
-遇	jyu	1000
+逾	jyu
+遇	jyu
 邘	jyu
 鄅	jyu
-酗	jyu	500
+酗	jyu
 醧	jyu
 醹	jyu
 釪	jyu
@@ -12681,25 +12682,25 @@ min_phrase_weight: 100
 陓	jyu
 陓	wu
 隃	jyu
-隅	jyu	500
-雨	jyu	1000
+隅	jyu
+雨	jyu
 雩	jyu
-預	jyu	1000
+預	jyu
 预	jyu
 飫	jyu
-餘	jyu	1000
+餘	jyu
 饇	jyu
 饫	jyu
 馀	jyu
-馭	jyu	500
+馭	jyu
 驭	jyu
-魚	jyu	1000
+魚	jyu
 鱼	jyu
 鴽	jyu
 鸆	jyu
 鸒	jyu
 麌	jyu
-齬	jyu	500
+齬	jyu
 齵	jyu
 龉	jyu
 龥	jyu
@@ -12714,20 +12715,20 @@ min_phrase_weight: 100
 䡱	zyun
 䲮	jyun
 䲮	zyun
-丸	jyun	1000
+丸	jyun
 倇	jyun
-元	jyun	1000
-冤	jyun	1000
+元	jyun
+冤	jyun
 刓	jyun
-原	jyun	1000
+原	jyun
 县	jyun
 员	jyun
-員	jyun	1000
+員	jyun
 員	wan	0%
 园	jyun
 圆	jyun
-園	jyun	1000
-圓	jyun	1000
+園	jyun
+圓	jyun
 圜	jyun
 圜	waan
 垸	jyun
@@ -12736,27 +12737,27 @@ min_phrase_weight: 100
 夗	jyun
 奫	jyun
 奫	wan
-婉	jyun	1000
-媛	jyun	500
-媛	wun	500
+婉	jyun
+媛	jyun
+媛	wun
 嫄	jyun
-完	jyun	1000
-宛	jyun	1000
+完	jyun
+宛	jyun
 寃	jyun
 岏	jyun
-怨	jyun	1000
+怨	jyun
 悬	jyun
-惋	jyun	1000
+惋	jyun
 惋	wun	0%
 惌	jyun
-愿	jyun	500
-懸	jyun	1000
+愿	jyun
+懸	jyun
 抏	jyun
 抏	waan
 抏	wun
 掾	jyun
-援	jyun	1000
-援	wun	1000
+援	jyun
+援	wun
 昡	jyun
 晼	jyun
 杬	jyun
@@ -12765,23 +12766,23 @@ min_phrase_weight: 100
 橼	jyun
 櫞	jyun
 汍	jyun
-沅	jyun	500
-沿	jyun	1000
+沅	jyun
+沿	jyun
 泫	jyun
 洹	jyun
 洹	wun
-淵	jyun	1000
+淵	jyun
 渊	jyun
 湲	jyun
 湲	wun
-源	jyun	1000
-炫	jyun	1000
+源	jyun
+炫	jyun
 烷	jyun
-爰	jyun	500
-爰	wun	500
+爰	jyun
+爰	wun
 猨	jyun
-猿	jyun	1000
-玄	jyun	500
+猿	jyun
+玄	jyun
 琬	jyun
 瑗	jyun
 瓀	jyun
@@ -12789,13 +12790,13 @@ min_phrase_weight: 100
 盷	jyun
 盷	tin
 眢	jyun
-眩	jyun	500
+眩	jyun
 睕	jyun
 睕	waan
 礝	jyun
 紈	jyun
-緣	jyun	1000
-縣	jyun	1000
+緣	jyun
+縣	jyun
 繯	jyun
 繯	waan
 纨	jyun
@@ -12805,7 +12806,7 @@ min_phrase_weight: 100
 肙	jyun
 芄	jyun
 芫	jyun
-苑	jyun	500
+苑	jyun
 菀	jyun
 葾	jyun
 蒝	jyun
@@ -12813,39 +12814,39 @@ min_phrase_weight: 100
 薳	wai
 蚖	jyun
 蜎	jyun
-蜿	jyun	1000
+蜿	jyun
 蝝	jyun
 蝯	jyun
 螈	jyun
 衒	jyun
-袁	jyun	500
+袁	jyun
 褑	jyun
 豲	jyun
 豲	wun
 踠	jyun
-軟	jyun	1000
+軟	jyun
 輭	jyun
 輲	jyun
 輲	syun
-轅	jyun	500
+轅	jyun
 软	jyun
 辕	jyun
 远	jyun
-遠	jyun	1000
+遠	jyun
 邍	jyun
 邧	jyun
 鈆	jyun
 鉉	jyun
-鉛	jyun	1000
+鉛	jyun
 铅	jyun
 铉	jyun
-阮	jyun	500
-院	jyun	1000
-隕	jyun	500
-隕	wan	500
-願	jyun	1000
+阮	jyun
+院	jyun
+隕	jyun
+隕	wan
+願	jyun
 騵	jyun
-鳶	jyun	500
+鳶	jyun
 鵷	jyun
 鶢	jyun
 鸢	jyun
@@ -12855,39 +12856,39 @@ min_phrase_weight: 100
 鼋	jyun
 鼘	jyun
 䮑	jyut
-乙	jyut	1000
+乙	jyut
 刖	jyut
 哕	jyut
 噦	jyut
 噦	wai
 悅	jyut
-悦	jyut	1000
+悦	jyut
 戉	jyut
 抈	jyut
-月	jyut	1000
+月	jyut
 樾	jyut
 泧	jyut
 泧	kut
 泧	kwut
 爇	jyut
 玥	jyut
-穴	jyut	1000
+穴	jyut
 粤	jyut
-粵	jyut	1000
-聿	jyut	500
-聿	leot	500
-聿	wat	500
-說	jyut	0
+粵	jyut
+聿	jyut
+聿	leot
+聿	wat
+說	jyut	0%
 說	seoi
 說	syut
-越	jyut	1000
+越	jyut
 軏	jyut
 釔	jyut
 鉞	jyut
 钇	jyut
 钺	jyut
 閱	jyut
-閲	jyut	1000
+閲	jyut
 阅	jyut
 鳦	jyut
 𫐄	jyut
@@ -12898,8 +12899,8 @@ min_phrase_weight: 100
 䯊	kaa
 䯊	o
 佧	kaa
-卡	kaa	1000
-卡	kaat	1000
+卡	kaa
+卡	kaat
 咔	kaa
 擖	kaa
 擖	kat
@@ -12947,9 +12948,9 @@ min_phrase_weight: 100
 䉚	ngaa
 䎋	kaau
 䳹	kaau
-銬	kaau	500
+銬	kaau
 铐	kaau
-靠	kaau	1000
+靠	kaau
 㒅	kai
 㡁	kai
 㡁	kwaa
@@ -12960,8 +12961,8 @@ min_phrase_weight: 100
 䭬	kai
 启	kai
 啓	kai
-啟	kai	1000
-契	kai	1000
+啟	kai
+契	kai
 契	kit	0%
 契	sit	0%
 嵇	kai
@@ -12970,13 +12971,13 @@ min_phrase_weight: 100
 愒	koi
 栔	kai
 棨	kai
-溪	kai	1000
+溪	kai
 瘈	kai
 瘈	zai
 瘛	kai
 磎	kai
-稽	kai	1000
-谿	kai	500
+稽	kai
+谿	kai
 鸂	kai
 揢	kak
 𠸉	kak
@@ -12985,28 +12986,28 @@ min_phrase_weight: 100
 䔷	kam
 䥅	kam
 䥆	kam
-噙	kam	500
+噙	kam
 妗	kam
 捦	kam
-擒	kam	1000
+擒	kam
 檎	kam
-琴	kam	1000
-禽	kam	1000
+琴	kam
+禽	kam
 芩	kam
 蠄	kam
 衾	kam
-襟	kam	1000
+襟	kam
 靲	kam
 𠸐	kam
 𠹸	kam
 𢫏	kam
 㘦	kan
-勤	kan	1000
+勤	kan
 慬	kan
 懃	kan
 懄	kan
 斳	kan
-芹	kan	1000
+芹	kan
 掯	kang
 裉	kang
 𠼰	kang
@@ -13015,18 +13016,18 @@ min_phrase_weight: 100
 㬛	kap
 㲸	kap
 伋	kap
-吸	kap	1000
+吸	kap
 吸	ngap	0%
 圾	kap	0%
-圾	saap	1000
+圾	saap
 扱	kap
 歙	kap
 歙	sip
-汲	kap	1000
+汲	kap
 盵	kap
 笈	kap
-級	kap	1000
-給	kap	1000
+級	kap
+給	kap
 级	kap
 给	kap
 鈒	kap
@@ -13045,43 +13046,43 @@ min_phrase_weight: 100
 䟵	kau
 䣇	kau
 䤛	kau
-佝	kau	500
-佝	keoi	500
+佝	kau
+佝	keoi
 俅	kau
 厹	kau
-叩	kau	500
+叩	kau
 叴	kau
-寇	kau	500
+寇	kau
 巯	kau
 巰	kau
 彄	kau
 怐	kau
 怐	ngau
-扣	kau	1000
+扣	kau
 抠	kau
 摳	kau
 桕	kau
 梂	kau
 毬	kau
-求	kau	1000
+求	kau
 滱	kau
 犰	kau
-球	kau	1000
+球	kau
 璆	kau
 筘	kau
 簆	kau
 絿	kau
 缑	kau
-臼	kau	1000
-舅	kau	1000
+臼	kau
+舅	kau
 艽	kau
 芤	kau
 蔲	kau
 蔻	kau
 虬	kau
-虯	kau	500
+虯	kau
 蛷	kau
-裘	kau	500
+裘	kau
 觓	kau
 觩	kau
 訄	kau
@@ -13089,11 +13090,11 @@ min_phrase_weight: 100
 赇	kau
 逑	kau
 釚	kau
-釦	kau	500
+釦	kau
 銶	kau
 鷇	kau
 鼽	kau
-瘸	ke	500
+瘸	ke
 𡲢	ke
 企	kei	5
 㞿	kei
@@ -13121,38 +13122,38 @@ min_phrase_weight: 100
 䶞	kei
 亓	kei
 俟	kei	0%
-俟	zi	1000
-冀	kei	1000
+俟	zi
+冀	kei
 圻	kei
 圻	ngan
 埼	kei
-岐	kei	500
-崎	kei	1000
+岐	kei
+崎	kei
 懻	kei
 攲	kei
 旂	kei
-旗	kei	1000
-暨	kei	500
+旗	kei
+暨	kei
 枝	kei	0%
-枝	zi	1000
+枝	zi
 桤	kei
 棊	kei
-棋	kei	1000
-歧	kei	1000
-淇	kei	1000
-琦	kei	500
-琪	kei	500
+棋	kei
+歧	kei
+淇	kei
+琦	kei
+琪	kei
 疧	kei
 碁	kei
 碕	kei
-祁	kei	500
-祇	kei	500
-祇	zi	500
-祈	kei	1000
-祺	kei	500
+祁	kei
+祇	kei
+祇	zi
+祈	kei
+祺	kei
 竒	kei
 綦	kei
-耆	kei	500
+耆	kei
 肵	kei
 臮	kei
 芪	kei
@@ -13169,7 +13170,7 @@ min_phrase_weight: 100
 颀	kei
 騏	kei
 騹	kei
-驥	kei	500
+驥	kei
 骐	kei
 骑	kei
 骥	kei
@@ -13179,15 +13180,15 @@ min_phrase_weight: 100
 鮨	ngai
 鮨	zi
 鯕	kei
-鰭	kei	1000
+鰭	kei
 鳍	kei
-麒	kei	500
+麒	kei
 𨀣	kei
 㘌	kek
 乪	kek
 剧	kek
-劇	kek	1000
-屐	kek	500
+劇	kek
+屐	kek
 𢲈	kek
 𢲈	kik
 㜹	keoi
@@ -13211,17 +13212,17 @@ min_phrase_weight: 100
 䮃	keoi
 䵶	keoi
 佉	keoi
-劬	keoi	500
+劬	keoi
 呿	keoi
 岖	keoi
-嶇	keoi	1000
+嶇	keoi
 懅	keoi
-拒	keoi	1000
-拘	keoi	1000
+拒	keoi
+拘	keoi
 斪	keoi
 朐	keoi
 氍	keoi
-渠	keoi	1000
+渠	keoi
 灈	keoi
 璩	keoi
 痀	keoi
@@ -13238,16 +13239,16 @@ min_phrase_weight: 100
 蕖	keoi
 蘧	keoi
 蟝	keoi
-衢	keoi	500
+衢	keoi
 袪	keoi
 跔	keoi
 躣	keoi
 躯	keoi
-軀	keoi	1000
+軀	keoi
 軥	keoi
 阹	keoi
-駒	keoi	500
-驅	keoi	1000
+駒	keoi
+驅	keoi
 驱	keoi
 驹	keoi
 鮈	keoi
@@ -13258,19 +13259,19 @@ min_phrase_weight: 100
 䈤	kim
 岒	kim
 拑	kim
-箝	kim	500
-鈐	kim	500
-鉗	kim	1000
+箝	kim
+鈐	kim
+鉗	kim
 钤	kim
 钳	kim
-黔	kim	500
+黔	kim
 黚	kim
 㨜	kin
 㩮	kin
 䖍	kin
 掮	kin
 揵	kin
-虔	kin	1000
+虔	kin
 鰬	kin
 㒌	king
 㔀	king
@@ -13285,24 +13286,24 @@ min_phrase_weight: 100
 䔛	loek
 䵞	king
 倾	king
-傾	king	1000
+傾	king
 勍	king
 墘	king
 廎	king
 惸	king
-擎	king	1000
+擎	king
 檠	king
 焭	king
 煢	king
 琼	king
-瓊	king	500
+瓊	king
 睘	king
 瞏	king
 茕	king
 藑	king
-頃	king	1000
+頃	king
 顷	king
-鯨	king	1000
+鯨	king
 鲸	king
 黥	king
 𢐧	king
@@ -13312,9 +13313,9 @@ min_phrase_weight: 100
 㼤	kit
 䅥	kit
 劼	kit
-孑	kit	500
-挈	kit	500
-揭	kit	1000
+孑	kit
+挈	kit
+揭	kit
 朅	kit
 楬	kit
 碣	kit
@@ -13323,10 +13324,10 @@ min_phrase_weight: 100
 纈	lit
 缬	kit
 缬	lit
-羯	kit	500
-訐	kit	500
+羯	kit
+訐	kit
 讦	kit
-鍥	kit	500
+鍥	kit
 锲	kit
 㚁	kiu
 㝯	kiu
@@ -13336,16 +13337,16 @@ min_phrase_weight: 100
 䱁	kiu
 乔	kiu
 侨	kiu
-僑	kiu	1000
-喬	kiu	1000
+僑	kiu
+喬	kiu
 嘺	kiu
 桥	kiu
-橋	kiu	1000
+橋	kiu
 皛	kiu
 皛	miu
 礄	kiu
 翘	kiu
-翹	kiu	500
+翹	kiu
 荍	kiu
 荞	kiu
 蕎	kiu
@@ -13361,7 +13362,7 @@ min_phrase_weight: 100
 㾡	koek
 䐘	koek
 却	koek
-卻	koek	1000
+卻	koek
 臄	koek
 㩖	koeng
 嵹	koeng
@@ -13377,16 +13378,16 @@ min_phrase_weight: 100
 㧉	koi
 䏗	koi
 䏗	kui
-丐	koi	1000
+丐	koi
 忾	koi
-愾	koi	500
-慨	koi	1000
+愾	koi
+慨	koi
 戤	koi
-概	koi	1000
+概	koi
 槪	koi
-溉	koi	1000
+溉	koi
 漑	koi
-鈣	koi	1000
+鈣	koi
 钙	koi
 㤩	kok
 㩁	kok
@@ -13399,36 +13400,36 @@ min_phrase_weight: 100
 䶅	kok
 䶅	lok
 塙	kok
-壑	kok	500
-恪	kok	500
+壑	kok
+恪	kok
 悫	kok
 愘	kok
 愨	kok
 慤	kok
 搉	kok
-榷	kok	500
-涸	kok	500
+榷	kok
+涸	kok
 确	kok
-確	kok	1000
+確	kok
 碻	kok
 礐	kok
 㢜	kong
 㰠	kong
 䊯	kong
 䊯	kwong
-伉	kong	500
+伉	kong
 匟	kong
 夼	kong
 夼	kwaang
 夼	kwong
 懭	kong
 懭	kwong
-抗	kong	1000
+抗	kong
 爌	kong
 爌	kwong
 犺	kong
 狂	kong	0%
-狂	kwong	1000
+狂	kwong
 矿	kong
 邟	kong
 鈧	kong
@@ -13454,7 +13455,7 @@ min_phrase_weight: 100
 䭝	kui
 䯤	kui
 侩	kui
-儈	kui	500
+儈	kui
 刽	kui
 廥	kui
 廥	kwui
@@ -13462,21 +13463,21 @@ min_phrase_weight: 100
 憒	kui
 旝	kui
 桧	kui
-檜	kui	500
+檜	kui
 浍	kui
 溃	kui
-潰	kui	1000
+潰	kui
 澮	kui
 狯	kui
 獪	kui
 繢	kui
-繪	kui	1000
+繪	kui
 绘	kui
 缋	kui
 聩	kui
 聵	kui
 脍	kui
-膾	kui	500
+膾	kui
 荟	kui
 荟	wai
 荟	wui
@@ -13490,7 +13491,7 @@ min_phrase_weight: 100
 㖆	kuk
 㻃	kuk
 䢗	kuk
-曲	kuk	1000
+曲	kuk
 蛐	kuk
 㑋	kung
 㤟	kung
@@ -13503,7 +13504,7 @@ min_phrase_weight: 100
 䠻	kung
 匑	kung
 穷	kung
-窮	kung	1000
+窮	kung
 竆	kung
 笻	kung
 筇	kung
@@ -13522,13 +13523,13 @@ min_phrase_weight: 100
 䯺	kut
 佸	kut
 佸	wut
-括	kut	1000
+括	kut
 栝	kut
 濊	kut
 濊	wai
 筈	kut
 聒	kut
-豁	kut	500
+豁	kut
 适	kut
 适	sik
 髺	kut
@@ -13539,13 +13540,13 @@ min_phrase_weight: 100
 䋀	kwaa
 䯞	kwaa
 侉	kwaa
-垮	kwaa	1000
-夸	kwaa	500
+垮	kwaa
+夸	kwaa
 姱	kwaa
 胯	kwaa
 荂	kwaa
-誇	kwaa	1000
-跨	kwaa	1000
+誇	kwaa
+跨	kwaa
 銙	kwaa
 骻	kwaa
 㛻	kwaai
@@ -13597,32 +13598,32 @@ min_phrase_weight: 100
 巂	kwai
 巂	seoi
 巋	kwai
-愧	kwai	1000
+愧	kwai
 戣	kwai
-揆	kwai	500
+揆	kwai
 携	kwai
-攜	kwai	1000
+攜	kwai
 暌	kwai
 槻	kwai
 槼	kwai
 犪	kwai
-畦	kwai	500
-盔	kwai	500
+畦	kwai
+盔	kwai
 眭	kwai
 眭	seoi
-睽	kwai	500
+睽	kwai
 瞡	kwai
 窥	kwai
-窺	kwai	500
+窺	kwai
 聧	kwai
-葵	kwai	1000
+葵	kwai
 蠵	kwai
-規	kwai	1000
+規	kwai
 规	kwai
 觿	kwai
 跬	kwai
 蹞	kwai
-逵	kwai	500
+逵	kwai
 酅	kwai
 鑴	kwai
 闚	kwai
@@ -13639,9 +13640,9 @@ min_phrase_weight: 100
 㪊	kwan
 㿏	kwan
 䖵	kwan
-困	kwan	1000
+困	kwan
 囷	kwan
-坤	kwan	1000
+坤	kwan
 堃	kwan
 壸	kwan
 壼	kwan
@@ -13649,23 +13650,23 @@ min_phrase_weight: 100
 峮	kwan
 悃	kwan
 捃	kwan
-捆	kwan	1000
+捆	kwan
 攗	kwan
 攗	mei
 梱	kwan
 猑	kwan
-睏	kwan	500
+睏	kwan
 碅	kwan
 稇	kwan
 稛	kwan
-窘	kwan	500
+窘	kwan
 箘	kwan
-綑	kwan	500
-羣	kwan	1000
+綑	kwan
+羣	kwan
 群	kwan
-菌	kwan	1000
+菌	kwan
 菎	kwan
-裙	kwan	1000
+裙	kwan
 閫	kwan
 阃	kwan
 騉	kwan
@@ -13681,10 +13682,10 @@ min_phrase_weight: 100
 䵃	kwong
 䵃	wong
 圹	kwong
-壙	kwong	500
+壙	kwong
 扩	kwong
 旷	kwong
-曠	kwong	1000
+曠	kwong
 纊	kwong
 纩	kwong
 邝	kwong
@@ -13693,9 +13694,9 @@ min_phrase_weight: 100
 䠰	kyun
 巏	kyun
 惓	kyun
-拳	kyun	1000
+拳	kyun
 权	kyun
-權	kyun	1000
+權	kyun
 蜷	kyun
 蠸	kyun
 踡	kyun
@@ -13724,29 +13725,29 @@ min_phrase_weight: 100
 䮹	waai
 亅	kyut
 决	kyut
-厥	kyut	500
+厥	kyut
 噘	kyut
-孓	kyut	500
-抉	kyut	500
+孓	kyut
+抉	kyut
 撅	kyut
-決	kyut	1000
-獗	kyut	500
+決	kyut
+獗	kyut
 玦	kyut
-缺	kyut	1000
+缺	kyut
 芵	kyut
 蒛	kyut
-蕨	kyut	500
+蕨	kyut
 蟨	kyut
 觖	kyut
 觼	kyut
-訣	kyut	1000
-譎	kyut	500
+訣	kyut
+譎	kyut
 诀	kyut
 谲	kyut
 趹	kyut
 鈌	kyut
 鐍	kyut
-闋	kyut	500
+闋	kyut
 闕	kyut
 阕	kyut
 阙	kyut
@@ -13761,11 +13762,11 @@ min_phrase_weight: 100
 㙈	laa
 㙤	laa
 䖃	laa
-啦	laa	1000
+啦	laa
 嘑	laa
 嚹	laa
 拉	laa	0%
-拉	laai	1000
+拉	laai
 拉	laap	0%
 揦	laa
 砬	laa
@@ -13799,17 +13800,17 @@ min_phrase_weight: 100
 攋	laai
 濑	laai
 癞	laai
-癩	laai	500
+癩	laai
 籁	laai
-籟	laai	500
-舐	laai	500
-舐	lem	500
-舐	lim	500
-舐	saai	500
+籟	laai
+舐	laai
+舐	lem
+舐	lim
+舐	saai
 落	laai	0%
-落	lok	1000
+落	lok
 藾	laai
-賴	laai	1000
+賴	laai
 赖	laai
 酹	laai
 酹	lyut
@@ -13820,14 +13821,14 @@ min_phrase_weight: 100
 㖀	laak
 㖀	lak
 㖀	leot
-勒	laak	200
-勒	lak	1000
+勒	laak
+勒	lak
 嘞	laak
 嘞	lak	1000
 砳	laak
 砳	lak
-肋	laak	200
-肋	lak	1000
+肋	laak
+肋	lak
 𨊛	laak
 㜮	laam
 㞩	laam
@@ -13847,34 +13848,34 @@ min_phrase_weight: 100
 䫐	laau
 䰐	laam
 嚂	laam
-婪	laam	500
+婪	laam
 岚	laam
-嵐	laam	500
+嵐	laam
 惏	laam
 揽	laam
 擥	laam
-攬	laam	1000
+攬	laam
 榄	laam
-欖	laam	1000
+欖	laam
 滥	laam
 漤	laam
-濫	laam	1000
+濫	laam
 灠	laam
 爁	laam
 爦	laam
 礛	laam
 箖	laam
 篮	laam
-籃	laam	1000
-纜	laam	1000
+籃	laam
+纜	laam
 缆	laam
 舰	laam
-艦	laam	1000
+艦	laam
 蓝	laam
-藍	laam	1000
+藍	laam
 褴	laam
-襤	laam	500
-覽	laam	1000
+襤	laam
+覽	laam
 览	laam
 轞	laam
 𨅏	laam
@@ -13891,30 +13892,30 @@ min_phrase_weight: 100
 囒	laan
 嬾	laan
 懒	laan
-懶	laan	1000
+懶	laan
 拦	laan
-攔	laan	1000
+攔	laan
 斓	laan
 斕	laan
 栏	laan
-欄	laan	1000
+欄	laan
 澜	laan
-瀾	laan	500
+瀾	laan
 灡	laan
 烂	laan
-爛	laan	1000
+爛	laan
 籣	laan
 糷	laan
-蘭	laan	1000
+蘭	laan
 襴	laan
 讕	laan
 谰	laan
 鑭	laan
 镧	laan
-闌	laan	1000
+闌	laan
 阑	laan
 𢦂	laan
-冷	laang	1000
+冷	laang
 唥	laang
 唥	lang
 㧜	laap
@@ -13925,20 +13926,20 @@ min_phrase_weight: 100
 䃳	laap
 䗶	laap
 䶘	laap
-垃	laap	1000
+垃	laap
 妠	laap
 妠	naap
 擸	laap
 擸	lip
-立	laap	1000
-立	lap	1000
+立	laap
+立	lap
 翋	laap
 腊	laap
 腊	sik
 臈	laap
-臘	laap	1000
-臘	lip	200
-蠟	laap	1000
+臘	laap
+臘	lip
+蠟	laap
 邋	laap
 邋	laat
 鑞	laap
@@ -13950,13 +13951,13 @@ min_phrase_weight: 100
 㻝	laat
 䱫	laat
 䶛	laat
-列	laat	501
-列	lit	1000
-剌	laat	500
+列	laat
+列	lit
+剌	laat
 楋	laat
 瘌	laat
 辢	laat
-辣	laat	1000
+辣	laat
 辣	lat	0%
 迾	laat
 迾	lit
@@ -13989,8 +13990,8 @@ min_phrase_weight: 100
 䱾	laau
 捞	laau
 捞	lou
-撈	laau	1000
-撈	lou	1000
+撈	laau
+撈	lou
 嚟	lai	10000
 嚟	lei
 㒧	lai
@@ -14020,24 +14021,24 @@ min_phrase_weight: 100
 䴡	lai
 䵩	lai
 丽	lai
-來	lai	501
-來	loi	1000
-例	lai	1000
+來	lai
+來	loi
+例	lai
 俪	lai
-儷	lai	500
+儷	lai
 剺	lai
 剺	lei
 劙	lai
 劙	lei
 励	lai
-勵	lai	1000
+勵	lai
 厉	lai
-厲	lai	1000
+厲	lai
 囄	lai
 囄	lei
 悷	lai
 捩	lai	0%
-捩	lit	1000
+捩	lit
 捩	leoi	0%
 攦	lai
 攭	lai
@@ -14046,28 +14047,28 @@ min_phrase_weight: 100
 樏	lai
 樏	leoi
 欐	lai
-澧	lai	500
+澧	lai
 濿	lai
-犁	lai	1000
+犁	lai
 犂	lai
 疠	lai
-癘	lai	500
+癘	lai
 矋	lai
 矖	lai
 砅	lai
 砺	lai
-礪	lai	500
+礪	lai
 礼	lai
-禮	lai	1000
+禮	lai
 粝	lai
 糲	lai
-荔	lai	1000
+荔	lai
 蔾	lai
 藜	lai
 藜	lei
 蛎	lai
-蠡	lai	500
-蠣	lai	500
+蠡	lai
+蠣	lai
 豊	lai
 迣	lai
 迣	lit
@@ -14075,8 +14076,8 @@ min_phrase_weight: 100
 醴	lai
 鱧	lai
 鳢	lai
-麗	lai	1000
-黎	lai	1000
+麗	lai
+黎	lai
 黧	lai
 𡂖	lai
 𡅏	lai
@@ -14120,25 +14121,25 @@ min_phrase_weight: 100
 䕲	lam
 临	lam
 凛	lam
-凜	lam	500
+凜	lam
 啉	lam
 壈	lam
 廩	lam
 廪	lam
-懍	lam	500
+懍	lam
 懔	lam
-林	lam	1000
+林	lam
 檁	lam
 檩	lam
-淋	lam	1000
-琳	lam	1000
-痳	lam	500
-痳	maa	500
+淋	lam
+琳	lam
+痳	lam
+痳	maa
 罧	lam
 罧	sam
-臨	lam	1000
+臨	lam
 菻	lam
-霖	lam	500
+霖	lam
 𡒄	lam
 𠹹	lan
 𠹹	leon
@@ -14158,9 +14159,9 @@ min_phrase_weight: 100
 䤚	lei
 䲞	lap
 搚	lap
-笠	lap	500
-粒	lap	200
-粒	nap	1000
+笠	lap
+粒	lap
+粒	nap
 苙	lap
 镴	lap
 鴗	lap
@@ -14169,7 +14170,7 @@ min_phrase_weight: 100
 䀳	lat
 䏀	lat
 䏀	lit
-甩	lat	1000
+甩	lat
 𢫫	lat
 㐬	lau
 㔷	lau
@@ -14190,13 +14191,13 @@ min_phrase_weight: 100
 偻	lau
 僂	lau
 刘	lau
-劉	lau	1000
+劉	lau
 喽	lau
-嘍	lau	500
+嘍	lau
 嚠	lau
 塿	lau
 娄	lau
-婁	lau	500
+婁	lau
 嵝	lau
 嶁	lau
 廇	lau
@@ -14204,41 +14205,41 @@ min_phrase_weight: 100
 慺	lau
 懰	lau
 搂	lau
-摟	lau	1000
+摟	lau
 旈	lau
 旒	lau
-柳	lau	1000
+柳	lau
 楼	lau
-榴	lau	1000
-樓	lau	1000
+榴	lau
+樓	lau
 橊	lau
-流	lau	1000
+流	lau
 浏	lau
-溜	lau	1000
-溜	liu	501
+溜	lau
+溜	liu	4%
 漊	lau
 漊	lou
-漏	lau	1000
+漏	lau
 漻	lau
 漻	liu
-瀏	lau	1000
-琉	lau	500
+瀏	lau
+琉	lau
 瑠	lau
 璢	lau
-留	lau	1000
+留	lau
 畱	lau
 瘘	lau
-瘤	lau	1000
+瘤	lau
 瘺	lau
 瘻	lau
 癅	lau
 瞜	lau
-硫	lau	500
+硫	lau
 篓	lau
-簍	lau	500
+簍	lau
 綹	lau
-縷	lau	500
-縷	leoi	500
+縷	lau
+縷	leoi
 绺	lau
 罶	lau
 翏	lau
@@ -14252,9 +14253,9 @@ min_phrase_weight: 100
 蒌	lau
 蔞	lau
 蝼	lau
-螻	lau	500
+螻	lau
 蟉	lau
-褸	lau	1000
+褸	lau
 褸	leoi	0%
 謱	lau
 謱	leoi
@@ -14268,30 +14269,30 @@ min_phrase_weight: 100
 镂	lau
 镏	lau
 镠	lau
-陋	lau	1000
+陋	lau
 霤	lau
 露	lau	0%
-露	lou	1000
+露	lou
 鞻	lau
 飀	lau
 飂	lau
 飂	liu
 飗	lau
-餾	lau	500
+餾	lau
 馏	lau
 騮	lau
 骝	lau
 髅	lau
-髏	lau	500
+髏	lau
 鰡	lau
 鶹	lau
 鷚	lau
 鹠	lau
 鹨	lau
 𤠑	lau
-咧	le	500
-哩	le	1000
-哩	lei	1000
+咧	le
+哩	le
+哩	lei
 哩	li	0%
 褦	le
 褦	naai
@@ -14323,67 +14324,67 @@ min_phrase_weight: 100
 䧉	lei
 䱘	lei
 䴻	lei
-俐	lei	1000
-俚	lei	500
-利	lei	1000
+俐	lei
+俚	lei
+利	lei
 厘	lei
-吏	lei	1000
+吏	lei
 唎	lei
 唎	li
-喱	lei	1000
-妳	lei	500
-妳	naai	500
-妳	nei	500
-娌	lei	500
+喱	lei
+妳	lei
+妳	naai
+妳	nei
+娌	lei
 嫠	lei
 孋	lei
-履	lei	1000
+履	lei
 履	leoi	0%
 峛	lei
-李	lei	1000
-梨	lei	1000
+李	lei
+梨	lei
 梩	lei
 棃	lei
 樆	lei
 氂	lei
 氂	moi
-浬	lei	500
+浬	lei
 浰	lei
 浰	lin
 涖	lei
-漓	lei	500
+漓	lei
 漦	lei
 灕	lei
-犛	lei	500
-狸	lei	1000
+犛	lei
+狸	lei
 猁	lei
 猕	lei
 猕	mei
 獼	lei
 獼	mei
 獼	nei
-理	lei	1000
+理	lei
 琍	lei
-璃	lei	1000
+璃	lei
 瓈	lei
-痢	lei	500
+痢	lei
 离	lei
 离	sit
 筣	lei
 篱	lei
-籬	lei	1000
+籬	lei
 縭	lei
 缡	lei
-罹	lei	1000
+罹	lei
 脷	lei
 莅	lei
-莉	lei	500
-蒞	lei	500
+莉	lei
+蒞	lei
 蓠	lei
 蘺	lei
 蜊	lei
 裏	lei	0%
-裏	leoi	1000
+裏	leoi
 裡	lei
 裡	leoi
 褵	lei
@@ -14391,19 +14392,19 @@ min_phrase_weight: 100
 謧	lei
 貍	lei
 逦	lei
-邐	lei	500
+邐	lei
 醨	lei
-里	lei	1000
+里	lei
 鋰	lei
 锂	lei
-離	lei	1000
-霾	lei	500
-霾	maai	500
-霾	mai	500
-驪	lei	500
+離	lei
+霾	lei
+霾	maai
+霾	mai
+驪	lei
 骊	lei
 鬁	lei
-鯉	lei	1000
+鯉	lei
 鱺	lei
 鲡	lei
 鲤	lei
@@ -14423,14 +14424,14 @@ min_phrase_weight: 100
 䈊	liu
 僆	leng
 僆	lin
-嶺	leng	200
-嶺	ling	1000
-靈	leng	501
-靈	ling	1000
+嶺	leng
+嶺	ling
+靈	leng	4%
+靈	ling
 靓	leng
 靓	zing
-領	leng	501
-領	ling	1000
+領	leng
+領	ling
 鮻	leng
 鯪	leng
 鯪	ling
@@ -14470,48 +14471,48 @@ min_phrase_weight: 100
 䯁	leoi
 䴎	leoi
 侣	leoi
-侶	leoi	1000
-儡	leoi	500
+侶	leoi
+儡	leoi
 儢	leoi
 儽	leoi
 勴	leoi
 吕	leoi
-呂	leoi	500
-唳	leoi	500
+呂	leoi
+唳	leoi
 垒	leoi
-壘	leoi	1000
+壘	leoi
 壘	leot	0%
-嫘	leoi	500
+嫘	leoi
 屡	leoi
-屢	leoi	1000
+屢	leoi
 惀	leoi
 惀	leon
-慮	leoi	1000
-戾	leoi	500
-擂	leoi	1000
+慮	leoi
+戾	leoi
+擂	leoi
 攂	leoi
-旅	leoi	1000
+旅	leoi
 梠	leoi
 榈	leoi
 檑	leoi
 櫐	leoi
 櫑	leoi
-櫚	leoi	500
+櫚	leoi
 欙	leoi
 氀	leoi
 沴	leoi
 泪	leoi
-淚	leoi	1000
+淚	leoi
 滤	leoi
 漯	leoi
 漯	lok
 漯	taap
-濾	leoi	1000
+濾	leoi
 灅	leoi
 畾	leoi
 癗	leoi
 盭	leoi
-磊	leoi	500
+磊	leoi
 磥	leoi
 礌	leoi
 礧	leoi
@@ -14520,21 +14521,21 @@ min_phrase_weight: 100
 稆	leoi
 穭	leoi
 类	leoi
-累	leoi	1000
+累	leoi
 絫	leoi
-縲	leoi	500
+縲	leoi
 纇	leoi
 纍	leoi
 缕	leoi
 缧	leoi
 罍	leoi
-羸	leoi	500
-耒	leoi	500
-耒	loi	500
+羸	leoi
+耒	leoi
+耒	loi
 膂	leoi
 蔂	leoi
 蔂	lo
-蕾	leoi	1000
+蕾	leoi
 藘	leoi
 藟	leoi
 蘱	leoi
@@ -14548,17 +14549,17 @@ min_phrase_weight: 100
 誄	loi
 轠	leoi
 郘	leoi
-鋁	leoi	1000
-鐳	leoi	1000
+鋁	leoi
+鐳	leoi
 鑢	leoi
 铝	leoi
 镭	leoi
-閭	leoi	500
+閭	leoi
 闾	leoi
-雷	leoi	1000
-類	leoi	1000
-驢	leoi	1000
-驢	lou	1000
+雷	leoi
+類	leoi
+驢	leoi
+驢	lou
 驴	leoi
 驴	lou
 鸓	leoi
@@ -14586,56 +14587,56 @@ min_phrase_weight: 100
 䮼	leon
 仑	leon
 伦	leon
-侖	leon	500
-倫	leon	1000
-卵	leon	1000
+侖	leon
+倫	leon
+卵	leon
 卵	lo	0%
-吝	leon	1000
+吝	leon
 噒	leon
 囵	leon
 圇	leon
 崘	leon
-崙	leon	500
+崙	leon
 嶙	leon
 抡	leon
-掄	leon	500
+掄	leon
 橉	leon
 沦	leon
-淪	leon	1000
+淪	leon
 潾	leon
-燐	leon	500
+燐	leon
 璘	leon
 甐	leon
 疄	leon
 瞵	leon
-磷	leon	500
+磷	leon
 粦	leon
 粼	leon
 紊	leon	0%
-紊	man	1000
+紊	man
 膦	leon
 菕	leon
 蔺	leon
-藺	leon	1000
-論	leon	1000
+藺	leon
+論	leon
 论	leon
 蹸	leon
 躏	leon
-躪	leon	500
-輪	leon	1000
-轔	leon	500
+躪	leon
+輪	leon
+轔	leon
 轮	leon
 辚	leon
-遴	leon	500
+遴	leon
 邻	leon
-鄰	leon	1000
+鄰	leon
 鏻	leon
 閵	leon
 隣	leon
 驎	leon
-鱗	leon	1000
+鱗	leon
 鳞	leon
-麟	leon	500
+麟	leon
 㧒	leot
 㧒	waat
 㮚	leot
@@ -14654,13 +14655,13 @@ min_phrase_weight: 100
 噊	leot
 噊	wat
 嵂	leot
-律	leot	1000
-慄	leot	500
+律	leot
+慄	leot
 搮	leot
-栗	leot	500
+栗	leot
 溧	leot
-率	leot	1000
-率	seot	1000
+率	leot
+率	seot
 瑮	leot
 硉	leot
 篥	leot
@@ -14698,7 +14699,7 @@ min_phrase_weight: 100
 䮥	lik
 䰛	lik
 䰜	lik
-力	lik	1000
+力	lik
 历	lik
 厤	lik
 呖	lik
@@ -14706,21 +14707,21 @@ min_phrase_weight: 100
 坜	lik
 擽	lik
 擽	loek
-曆	lik	1000
+曆	lik
 枥	lik
 栎	lik
 櫟	lik
 櫪	lik
 歴	lik
-歷	lik	1000
+歷	lik
 沥	lik
-瀝	lik	1000
+瀝	lik
 爍	lik	0%
-爍	soek	1000
+爍	soek
 瓅	lik
 皪	lik
 磿	lik
-礫	lik	500
+礫	lik
 芀	lik
 芀	siu
 芀	tiu
@@ -14736,9 +14737,9 @@ min_phrase_weight: 100
 郦	lik
 酈	lik
 雳	lik
-靂	lik	500
-令	lim	0
-令	ling	1000
+靂	lik
+令	lim	0%
+令	ling
 㝺	lim
 㡘	lim
 㪘	lim
@@ -14755,25 +14756,25 @@ min_phrase_weight: 100
 䨬	lim
 䭑	lim
 奁	lim
-奩	lim	500
-帘	lim	500
-廉	lim	1000
+奩	lim
+帘	lim
+廉	lim
 敛	lim
-斂	lim	500
+斂	lim
 歛	lim
 殓	lim
-殮	lim	500
+殮	lim
 溓	lim
 潋	lim
 澰	lim
-濂	lim	500
+濂	lim
 瀲	lim
 磏	lim
-簾	lim	1000
+簾	lim
 羷	lim
 脸	lim
 臁	lim
-臉	lim	1000
+臉	lim
 蔹	lim
 蘞	lim
 蠊	lim
@@ -14783,7 +14784,7 @@ min_phrase_weight: 100
 襜	zim
 襝	lim
 鎌	lim
-鐮	lim	500
+鐮	lim
 镰	lim
 鬑	lim
 𢅏	lim
@@ -14798,35 +14799,35 @@ min_phrase_weight: 100
 嗹	lin
 怜	lin
 怜	ling
-憐	lin	1000
+憐	lin
 摙	lin
 撵	lin
-攆	lin	500
+攆	lin
 梿	lin
 楝	lin
 槤	lin
 涟	lin
 湅	lin
-漣	lin	500
+漣	lin
 炼	lin
-煉	lin	1000
+煉	lin
 琏	lin
 璉	lin
-練	lin	1000
+練	lin
 练	lin
 莲	lin
-蓮	lin	1000
+蓮	lin
 裢	lin
 褳	lin
 謰	lin
-輦	lin	500
+輦	lin
 辇	lin
 连	lin
-連	lin	1000
-鍊	lin	500
-鏈	lin	1000
+連	lin
+鍊	lin
+鏈	lin
 链	lin
-鰱	lin	500
+鰱	lin
 鲢	lin
 㖫	ling
 㡵	ling
@@ -14865,25 +14866,25 @@ min_phrase_weight: 100
 䴇	ling
 䴒	ling
 䴫	ling
-伶	ling	1000
-凌	ling	1000
-另	ling	1000
+伶	ling
+凌	ling
+另	ling
 呤	ling
 囹	ling
 堎	ling
 夌	ling
 岭	ling
 崚	ling
-愣	ling	1000
+愣	ling
 拎	ling
-擰	ling	501
-擰	ning	1000
+擰	ling
+擰	ning
 柃	ling
 棂	ling
 棱	ling
-楞	ling	500
-檸	ling	501
-檸	ning	1000
+楞	ling
+檸	ling
+檸	ning
 櫺	ling
 欞	ling
 泠	ling
@@ -14891,21 +14892,21 @@ min_phrase_weight: 100
 灵	ling
 炩	ling
 狑	ling
-玲	ling	500
+玲	ling
 瓴	ling
 睖	ling
 稑	ling
 稑	luk
-稜	ling	500
+稜	ling
 笭	ling
-綾	ling	500
+綾	ling
 绫	ling
-羚	ling	500
-翎	ling	500
-聆	ling	1000
+羚	ling
+翎	ling
+聆	ling
 舲	ling
-苓	ling	500
-菱	ling	1000
+苓	ling
+菱	ling
 蔆	ling
 薐	ling
 蘦	ling
@@ -14915,17 +14916,17 @@ min_phrase_weight: 100
 輘	ling
 酃	ling
 醽	ling
-鈴	ling	1000
+鈴	ling
 铃	ling
-陵	ling	1000
-零	ling	1000
+陵	ling
+零	ling
 霝	ling
 领	ling
 鲮	ling
 鳹	ling
 鴒	ling
 鸰	ling
-齡	ling	1000
+齡	ling
 龄	ling
 𫐉	ling
 㯿	lip
@@ -14937,7 +14938,7 @@ min_phrase_weight: 100
 巤	lip
 犣	lip
 猎	lip
-獵	lip	1000
+獵	lip
 躐	lip
 鬣	lip
 𤢪	lip
@@ -14949,13 +14950,13 @@ min_phrase_weight: 100
 䅀	lit
 䮋	lit
 䴕	lit
-冽	lit	500
+冽	lit
 洌	lit
-烈	lit	1000
+烈	lit
 綟	lit
 茢	lit
 蛚	lit
-裂	lit	1000
+裂	lit
 趔	lit
 颲	lit
 鮤	lit
@@ -14977,40 +14978,40 @@ min_phrase_weight: 100
 䢧	liu
 䨅	liu
 䩍	liu
-了	liu	1000
-僚	liu	500
-嘹	liu	1000
+了	liu
+僚	liu
+嘹	liu
 嫽	liu
-寥	liu	1000
-寮	liu	500
+寥	liu
+寮	liu
 尥	liu
 屪	liu
 嵺	liu
 嶚	liu
-廖	liu	500
+廖	liu
 憀	liu
 憭	liu
 撂	liu
-撩	liu	500
+撩	liu
 敹	liu
-料	liu	1000
+料	liu
 暸	liu
 橑	liu
 橑	lou
-潦	liu	1000
-潦	lou	1000
+潦	liu
+潦	lou
 炓	liu
 炓	tau
-燎	liu	500
+燎	liu
 獠	liu
 獠	lou
 疗	liu
-療	liu	1000
-瞭	liu	1000
+療	liu
+瞭	liu
 簝	liu
-繚	liu	1000
+繚	liu
 缭	liu
-聊	liu	1000
+聊	liu
 膋	liu
 膫	liu
 蓼	liu
@@ -15020,7 +15021,7 @@ min_phrase_weight: 100
 蹘	liu
 蹘	mau
 辽	liu
-遼	liu	1000
+遼	liu
 鄝	liu
 釕	liu
 鐐	liu
@@ -15047,30 +15048,30 @@ min_phrase_weight: 100
 椤	lo
 欏	lo
 猡	lo
-玀	lo	500
+玀	lo
 瘰	lo
 砢	lo
 箩	lo
-籮	lo	1000
+籮	lo
 罗	lo
-羅	lo	1000
+羅	lo
 脶	lo
 腡	lo
 臝	lo
 萝	lo
 蓏	lo
-蘿	lo	1000
-螺	lo	1000
+蘿	lo
+螺	lo
 蠃	lo
-裸	lo	1000
+裸	lo
 覶	lo
 躶	lo
 逻	lo
-邏	lo	1000
-鑼	lo	1000
+邏	lo
+鑼	lo
 锣	lo
 饠	lo
-騾	lo	1000
+騾	lo
 驘	lo
 骡	lo
 鸁	lo
@@ -15085,8 +15086,8 @@ min_phrase_weight: 100
 㨼	loek
 䂮	loek
 䌎	loek
-掠	loek	1000
-略	loek	1000
+掠	loek
+略	loek
 畧	loek
 㒳	loeng
 㔝	loeng
@@ -15102,40 +15103,40 @@ min_phrase_weight: 100
 䭪	loeng
 両	loeng
 两	loeng
-亮	loeng	1000
+亮	loeng
 俍	loeng
 俩	loeng
-倆	loeng	1000
-兩	loeng	1000
+倆	loeng
+兩	loeng
 凉	loeng
 唡	loeng
 啢	loeng
 喨	loeng
 悢	loeng
 悢	long
-梁	loeng	1000
+梁	loeng
 椋	loeng
-樑	loeng	1000
-涼	loeng	1000
+樑	loeng
+涼	loeng
 粮	loeng
-粱	loeng	1000
-糧	loeng	1000
+粱	loeng
+糧	loeng
 緉	loeng
-良	loeng	1000
+良	loeng
 莨	loeng
 莨	long
 蜋	loeng
 蜋	long
 裲	loeng
-諒	loeng	1000
+諒	loeng
 谅	loeng
 踉	loeng
 踉	long
-輛	loeng	1000
+輛	loeng
 輬	loeng
 辆	loeng
 辌	loeng
-量	loeng	1000
+量	loeng
 魉	loeng
 魎	loeng
 㚓	loi
@@ -15157,9 +15158,9 @@ min_phrase_weight: 100
 涞	loi
 淶	loi
 睐	loi
-睞	loi	500
+睞	loi
 莱	loi
-萊	loi	500
+萊	loi
 诔	loi
 賚	loi
 赉	loi
@@ -15187,20 +15188,20 @@ min_phrase_weight: 100
 䌴	lok
 乐	lok
 乐	ngok
-樂	lok	1000
-樂	ngaau	200
-樂	ngok	1000
-洛	lok	1000
-烙	lok	500
-犖	lok	500
+樂	lok
+樂	ngaau
+樂	ngok
+洛	lok
+烙	lok
+犖	lok
 珞	lok
-絡	lok	1000
+絡	lok
 络	lok
 荦	lok
-酪	lok	1000
-酪	lou	1000
+酪	lok
+酪	lou
 雒	lok
-駱	lok	1000
+駱	lok
 骆	lok
 𡀩	lok
 㓪	long
@@ -15221,30 +15222,30 @@ min_phrase_weight: 100
 啷	long
 塱	long
 崀	long
-廊	long	1000
+廊	long
 晾	long
-朗	long	1000
+朗	long
 桹	long
-榔	long	500
-浪	long	1000
+榔	long
+浪	long
 烺	long
-狼	long	1000
-琅	long	500
-瑯	long	1000
+狼	long
+琅	long
+瑯	long
 硠	long
 稂	long
 筤	long
 蒗	long
 蓢	long
-螂	long	1000
-郎	long	1000
+螂	long
+郎	long
 郞	long
 鋃	long
 鎯	long
 锒	long
 閬	long
 阆	long
-廊	long	1000
+廊	long
 𠺘	long
 𠻴	long
 𢲲	long
@@ -15278,28 +15279,28 @@ min_phrase_weight: 100
 䵏	lou
 僗	lou
 劳	lou
-勞	lou	1000
+勞	lou
 卢	lou
 卤	lou
 唠	lou
-嘮	lou	500
+嘮	lou
 噜	lou
-嚕	lou	500
+嚕	lou
 垆	lou
 壚	lou
-姥	lou	1000
+姥	lou
 姥	mou	0%
 嫪	lou
 庐	lou
-廬	lou	1000
+廬	lou
 恅	lou
 掳	lou
-擄	lou	1000
+擄	lou
 擼	lou
 栌	lou
 栳	lou
 橹	lou
-櫓	lou	500
+櫓	lou
 櫨	lou
 氇	lou
 氌	lou
@@ -15311,23 +15312,23 @@ min_phrase_weight: 100
 澇	lou
 瀘	lou
 炉	lou
-爐	lou	1000
-牢	lou	1000
+爐	lou
+牢	lou
 狫	lou
 玈	lou
 璐	lou
 痨	lou
-癆	lou	500
-盧	lou	500
+癆	lou
+盧	lou
 磠	lou
 簩	lou
 簬	lou
 籚	lou
 纑	lou
 罏	lou
-老	lou	1000
+老	lou
 胪	lou
-臚	lou	500
+臚	lou
 舻	lou
 艣	lou
 艪	lou
@@ -15335,14 +15336,14 @@ min_phrase_weight: 100
 芦	lou
 蓾	lou
 蕗	lou
-蘆	lou	1000
+蘆	lou
 虏	lou
-虜	lou	1000
+虜	lou
 蟧	lou
 蠦	lou
-賂	lou	1000
+賂	lou
 赂	lou
-路	lou	1000
+路	lou
 輅	lou
 轑	lou
 轤	lou
@@ -15355,19 +15356,19 @@ min_phrase_weight: 100
 鑪	lou
 铑	lou
 铹	lou
-顱	lou	1000
+顱	lou
 颅	lou
-魯	lou	1000
-鱸	lou	500
+魯	lou
+鱸	lou
 鲁	lou
 鲈	lou
-鷺	lou	500
+鷺	lou
 鸕	lou
 鸬	lou
 鹭	lou
-鹵	lou	500
+鹵	lou
 黸	lou
-虜	lou	1000
+虜	lou
 𡀔	lou
 𢲸	lou
 㓐	luk
@@ -15397,13 +15398,13 @@ min_phrase_weight: 100
 䱚	luk
 䴪	luk
 僇	luk
-六	luk	1000
+六	luk
 坴	luk
 彔	luk
 录	luk
-戮	luk	500
+戮	luk
 摝	luk
-氯	luk	500
+氯	luk
 淥	luk
 渌	luk
 漉	luk
@@ -15412,15 +15413,15 @@ min_phrase_weight: 100
 甪	luk
 盝	luk
 睩	luk
-碌	luk	1000
+碌	luk
 磟	luk
-祿	luk	500
+祿	luk
 禄	luk
 穋	luk
 箓	luk
 簏	luk
 籙	luk
-綠	luk	1000
+綠	luk
 绿	luk
 菉	luk
 觻	luk
@@ -15429,14 +15430,14 @@ min_phrase_weight: 100
 辘	luk
 逯	luk
 醁	luk
-錄	luk	1000
+錄	luk
 錴	luk
 陆	luk
-陸	luk	1000
+陸	luk
 騄	luk
 鯥	luk
-鹿	luk	1000
-麓	luk	1000
+鹿	luk
+麓	luk
 𢮑	luk
 𤊒	luk
 窿	lung	1000
@@ -15462,37 +15463,37 @@ min_phrase_weight: 100
 儱	lung
 咙	lung
 哢	lung
-嚨	lung	1000
+嚨	lung
 垄	lung
-壟	lung	500
+壟	lung
 巃	lung
-弄	lung	1000
-弄	nung	200
+弄	lung
+弄	nung
 徿	lung
 拢	lung
-攏	lung	500
+攏	lung
 昽	lung
 曨	lung
-朧	lung	1000
+朧	lung
 栊	lung
 櫳	lung
 泷	lung
 瀧	lung
 瀧	soeng
 珑	lung
-瓏	lung	500
+瓏	lung
 癃	lung
 眬	lung
-矓	lung	500
+矓	lung
 砻	lung
 礱	lung
 竉	lung
 竜	lung
 笼	lung
 篢	lung
-籠	lung	1000
+籠	lung
 聋	lung
-聾	lung	1000
+聾	lung
 胧	lung
 茏	lung
 蘢	lung
@@ -15501,9 +15502,9 @@ min_phrase_weight: 100
 躘	lung
 鑨	lung
 陇	lung
-隆	lung	1000
-隴	lung	500
-龍	lung	1000
+隆	lung
+隴	lung
+龍	lung
 龙	lung
 𢙱	lung
 𤮨	lung
@@ -15520,18 +15521,18 @@ min_phrase_weight: 100
 䖂	lyun
 䜌	lyun
 乱	lyun
-亂	lyun	1000
+亂	lyun
 圞	lyun
 娈	lyun
 孌	lyun
 孪	lyun
-孿	lyun	500
+孿	lyun
 峦	lyun
-巒	lyun	1000
+巒	lyun
 恋	lyun
-戀	lyun	1000
+戀	lyun
 挛	lyun
-攣	lyun	1000
+攣	lyun
 栾	lyun
 欒	lyun
 滦	lyun
@@ -15539,14 +15540,14 @@ min_phrase_weight: 100
 癵	lyun
 羉	lyun
 联	lyun
-聯	lyun	1000
+聯	lyun
 脔	lyun
 臠	lyun
 薍	lyun
 薍	waan
 銮	lyun
-鑾	lyun	500
-鸞	lyun	500
+鑾	lyun
+鸞	lyun
 鸾	lyun
 𪢮	lyun
 㭞	lyut
@@ -15555,7 +15556,7 @@ min_phrase_weight: 100
 㸹	lyut
 㽟	lyut
 䤣	lyut
-劣	lyut	1000
+劣	lyut
 哷	lyut
 埒	lyut
 挘	lyut
@@ -15565,7 +15566,7 @@ min_phrase_weight: 100
 鋝	lyut
 锊	lyut
 唔	m	100000
-唔	ng	1000
+唔	ng
 呒	m
 呣	m
 㐷	maa
@@ -15588,38 +15589,38 @@ min_phrase_weight: 100
 䵢	mui
 傌	maa
 吗	maa
-嗎	maa	1000
-嘛	maa	1000
+嗎	maa
+嘛	maa
 嚜	maa
 嚜	maak
 嚜	mak
 妈	maa
-媽	maa	1000
+媽	maa
 嫲	maa
-嬤	maa	500
+嬤	maa
 嬷	maa
 孖	maa
 榪	maa
 玛	maa
-瑪	maa	1000
+瑪	maa
 痲	maa
 码	maa
-碼	maa	1000
+碼	maa
 祃	maa
 禡	maa
-罵	maa	1000
+罵	maa
 蔴	maa
 蚂	maa
-螞	maa	1000
-蟆	maa	500
+螞	maa
+蟆	maa
 鎷	maa
-馬	maa	1000
+馬	maa
 駡	maa
 马	maa
 骂	maa
-麻	maa	1000
+麻	maa
 麼	maa	0%
-麼	mo	1000
+麼	mo
 㜆	maai
 㜥	maai
 㝥	maai
@@ -15637,12 +15638,12 @@ min_phrase_weight: 100
 劢	maai
 勱	maai
 卖	maai
-埋	maai	1000
+埋	maai
 薶	maai
-買	maai	1000
-賣	maai	1000
+買	maai
+賣	maai
 迈	maai
-邁	maai	1000
+邁	maai
 𠹺	maai
 䁇	maak
 䁇	maat
@@ -15655,9 +15656,9 @@ min_phrase_weight: 100
 䮬	maak
 䳮	maak
 䳮	maat
-擘	maak	500
+擘	maak
 麥	maak	0%
-麥	mak	1000
+麥	mak
 㗃	maan
 㗈	maan
 㝰	maan
@@ -15683,56 +15684,56 @@ min_phrase_weight: 100
 卍	maan
 墁	maan
 姏	maan
-娩	maan	500
-娩	min	500
+娩	maan
+娩	min
 嫚	maan
-幔	maan	500
-慢	maan	1000
+幔	maan
+慢	maan
 摱	maan
-晚	maan	1000
-曼	maan	1000
+晚	maan
+曼	maan
 槾	maan
-漫	maan	1000
+漫	maan
 熳	maan
 矕	maan
 縵	maan
 缦	maan
 脕	maan
-萬	maan	1000
-蔓	maan	1000
+萬	maan
+蔓	maan
 蛮	maan
-蠻	maan	1000
+蠻	maan
 謾	maan
 谩	maan
 鄤	maan
 鏝	maan
 镘	maan
-饅	maan	1000
+饅	maan
 馒	maan
 鬘	maan
-鰻	maan	500
+鰻	maan
 鳗	maan
 𢶯	maan
 𢺳	maan
 䁅	maang
 䁅	mang
 䇇	maang
-孟	maang	1000
+孟	maang
 掹	maang
 掹	mang
 氓	maang	0%
-氓	man	1000
-氓	mong	1000
-猛	maang	1000
-盲	maang	1000
+氓	man
+氓	mong
+猛	maang
+盲	maang
 盳	maang
 盳	mong
 艋	maang
 莔	maang
-蜢	maang	500
+蜢	maang
 鄳	maang
 鄳	mong
-錳	maang	500
+錳	maang
 锰	maang
 鯭	maang
 䀛	maat
@@ -15742,10 +15743,10 @@ min_phrase_weight: 100
 䊅	maat
 䊅	ming
 䠚	maat
-抹	maat	501
-抹	mut	1000
+抹	maat
+抹	mut
 襪	maat	0%
-襪	mat	1000
+襪	mat
 㚹	maau
 㚹	mau
 㮘	maau
@@ -15761,24 +15762,24 @@ min_phrase_weight: 100
 䤊	maau
 䤊	zung
 䫉	maau
-卯	maau	1000
+卯	maau
 媌	maau
 昴	maau
 泖	maau
-牡	maau	1000
+牡	maau
 牡	mau	0%
 猫	maau
-矛	maau	1000
-茅	maau	1000
+矛	maau
+茅	maau
 茆	maau
 蝥	maau
 蟊	maau
-貌	maau	1000
-貓	maau	1000
+貌	maau
+貓	maau
 貓	miu	0%
 鉚	maau
-錨	maau	500
-錨	naau	500
+錨	maau
+錨	naau
 铆	maau
 锚	maau
 锚	naau
@@ -15791,24 +15792,24 @@ min_phrase_weight: 100
 䨪	mai
 䨪	mo
 䱊	mai
-弭	mai	500
-弭	mei	500
+弭	mai
+弭	mei
 敉	mai
 敉	mei
 渳	mai
 眯	mai
 眯	mei
 眯	mi
-瞇	mai	500
-瞇	mei	500
-瞇	mi	500
-米	mai	1000
+瞇	mai
+瞇	mei
+瞇	mi
+米	mai
 蛑	mai
 蛑	mau
-袂	mai	500
-謎	mai	1000
+袂	mai
+謎	mai
 谜	mai
-迷	mai	1000
+迷	mai
 醚	mai
 銤	mai
 麛	mai
@@ -15819,14 +15820,14 @@ min_phrase_weight: 100
 䘑	mak
 䮮	mak
 冒	mak	0%
-冒	mou	1000
+冒	mou
 唛	mak
 嘜	mak
-墨	mak	1000
+墨	mak
 癦	mak
 眽	mak
 纆	mak
-脈	mak	1000
+脈	mak
 脉	mak
 蓦	mak
 衇	mak
@@ -15838,12 +15839,12 @@ min_phrase_weight: 100
 貊	mak
 貘	mak
 貘	mok
-陌	mak	1000
+陌	mak
 霡	mak
 霢	mak
-驀	mak	500
+驀	mak
 麦	mak
-默	mak	1000
+默	mak
 黙	mak
 𦢓	mak
 𩜠	mam
@@ -15881,28 +15882,28 @@ min_phrase_weight: 100
 伩	seon
 僶	man
 免	man	0%
-免	min	1000
-刎	man	500
+免	min
+刎	man
 勄	man
-吻	man	1000
+吻	man
 呅	man
 呡	man
-問	man	1000
-岷	man	500
+問	man
+岷	man
 忞	man
 怋	man
 悯	man
 愍	man
-憫	man	500
+憫	man
 抆	man
-抿	man	500
+抿	man
 敃	man
-敏	man	1000
-文	man	1000
+敏	man
+文	man
 旻	man
 旼	man
 暋	man
-民	man	1000
+民	man
 汶	man
 泯	man
 渑	man
@@ -15911,31 +15912,31 @@ min_phrase_weight: 100
 澠	man
 澠	sing
 炆	man
-玟	man	500
+玟	man
 珉	man
 璺	man
 甿	man
 甿	mong
 笢	man
-紋	man	1000
+紋	man
 絻	man
 纹	man
 罠	man
-聞	man	1000
+聞	man
 肳	man
 脗	man
 芠	man
 苠	man
-蚊	man	1000
-閔	man	1000
-閩	man	500
+蚊	man
+閔	man
+閩	man
 閿	man
 问	man
 闵	man
 闻	man
 闽	man
 阌	man
-雯	man	500
+雯	man
 魰	man
 鰵	man
 鰶	man
@@ -15957,14 +15958,14 @@ min_phrase_weight: 100
 忟	mang
 擝	mang
 甍	mang
-盟	mang	1000
-萌	mang	1000
+盟	mang
+萌	mang
 𠵼	mang
 𢛴	mang
 𤷪	mang
 乜	mat	10000
 乜	me	10000
-乜	mi	0
+乜	mi	0%
 乜	ne
 㫘	mat
 㳴	mat
@@ -15975,15 +15976,15 @@ min_phrase_weight: 100
 䍪	mat
 䛑	mat
 䤉	mat
-勿	mat	1000
+勿	mat
 嘧	mat
-密	mat	1000
+密	mat
 沕	mat
 沕	mei
 滵	mat
-物	mat	1000
+物	mat
 蔤	mat
-蜜	mat	1000
+蜜	mat
 蟔	mat
 袜	mat
 謐	mat
@@ -16005,25 +16006,25 @@ min_phrase_weight: 100
 厶	si
 哞	mau
 懋	mau
-某	mau	1000
+某	mau
 楙	mau
-牟	mau	500
-畝	mau	1000
-眸	mau	500
+牟	mau
+畝	mau
+眸	mau
 睯	mau
 瞀	mau
-繆	mau	500
-繆	miu	500
-繆	muk	500
+繆	mau
+繆	miu
+繆	muk
 缪	mau
 缪	miu
-茂	mau	1000
+茂	mau
 袤	mau
-謀	mau	1000
-謬	mau	1000
+謀	mau
+謬	mau
 谋	mau
 谬	mau
-貿	mau	1000
+貿	mau
 贸	mau
 鄮	mau
 鍪	mau
@@ -16036,8 +16037,8 @@ min_phrase_weight: 100
 咩	me	1000
 哶	me
 孭	me
-歪	me	501
-歪	waai	1000
+歪	me
+歪	waai
 羋	me
 芈	me
 𡥼	me
@@ -16073,23 +16074,23 @@ min_phrase_weight: 100
 亹	mei
 亹	mun
 冞	mei
-味	mei	1000
+味	mei
 堳	mei
 堳	mui
-娓	mei	500
-媚	mei	1000
+娓	mei
+媚	mei
 媺	mei
-寐	mei	500
-尾	mei	1000
+寐	mei
+尾	mei
 屘	mei
 嵋	mei
 弥	mei
 弥	nei
-彌	mei	1000
-彌	nei	1000
-微	mei	1000
+彌	mei
+彌	nei
+微	mei
 攠	mei
-未	mei	1000
+未	mei
 楣	mei
 沬	mei
 沬	mui
@@ -16099,37 +16100,37 @@ min_phrase_weight: 100
 溦	mei
 濔	mei
 濔	nei
-瀰	mei	1000
-瀰	nei	1000
+瀰	mei
+瀰	nei
 煝	mei
 爢	mei
-眉	mei	1000
+眉	mei
 睸	mei
-糜	mei	500
+糜	mei
 縻	mei
-美	mei	1000
+美	mei
 羙	mei
 艉	mei
 菋	mei
 葞	mei
-薇	mei	500
+薇	mei
 蘼	mei
 蝞	mei
 郿	mei
 醾	mei
-鎂	mei	500
+鎂	mei
 镁	mei
-靡	mei	500
-魅	mei	1000
+靡	mei
+魅	mei
 魅	mui	0%
 鮇	mei
-麋	mei	500
-黴	mei	500
+麋	mei
+黴	mei
 𧋦	mei
-名	meng	501
-名	ming	1000
-命	meng	501
-命	ming	1000
+名	meng
+名	ming
+命	meng
+命	ming
 㨠	mik
 㵋	mik
 䌐	mik
@@ -16145,7 +16146,7 @@ min_phrase_weight: 100
 糸	mik
 糸	si
 羃	mik
-覓	mik	1000
+覓	mik
 觅	mik
 鼏	mik
 㒙	min
@@ -16167,31 +16168,31 @@ min_phrase_weight: 100
 䰓	min
 丏	min
 偭	min
-冕	min	1000
-勉	min	1000
+冕	min
+勉	min
 勔	min
 媔	min
 宀	min
 愐	min
-棉	min	1000
+棉	min
 櫋	min
 沔	min
 湎	min
 眄	min
-眠	min	1000
+眠	min
 矊	min
-綿	min	1000
+綿	min
 緜	min
-緬	min	1000
+緬	min
 绵	min
 缅	min
 腼	min
 腼	tin
-面	min	1000
-靦	min	500
-靦	tin	500
+面	min
+靦	min
+靦	tin
 鮸	min
-麪	min	1000
+麪	min
 麵	min
 㝠	ming
 㟰	ming
@@ -16200,24 +16201,24 @@ min_phrase_weight: 100
 䆨	ming
 䆩	ming
 䳟	ming
-冥	ming	500
+冥	ming
 嫇	ming
-明	ming	1000
+明	ming
 暝	ming
 榠	ming
 洺	ming
 溟	ming
-皿	ming	1000
+皿	ming
 眳	ming
-瞑	ming	500
-茗	ming	500
+瞑	ming
+茗	ming
 蓂	ming
-螟	ming	500
+螟	ming
 鄍	ming
-酩	ming	500
-銘	ming	500
+酩	ming
+銘	ming
 铭	ming
-鳴	ming	1000
+鳴	ming
 鸣	ming
 𠱷	ming
 㒝	mit
@@ -16227,11 +16228,11 @@ min_phrase_weight: 100
 䘊	mit
 䩏	mit
 搣	mit
-滅	mit	1000
+滅	mit
 灭	mit
 烕	mit
-篾	mit	500
-蔑	mit	500
+篾	mit
+蔑	mit
 蠛	mit
 衊	mit
 㑤	miu
@@ -16249,22 +16250,22 @@ min_phrase_weight: 100
 䚺	zaau
 䚺	ziu
 喵	miu
-妙	miu	1000
+妙	miu
 庙	miu
-廟	miu	1000
-描	miu	1000
+廟	miu
+描	miu
 杪	miu
 淼	miu
-渺	miu	1000
+渺	miu
 玅	miu
 眇	miu
-瞄	miu	1000
-秒	miu	1000
+瞄	miu
+秒	miu
 緲	miu
 缈	miu
 苖	miu
-苗	miu	1000
-藐	miu	500
+苗	miu
+藐	miu
 邈	miu
 邈	mok
 𠴕	miu
@@ -16276,16 +16277,16 @@ min_phrase_weight: 100
 嚤	mo
 塺	mo
 塺	mui
-摩	mo	1000
-摸	mo	1000
+摩	mo
+摸	mo
 摸	mok	0%
 擵	mo
-磨	mo	1000
+磨	mo
 藦	mo
-蘑	mo	1000
+蘑	mo
 饃	mo
 馍	mo
-魔	mo	1000
+魔	mo
 麽	mo
 牦	moi
 㱳	mok
@@ -16297,15 +16298,15 @@ min_phrase_weight: 100
 㿺	pok
 䒬	mok
 嗼	mok
-寞	mok	1000
-幕	mok	1000
+寞	mok
+幕	mok
 幙	mok
-漠	mok	1000
+漠	mok
 瘼	mok
 瞙	mok
-膜	mok	1000
+膜	mok
 膜	mou	0%
-莫	mok	1000
+莫	mok
 莫	mou	0%
 鄚	mok
 鏌	mok
@@ -16327,22 +16328,22 @@ min_phrase_weight: 100
 䗈	mong
 䥰	mong
 䵨	mong
-亡	mong	1000
+亡	mong
 亡	mou	0%
 兦	mong
 厖	mong
 厖	pong
 哤	mong
-妄	mong	500
+妄	mong
 尨	mong
 尨	mung
 尨	pong
 庬	mong
 庬	pong
-忘	mong	1000
-忙	mong	1000
-惘	mong	500
-望	mong	1000
+忘	mong
+忙	mong
+惘	mong
+望	mong
 朢	mong
 杗	mong
 杧	mong
@@ -16352,18 +16353,18 @@ min_phrase_weight: 100
 牻	mong
 狵	mong
 硭	mong
-網	mong	1000
+網	mong
 网	mong
-罔	mong	1000
-芒	mong	1000
-茫	mong	1000
+罔	mong
+芒	mong
+茫	mong
 茻	mong
-莽	mong	1000
+莽	mong
 菵	mong
 蘉	mong
 虻	mong
 蝱	mong
-蟒	mong	500
+蟒	mong
 輞	mong
 辋	mong
 邙	mong
@@ -16404,68 +16405,68 @@ min_phrase_weight: 100
 䱯	mou
 䳇	mou
 䳱	mou
-侮	mou	1000
+侮	mou
 务	mou
-務	mou	1000
-募	mou	1000
-墓	mou	1000
+務	mou
+募	mou
+墓	mou
 妩	mou
-姆	mou	1000
+姆	mou
 婺	mou
 媢	mou
 嫫	mou
-嫵	mou	500
-巫	mou	1000
-帽	mou	1000
+嫵	mou
+巫	mou
+帽	mou
 庑	mou
 廡	mou
 怃	mou
-慕	mou	1000
+慕	mou
 憮	mou
-戊	mou	1000
-拇	mou	1000
-摹	mou	500
+戊	mou
+拇	mou
+摹	mou
 旄	mou
 无	mou
-暮	mou	1000
+暮	mou
 楘	mou
 楘	muk
-模	mou	1000
+模	mou
 橆	mou
-武	mou	1000
-毋	mou	1000
-母	mou	1000
-毛	mou	1000
+武	mou
+毋	mou
+母	mou
+毛	mou
 毷	mou
 潕	mou
-無	mou	1000
+無	mou
 珷	mou
-瑁	mou	500
-瑁	mui	500
+瑁	mou
+瑁	mui
 甒	mou
 眊	mou
 砪	mou
 碔	mou
-糢	mou	500
+糢	mou
 耄	mou
-舞	mou	1000
+舞	mou
 芜	mou
 芼	mou
-蕪	mou	1000
+蕪	mou
 蝐	mou
 蝐	mui
-誣	mou	1000
-謨	mou	500
+誣	mou
+謨	mou
 诬	mou
 谟	mou
 酕	mou
 鉧	mou
 雾	mou
-霧	mou	1000
-騖	mou	500
+霧	mou
+騖	mou
 骛	mou
-髦	mou	1000
-鵡	mou	500
+髦	mou
+鵡	mou
 鶩	mou
 鹉	mou
 鹜	mou
@@ -16474,26 +16475,26 @@ min_phrase_weight: 100
 䆀	mui
 䊈	mui
 䍙	mui
-妹	mui	1000
-媒	mui	1000
+妹	mui
+媒	mui
 挴	mui
-昧	mui	500
-枚	mui	1000
-梅	mui	1000
-每	mui	1000
+昧	mui
+枚	mui
+梅	mui
+每	mui
 浼	mui
-煤	mui	1000
+煤	mui
 燘	mui
-玫	mui	1000
+玫	mui
 眛	mui
 禖	mui
 脢	mui
 腜	mui
 苺	mui
-莓	mui	1000
+莓	mui
 酶	mui
 鋂	mui
-霉	mui	1000
+霉	mui
 韎	mui
 𠵈	mui
 𡈎	mui
@@ -16506,13 +16507,13 @@ min_phrase_weight: 100
 䊾	muk
 䑵	muk
 坶	muk
-木	muk	1000
+木	muk
 毣	muk
-沐	muk	1000
-牧	muk	1000
-目	muk	1000
-睦	muk	1000
-穆	muk	1000
+沐	muk
+牧	muk
+目	muk
+睦	muk
+穆	muk
 苜	muk
 鉬	muk
 钼	muk
@@ -16526,29 +16527,29 @@ min_phrase_weight: 100
 䊡	mun
 䐽	mun
 们	mun
-們	mun	1000
+們	mun
 悗	mun
-悶	mun	1000
+悶	mun
 懑	mun
-懣	mun	500
+懣	mun
 扪	mun
-捫	mun	500
+捫	mun
 樠	mun
 满	mun
-滿	mun	1000
+滿	mun
 焖	mun
-燜	mun	500
+燜	mun
 璊	mun
 瞒	mun
-瞞	mun	1000
+瞞	mun
 穈	mun
 虋	mun
 蹒	mun
-蹣	mun	500
-蹣	pun	500
+蹣	mun
+蹣	pun
 鍆	mun
 钔	mun
-門	mun	1000
+門	mun
 门	mun
 闷	mun
 顢	mun
@@ -16575,22 +16576,22 @@ min_phrase_weight: 100
 䴿	mung
 䵆	mung
 儚	mung
-夢	mung	1000
+夢	mung
 幪	mung
 懜	mung
 懞	mung
-懵	mung	500
+懵	mung
 曚	mung
-朦	mung	1000
+朦	mung
 梦	mung
-檬	mung	1000
+檬	mung
 氋	mung
-濛	mung	500
+濛	mung
 瞢	mung
-矇	mung	500
+矇	mung
 礞	mung
 艨	mung
-蒙	mung	1000
+蒙	mung
 蠓	mung
 鄸	mung
 霥	mung
@@ -16603,16 +16604,16 @@ min_phrase_weight: 100
 䬴	mut
 䴲	mut
 妺	mut
-末	mut	1000
+末	mut
 歾	mut
-歿	mut	500
+歿	mut
 殁	mut
-沒	mut	1000
+沒	mut
 没	mut
-沫	mut	1000
+沫	mut
 瀎	mut
-秣	mut	500
-茉	mut	500
+秣	mut
+茉	mut
 靺	mut
 𠰌	mut
 𧻙	mut
@@ -16636,29 +16637,29 @@ min_phrase_weight: 100
 䛕	zyu
 䬁	naa
 䬁	zyu
-哪	naa	1000
-娜	naa	500
-娜	no	500
+哪	naa
+娜	naa
+娜	no
 拏	naa
-拿	naa	1000
+拿	naa
 詉	naa
 𠸎	naa
 𤶸	naa
 𤸻	naa
 𪐀	naa
-乃	naai	1000
+乃	naai
 乃	oi	0%
-奶	naai	1000
+奶	naai
 嬭	naai
-氖	naai	500
+氖	naai
 疓	naai
-迺	naai	500
+迺	naai
 釢	naai
 鼐	naai
 𠮨	naai
 䄒	naam
-南	naam	1000
-喃	naam	1000
+南	naam
+喃	naam
 囝	naam
 囝	zai
 囝	zoi
@@ -16666,11 +16667,11 @@ min_phrase_weight: 100
 揇	naam
 枏	naam
 柟	naam
-楠	naam	500
+楠	naam
 淰	naam
 淰	nam
 淰	sam
-男	naam	1000
+男	naam
 腩	naam
 蝻	naam
 諵	naam
@@ -16681,9 +16682,9 @@ min_phrase_weight: 100
 嶩	naan
 嶩	naau
 戁	naan
-赧	naan	500
+赧	naan
 难	naan
-難	naan	1000
+難	naan
 𢺋	naan
 𧕴	naan
 㴰	naang
@@ -16692,18 +16693,18 @@ min_phrase_weight: 100
 䯮	naang
 䯮	nai
 內	naap	0%
-內	noi	1000
-吶	naap	1000
+內	noi
+吶	naap
 吶	nat	0%
 吶	neot	0%
 呐	naap
 呐	neot
-納	naap	1000
+納	naap
 纳	naap
 衲	naap
 軜	naap
-鈉	naap	500
-鈉	naat	500
+鈉	naap
+鈉	naat
 钠	naap
 魶	naap
 捺	naat
@@ -16719,12 +16720,12 @@ min_phrase_weight: 100
 䏔	naau
 䰰	naau
 䰰	zyu
-呶	naau	500
+呶	naau
 夒	naau
 峱	naau
 怓	naau
 挠	naau
-撓	naau	1000
+撓	naau
 桡	naau
 淖	naau
 猱	naau
@@ -16732,11 +16733,11 @@ min_phrase_weight: 100
 獶	nou
 獿	naau
 譊	naau
-鐃	naau	500
+鐃	naau
 铙	naau
 閙	naau
 闹	naau
-鬧	naau	1000
+鬧	naau
 𥑪	naau
 𫍢	naau
 㚷	nai
@@ -16745,7 +16746,7 @@ min_phrase_weight: 100
 䍲	ngaai
 坭	nai
 抳	nai
-泥	nai	1000
+泥	nai
 泥	nei	0%
 臡	nai
 苨	nai
@@ -16758,7 +16759,7 @@ min_phrase_weight: 100
 焾	nam
 煁	nam
 煁	sam
-稔	nam	500
+稔	nam
 𡀝	nam
 𥈶	nam
 𥻚	nam
@@ -16767,13 +16768,13 @@ min_phrase_weight: 100
 㫱	nan
 㬮	nan
 䕼	nan
-撚	nan	500
-撚	nin	500
+撚	nan
+撚	nin
 㨢	nang
 㨢	pei
 坉	nang
 坉	tyun
-能	nang	1000
+能	nang
 㕕	nap
 㕕	wan
 㖠	nap
@@ -16790,8 +16791,8 @@ min_phrase_weight: 100
 嫐	nat
 肭	nat
 肭	neot
-訥	nat	500
-訥	neot	500
+訥	nat
+訥	neot
 讷	nat
 讷	neot
 㑱	nau
@@ -16800,26 +16801,26 @@ min_phrase_weight: 100
 㺀	nau
 䅦	nau
 䴃	nau
-妞	nau	500
+妞	nau
 嬲	nau
 嬲	niu
 忸	nau
 忸	nuk
-扭	nau	1000
+扭	nau
 檽	nau
 狃	nau
 獳	nau
-紐	nau	1000
+紐	nau
 纽	nau
 耨	nau
 膩	nau	0%
-膩	nei	1000
-鈕	nau	1000
+膩	nei
+鈕	nau
 鎒	nau
 钮	nau
-呢	ne	1000
-呢	nei	501
-呢	ni	501
+呢	ne
+呢	nei
+呢	ni
 㛅	nei
 㞾	nei
 㟜	nei
@@ -16842,14 +16843,14 @@ min_phrase_weight: 100
 䝚	nei
 䣵	nei
 䥸	nei
-你	nei	1000
-妮	nei	500
+你	nei
+妮	nei
 婗	nei
 婗	ngai
-尼	nei	1000
+尼	nei
 怩	nei
-您	nei	1000
-旎	nei	500
+您	nei
+旎	nei
 柅	nei
 檷	nei
 毦	nei
@@ -16861,7 +16862,7 @@ min_phrase_weight: 100
 腻	nei
 鈮	nei
 铌	nei
-餌	nei	500
+餌	nei
 饵	nei
 𨉖	nei
 𨉖	ni
@@ -16872,7 +16873,7 @@ min_phrase_weight: 100
 腇	neoi
 釹	neoi
 钕	neoi
-餒	neoi	1000
+餒	neoi
 餒	noi	0%
 㕯	neot
 䎪	neot
@@ -16890,24 +16891,24 @@ min_phrase_weight: 100
 䓊	ng
 䦜	ng
 䮏	ng
-五	ng	1000
+五	ng
 仵	ng
-伍	ng	1000
+伍	ng
 俉	ng
-午	ng	1000
-吳	ng	1000
+午	ng
+吳	ng
 吴	ng
-吾	ng	1000
+吾	ng
 啎	ng
-嗯	ng	1000
-寤	ng	500
+嗯	ng
+寤	ng
 峿	ng
 忢	ng
 忤	ng
 悞	ng
-悟	ng	1000
-晤	ng	1000
-梧	ng	500
+悟	ng
+晤	ng
+梧	ng
 浯	ng
 焐	ng
 牾	ng
@@ -16915,8 +16916,8 @@ min_phrase_weight: 100
 痦	ng
 蘁	ng
 蘁	ngok
-蜈	ng	1000
-誤	ng	1000
+蜈	ng
+誤	ng
 误	ng
 迕	ng
 遻	ng
@@ -16939,17 +16940,17 @@ min_phrase_weight: 100
 庌	ngaa
 枒	ngaa
 桠	ngaa
-牙	ngaa	1000
+牙	ngaa
 犽	ngaa
-瓦	ngaa	1000
+瓦	ngaa
 疋	ngaa	0%
-疋	pat	1000
+疋	pat
 疋	so	0%
 砑	ngaa
-芽	ngaa	1000
+芽	ngaa
 蚜	ngaa
-衙	ngaa	500
-訝	ngaa	1000
+衙	ngaa
+訝	ngaa
 讶	ngaa
 迓	ngaa
 齾	ngaa
@@ -16972,30 +16973,30 @@ min_phrase_weight: 100
 䣀	ngaai
 䫥	ngaai
 乂	ngaai
-刈	ngaai	500
+刈	ngaai
 厓	ngaai
 啀	ngaai
 堐	ngaai
-崖	ngaai	1000
-捱	ngaai	1000
-涯	ngaai	1000
+崖	ngaai
+捱	ngaai
+涯	ngaai
 睚	ngaai
-艾	ngaai	1000
+艾	ngaai
 峉	ngaak
 詻	ngaak
 頟	ngaak
-額	ngaak	1000
+額	ngaak
 额	ngaak
 𠱘	ngaak
 𠸺	ngaak
 𧦠	ngaak
 啱	ngaam	1000
 喦	ngaam
-岩	ngaam	500
+岩	ngaam
 嵒	ngaam
 巌	ngaam
-巖	ngaam	1000
-癌	ngaam	1000
+巖	ngaam
+癌	ngaam
 碞	ngaam
 黬	ngaam
 㙬	ngaan
@@ -17007,15 +17008,15 @@ min_phrase_weight: 100
 䇵	zi
 䴦	ngaan
 䴦	ngai
-眼	ngaan	1000
+眼	ngaan
 虤	ngaan
 贗	ngaan
 贗	ngan
-雁	ngaan	1000
-顏	ngaan	1000
+雁	ngaan
+顏	ngaan
 颜	ngaan
 鴈	ngaan
-硬	ngaang	1000
+硬	ngaang
 擪	ngaap
 㐳	ngaat
 㞕	ngaat
@@ -17031,13 +17032,13 @@ min_phrase_weight: 100
 䗤	ngaau
 䗤	zung
 䬲	ngaau
-咬	ngaau	1000
+咬	ngaau
 崤	ngaau
 挍	ngaau
 殽	ngaau
-淆	ngaau	1000
-爻	ngaau	500
-肴	ngaau	500
+淆	ngaau
+爻	ngaau
+肴	ngaau
 餚	ngaau
 齩	ngaau
 𠴳	ngaau
@@ -17050,54 +17051,54 @@ min_phrase_weight: 100
 䢃	ngai
 䭳	ngai
 伪	ngai
-倪	ngai	500
-偽	ngai	1000
+倪	ngai
+偽	ngai
 僞	ngai
-危	ngai	1000
+危	ngai
 呓	ngai
 噅	ngai
-囈	ngai	500
+囈	ngai
 埶	ngai
 埶	zap
 堄	ngai
 寱	ngai
 嵬	ngai
-巍	ngai	500
+巍	ngai
 掜	ngai
 掜	nip
-桅	ngai	500
-桅	wai	500
+桅	ngai
+桅	wai
 槸	ngai
 檥	ngai
-毅	ngai	1000
+毅	ngai
 犩	ngai
 猊	ngai
-睨	ngai	500
+睨	ngai
 礒	ngai
-羿	ngai	1000
+羿	ngai
 舣	ngai
 艤	ngai
 艺	ngai
 蓺	ngai
 藙	ngai
-藝	ngai	1000
+藝	ngai
 蚁	ngai
-蛾	ngai	500
-蛾	ngo	500
+蛾	ngai
+蛾	ngo
 蜺	ngai
 螘	ngai
-蟻	ngai	1000
+蟻	ngai
 襼	ngai
-詣	ngai	1000
+詣	ngai
 诣	ngai
 輗	ngai
 郳	ngai
 隗	ngai
 隗	wai
-霓	ngai	1000
+霓	ngai
 頠	ngai
 顗	ngai
-魏	ngai	1000
+魏	ngai
 鮠	ngai
 鮠	wai
 鯢	ngai
@@ -17123,13 +17124,13 @@ min_phrase_weight: 100
 䮗	ngon
 嚚	ngan
 圁	ngan
-垠	ngan	500
+垠	ngan
 奀	ngan
 狺	ngan
 誾	ngan
 赝	ngan
 鄞	ngan
-銀	ngan	1000
+銀	ngan
 银	ngan
 齗	ngan
 龂	ngan
@@ -17137,9 +17138,9 @@ min_phrase_weight: 100
 㟁	ngon
 䤝	ngang
 砐	ngap
-兀	ngat	500
+兀	ngat
 卼	ngat
-屹	ngat	1000
+屹	ngat
 屼	ngat
 杌	ngat
 汔	ngat
@@ -17157,12 +17158,12 @@ min_phrase_weight: 100
 䉰	ngau
 䋂	ngau
 䶧	ngau
-偶	ngau	1000
-牛	ngau	1000
+偶	ngau
+牛	ngau
 耦	ngau
 腢	ngau
 蕅	ngau
-藕	ngau	500
+藕	ngau
 騳	ngau
 㓟	ngo
 㓟	pai
@@ -17174,46 +17175,46 @@ min_phrase_weight: 100
 䖸	ngo
 䳗	ngo
 䳘	ngo
-俄	ngo	1000
-卧	ngo	1000
+俄	ngo
+卧	ngo
 吪	ngo
-哦	ngo	1000
-哦	o	501
-娥	ngo	1000
-峨	ngo	500
+哦	ngo
+哦	o
+娥	ngo
+峨	ngo
 峩	ngo
-我	ngo	1000
+我	ngo
 涐	ngo
 睋	ngo
 硪	ngo
 臥	ngo
 莪	ngo
-訛	ngo	500
+訛	ngo
 誐	ngo
 譌	ngo
 讹	ngo
 鋨	ngo
 锇	ngo
-餓	ngo	1000
+餓	ngo
 饿	ngo
-鵝	ngo	1000
+鵝	ngo
 鵞	ngo
 鹅	ngo
 𠹷	ngo
 㕌	ngoi
 㕌	zak
-外	ngoi	1000
+外	ngoi
 外	oi	0%
 愛	ngoi	0%
-愛	oi	1000
-氨	ngoi	500
-氨	on	500
+愛	oi
+氨	ngoi
+氨	on
 爱	ngoi
 爱	oi
-璦	ngoi	500
-璦	oi	500
+璦	ngoi
+璦	oi
 碍	ngoi
-礙	ngoi	1000
+礙	ngoi
 騃	ngoi
 𫘤	ngoi
 㓵	ngok
@@ -17229,30 +17230,30 @@ min_phrase_weight: 100
 咢	ngok
 噁	ngok
 噁	ok
-噩	ngok	500
+噩	ngok
 堮	ngok
-岳	ngok	1000
+岳	ngok
 崿	ngok
-嶽	ngok	1000
+嶽	ngok
 恶	ngok
 恶	ok
 恶	wu
 惡	ngok	0%
-惡	ok	1000
-惡	wu	1000
-愕	ngok	500
+惡	ok
+惡	wu
+愕	ngok
 櫮	ngok
 腭	ngok
-萼	ngok	500
+萼	ngok
 諤	ngok
 谔	ngok
-鄂	ngok	500
+鄂	ngok
 鍔	ngok
 锷	ngok
-顎	ngok	500
+顎	ngok
 颚	ngok
 鰐	ngok
-鱷	ngok	1000
+鱷	ngok
 鳄	ngok
 鶚	ngok
 鸑	ngok
@@ -17262,10 +17263,10 @@ min_phrase_weight: 100
 㸩	ngon
 䯃	ngon
 安	ngon	0%
-安	on	1000
-岸	ngon	1000
+安	on
+岸	ngon
 案	ngon	0%
-案	on	1000
+案	on
 胺	ngon
 胺	on
 銨	ngon
@@ -17282,7 +17283,7 @@ min_phrase_weight: 100
 戅	ngong
 戆	ngong
 戆	zong
-昂	ngong	1000
+昂	ngong
 㜜	ngou
 㟼	ngou
 㠂	ngou
@@ -17292,8 +17293,8 @@ min_phrase_weight: 100
 䫨	ngou
 䮯	ngou
 䵅	ngou
-傲	ngou	1000
-嗷	ngou	500
+傲	ngou
+嗷	ngou
 奡	ngou
 嶴	ngou
 嶴	ou
@@ -17301,38 +17302,38 @@ min_phrase_weight: 100
 摮	ngou
 擙	ngou
 擙	ou
-敖	ngou	1000
+敖	ngou
 滶	ngou
-熬	ngou	1000
+熬	ngou
 爊	ngou
 爊	ou
 獒	ngou
 璈	ngou
 磝	ngou
-翱	ngou	500
+翱	ngou
 翺	ngou
-聱	ngou	500
+聱	ngou
 芺	ngou
 芺	ou
 螯	ngou
 謷	ngou
-遨	ngou	500
+遨	ngou
 鏊	ngou
-鏖	ngou	500
-鏖	ou	500
+鏖	ngou
+鏖	ou
 隞	ngou
 驁	ngou
 骜	ngou
 鰲	ngou
 鳌	ngou
 鷔	ngou
-鼇	ngou	500
+鼇	ngou
 𢳆	ngou
 𦪈	ngou
 剭	nguk
 剭	uk
 屋	nguk	0%
-屋	uk	1000
+屋	uk
 𡃵	ngung
 𢫨	ngung
 𢶜	ngung
@@ -17342,15 +17343,15 @@ min_phrase_weight: 100
 䘌	nik
 䵑	nik
 䵒	nik
-匿	nik	500
+匿	nik
 嫟	nik
 惄	nik
-慝	nik	500
-慝	tik	500
+慝	nik
+慝	tik
 搦	nik
 昵	nik
 暱	nik
-溺	nik	1000
+溺	nik
 溺	niu	0%
 疒	nik
 砾	nik
@@ -17368,19 +17369,19 @@ min_phrase_weight: 100
 䬯	nim
 䵿	nim
 䵿	tip
-唸	nim	1000
-念	nim	1000
-拈	nim	500
-拈	nin	500
-捻	nim	500
-捻	nip	500
+唸	nim
+念	nim
+拈	nim
+拈	nin
+捻	nim
+捻	nip
 棯	nim
 粘	nim
 粘	zim
 蹨	nim
 鯰	nim
 鲶	nim
-黏	nim	1000
+黏	nim
 黏	zim	0%
 㞋	nin
 㮟	nin
@@ -17388,15 +17389,15 @@ min_phrase_weight: 100
 䄭	zin
 䄹	nin
 姩	nin
-年	nin	1000
+年	nin
 涊	nin
-碾	nin	500
+碾	nin
 脌	nin
 跈	nin
 蹍	nin
 蹍	zin
 輾	nin	0%
-輾	zin	1000
+輾	zin
 𢆡	nin
 㣷	ning
 㲌	ning
@@ -17405,19 +17406,19 @@ min_phrase_weight: 100
 䔭	ning
 䗿	ning
 䭢	ning
-佞	ning	500
+佞	ning
 儜	ning
 咛	ning
-嚀	ning	500
+嚀	ning
 寍	ning
 寗	ning
-寧	ning	1000
+寧	ning
 拧	ning
 柠	ning
 泞	ning
-濘	ning	1000
+濘	ning
 狞	ning
-獰	ning	500
+獰	ning
 甯	ning
 聍	ning
 聹	ning
@@ -17450,20 +17451,20 @@ min_phrase_weight: 100
 䯀	wai
 䯅	nip
 䳖	nip
-捏	nip	1000
+捏	nip
 揑	nip
 攝	nip	0%
-攝	sip	1000
+攝	sip
 敜	nip
 涅	nip
 湼	nip
 聂	nip
-聶	nip	500
+聶	nip
 苶	nip
 踂	nip
 蹑	nip
-躡	nip	500
-鎳	nip	500
+躡	nip
+鎳	nip
 鑷	nip
 镊	nip
 镍	nip
@@ -17482,15 +17483,15 @@ min_phrase_weight: 100
 䙚	niu
 䮍	niu
 嫋	niu
-嬝	niu	500
-尿	niu	1000
+嬝	niu
+尿	niu
 尿	seoi	0%
 茑	niu
 蔦	niu
 袅	niu
-裊	niu	500
+裊	niu
 褭	niu
-鳥	niu	1000
+鳥	niu
 鸟	niu
 㐡	no
 㡅	no
@@ -17500,15 +17501,15 @@ min_phrase_weight: 100
 傩	no
 儺	no
 愞	no
-懦	no	1000
+懦	no
 懧	no
-挪	no	1000
+挪	no
 挼	no
 捼	no
 稬	no
-糯	no	1000
+糯	no
 𥻟	no
-娘	noeng	1000
+娘	noeng
 孃	noeng
 㨅	noi
 㮈	noi
@@ -17519,18 +17520,18 @@ min_phrase_weight: 100
 䱞	noi
 倷	noi
 内	noi
-奈	noi	1000
+奈	noi
 柰	noi
 氝	noi
-耐	noi	1000
+耐	noi
 錼	noi
 餧	noi
 餧	wai
 馁	noi
-諾	nok	1000
+諾	nok
 诺	nok
 㶞	nong
-囊	nong	1000
+囊	nong
 囔	nong
 擃	nong
 攮	nong
@@ -17552,23 +17553,23 @@ min_phrase_weight: 100
 䜀	nou
 䜧	nou
 伮	nou
-努	nou	1000
-奴	nou	1000
+努	nou
+奴	nou
 孥	nou
-帑	nou	500
-帑	tong	500
-弩	nou	500
-怒	nou	1000
+帑	nou
+帑	tong
+弩	nou
+怒	nou
 恼	nou
 悩	nou
-惱	nou	1000
-瑙	nou	1000
+惱	nou
+瑙	nou
 砮	nou
 碯	nou
 笯	nou
 脑	nou
-腦	nou	1000
-駑	nou	500
+腦	nou
+駑	nou
 驽	nou
 䘐	nuk
 䚼	nuk
@@ -17582,27 +17583,27 @@ min_phrase_weight: 100
 䢉	nung
 䵜	nung
 侬	nung
-儂	nung	500
+儂	nung
 农	nung
 哝	nung
-噥	nung	500
+噥	nung
 浓	nung
 燶	nung
 秾	nung
 穠	nung
 脓	nung
-膿	nung	500
+膿	nung
 襛	nung
 譨	nung
-農	nung	1000
+農	nung
 醲	nung
 𪒬	nung
 䎡	nyun
 䞂	nyun
 䞂	zyun
 媆	nyun
-嫩	nyun	1000
-暖	nyun	1000
+嫩	nyun
+暖	nyun
 渜	nyun
 餪	nyun
 𡞾	nyun
@@ -17611,13 +17612,13 @@ min_phrase_weight: 100
 䋪	o
 嚄	o
 嚄	wok
-婀	o	500
+婀	o
 屙	o
-柯	o	500
+柯	o
 珂	o
 疴	o
 痾	o
-軻	o	500
+軻	o
 轲	o
 钶	o
 㗒	oi
@@ -17626,23 +17627,23 @@ min_phrase_weight: 100
 䨠	oi
 䨠	piu
 僾	oi
-哀	oi	1000
+哀	oi
 嗳	oi
-噯	oi	500
+噯	oi
 壒	oi
 嫒	oi
 嬡	oi
 暧	oi
-曖	oi	500
+曖	oi
 毐	oi
 瑷	oi
 瞹	oi
 蔼	oi
 薆	oi
-藹	oi	1000
+藹	oi
 鑀	oi
 霭	oi
-靄	oi	500
+靄	oi
 靉	oi
 垩	ok
 堊	ok
@@ -17651,19 +17652,19 @@ min_phrase_weight: 100
 䅁	on
 䢿	on
 䬶	on
-按	on	1000
+按	on
 摁	on
 桉	on
-盎	on	1000
-盎	ong	1000
+盎	on
+盎	ong
 铵	on
 鞌	on
-鞍	on	1000
+鞍	on
 㼜	ong
 䱀	ong
 䱀	zoeng
-甕	ong	500
-甕	ung	500
+甕	ong
+甕	ung
 罋	ong
 罋	ung
 軮	ong
@@ -17683,14 +17684,14 @@ min_phrase_weight: 100
 䴠	ziu
 墺	ou
 奥	ou
-奧	ou	1000
+奧	ou
 媪	ou
-媼	ou	500
-媼	wan	500
+媼	ou
+媼	wan
 岙	ou
-懊	ou	1000
+懊	ou
 袄	ou
-襖	ou	500
+襖	ou
 鏕	ou
 镺	ou
 𥜌	ou
@@ -17699,16 +17700,16 @@ min_phrase_weight: 100
 䎱	paa
 帊	paa
 帕	paa	0%
-帕	paak	1000
-怕	paa	1000
-扒	paa	1000
+帕	paak
+怕	paa
+扒	paa
 掱	paa
-杷	paa	500
-爬	paa	1000
-琶	paa	1000
+杷	paa
+爬	paa
+琶	paa
 筢	paa
-耙	paa	500
-趴	paa	1000
+耙	paa
+趴	paa
 跁	paa
 𦘩	paa
 㭛	paai
@@ -17717,11 +17718,11 @@ min_phrase_weight: 100
 䰦	paai
 䰦	pei
 䱝	paai
-俳	paai	500
-排	paai	1000
+俳	paai
+排	paai
 棑	paai
-派	paai	1000
-牌	paai	1000
+派	paai
+牌	paai
 篺	paai
 簰	paai
 蒎	paai
@@ -17734,9 +17735,9 @@ min_phrase_weight: 100
 䪖	paak
 䪖	pak
 䪖	pok
-啪	paak	1000
-拍	paak	1000
-珀	paak	500
+啪	paak
+拍	paak
+珀	paak
 㐴	paan
 㰋	paan
 㰋	pei
@@ -17744,9 +17745,9 @@ min_phrase_weight: 100
 䤨	paan
 䤨	pik
 䤨	wan
-扳	paan	500
-攀	paan	1000
-盼	paan	1000
+扳	paan
+攀	paan
+盼	paan
 眅	paan
 袢	paan
 襻	paan
@@ -17757,32 +17758,32 @@ min_phrase_weight: 100
 倗	pang
 匉	paang
 匉	ping
-彭	paang	500
-彭	pang	500
+彭	paang
+彭	pang
 恲	paang
 憉	paang
-抨	paang	500
-抨	ping	500
-棒	paang	1000
-棚	paang	1000
+抨	paang
+抨	ping
+棒	paang
+棚	paang
 泙	paang
 泙	ping
 淜	paang
 淜	pang
 淜	ping
 漰	paang
-澎	paang	1000
-烹	paang	1000
-硼	paang	500
-硼	pang	500
+澎	paang
+烹	paang
+硼	paang
+硼	pang
 磞	paang
 磞	pang
-膨	paang	1000
+膨	paang
 蟚	paang
 蟛	paang
 軯	paang
 輣	paang
-鵬	paang	500
+鵬	paang
 鹏	paang
 𢴒	paang
 𢵓	paang
@@ -17794,33 +17795,33 @@ min_phrase_weight: 100
 䠙	pong
 䬌	paau
 䶌	paau
-刨	paau	1000
-匏	paau	500
-咆	paau	500
+刨	paau
+匏	paau
+咆	paau
 奅	paau
-庖	paau	500
+庖	paau
 抛	paau
-拋	paau	1000
-泡	paau	1000
-泡	pou	1000
+拋	paau
+泡	paau
+泡	pou
 炰	paau
 疱	paau
-皰	paau	500
+皰	paau
 礟	paau
 礮	paau
 脬	paau
 趵	paau
-跑	paau	1000
-鉋	paau	500
+跑	paau
+鉋	paau
 鑤	paau
 铇	paau
 飑	paau
 䪹	pai
 䪹	pei
 䪹	pui
-批	pai	1000
+批	pai
 睤	pai
-睥	pai	500
+睥	pai
 磇	pai
 錍	pai
 𠜱	pai
@@ -17840,15 +17841,15 @@ min_phrase_weight: 100
 喷	pan
 嚬	pan
 嫔	pan
-牝	pan	500
+牝	pan
 玭	pan
 矉	pan
 蘋	pan	0%
-蘋	ping	1000
-貧	pan	1000
+蘋	ping
+貧	pan
 贫	pan
-頻	pan	1000
-顰	pan	500
+頻	pan
+顰	pan
 频	pan
 颦	pan
 㠮	pang
@@ -17862,9 +17863,9 @@ min_phrase_weight: 100
 䰷	pang
 䰷	pau
 凭	pang
-朋	pang	1000
+朋	pang
 𠗦	pang
-匹	pat	1000
+匹	pat
 鴄	pat
 㚿	pau
 㬓	pau
@@ -17896,46 +17897,46 @@ min_phrase_weight: 100
 䮒	pou
 䯱	pei
 䲹	pei
-丕	pei	500
-仳	pei	500
+丕	pei
+仳	pei
 伾	pei
-呸	pei	500
+呸	pei
 嚭	pei
 圮	pei
 埤	pei
 堛	pei
 堛	pik
-婢	pei	1000
+婢	pei
 嬖	pei
-屁	pei	1000
+屁	pei
 帔	pei
 庀	pei
-披	pei	1000
-枇	pei	500
-毗	pei	500
+披	pei
+枇	pei
+毗	pei
 毘	pei
 淠	pei
 濞	pei
 狉	pei
-琵	pei	1000
-疲	pei	1000
-痞	pei	500
-皮	pei	1000
+琵	pei
+疲	pei
+痞	pei
+皮	pei
 砒	pei
 秠	pei
 粃	pei
-紕	pei	500
+紕	pei
 纰	pei
 翍	pei
-脾	pei	1000
+脾	pei
 苤	pei
 蚍	pei
 蜱	pei
-譬	pei	1000
+譬	pei
 貔	pei
 邳	pei
 郫	pei
-鄙	pei	1000
+鄙	pei
 鈚	pei
 鈹	pei
 铍	pei
@@ -17944,32 +17945,32 @@ min_phrase_weight: 100
 駓	pei
 髬	pei
 魾	pei
-鼙	pei	500
+鼙	pei
 𨈚	pei
 𨉉	pei
 䌟	pek
-劈	pek	1000
+劈	pek
 劈	pik	0%
 噼	pek
 噼	pet
 呯	peng
-平	peng	501
-平	ping	1000
+平	peng
+平	ping
 瓶	peng	0%
-瓶	ping	1000
+瓶	ping
 𠝭	peng
 𣖕	peng
 𩩍	peng
 䑀	pik
 䴙	pik
-僻	pik	1000
+僻	pik
 擗	pik
 澼	pik
 甓	pik
-癖	pik	500
+癖	pik
 釽	pik
-闢	pik	1000
-霹	pik	500
+闢	pik
+霹	pik
 鷿	pik
 㓲	pin
 㛹	pin
@@ -17980,25 +17981,25 @@ min_phrase_weight: 100
 䏒	pin
 䡢	pin
 䮁	pin
-偏	pin	1000
+偏	pin
 媥	pin
 徧	pin
 楄	pin
 楩	pin
-片	pin	1000
-篇	pin	1000
-編	pin	1000
+片	pin
+篇	pin
+編	pin
 緶	pin
 缏	pin
 编	pin
-翩	pin	1000
+翩	pin
 諞	pin
 谝	pin
 跰	pin
 蹁	pin
-駢	pin	500
-駢	ping	500
-騙	pin	1000
+駢	pin
+駢	ping
+騙	pin
 骈	pin
 骗	pin
 骿	pin
@@ -18012,26 +18013,26 @@ min_phrase_weight: 100
 䶄	ping
 伻	ping
 俜	ping
-坪	ping	1000
-姘	ping	500
+坪	ping
+姘	ping
 娉	ping
 帡	ping
 帲	ping
 怦	ping
 拚	ping	0%
-拚	pun	1000
-拼	ping	1000
+拚	pun
+拼	ping
 枰	ping
 洴	ping
 甹	ping
-砰	ping	1000
+砰	ping
 竮	ping
 缾	ping
-聘	ping	1000
+聘	ping
 苹	ping
 荓	ping
-萍	ping	1000
-評	ping	1000
+萍	ping
+評	ping
 评	ping
 軿	ping
 郱	ping
@@ -18043,10 +18044,10 @@ min_phrase_weight: 100
 嫳	pit
 徶	pit
 撆	pit
-撇	pit	500
+撇	pit
 氕	pit
 潎	pit
-瞥	pit	500
+瞥	pit
 𢠳	pit
 㯱	piu
 㲏	piu
@@ -18059,20 +18060,20 @@ min_phrase_weight: 100
 䕯	piu
 䴩	piu
 僄	piu
-剽	piu	500
+剽	piu
 嘌	piu
-嫖	piu	500
+嫖	piu
 彯	piu
 慓	piu
 摽	piu
-朴	piu	500
-朴	po	500
-朴	pok	500
+朴	piu
+朴	po
+朴	pok
 殍	piu
-漂	piu	1000
-瓢	piu	500
+漂	piu
+瓢	piu
 皫	piu
-瞟	piu	500
+瞟	piu
 篻	piu
 縹	piu
 缥	piu
@@ -18080,32 +18081,32 @@ min_phrase_weight: 100
 螵	piu
 醥	piu
 顠	piu
-飄	piu	1000
+飄	piu
 飘	piu
-驃	piu	500
+驃	piu
 骠	piu
-鰾	piu	500
+鰾	piu
 鳔	piu
-叵	po	500
-婆	po	1000
+叵	po
+婆	po
 媻	po
 媻	pun
 尀	po
 樖	po
 皤	po
-破	po	1000
+破	po
 笸	po
-頗	po	1000
+頗	po
 颇	po
 䄸	pok
 䇚	pok
 䪙	pok
-噗	pok	500
+噗	pok
 墣	pok
 扑	pok
-撲	pok	1000
+撲	pok
 璞	pok
-粕	pok	500
+粕	pok
 蒪	pok
 釙	pok
 钋	pok
@@ -18123,44 +18124,44 @@ min_phrase_weight: 100
 䮾	pong
 嗙	pong
 庞	pong
-徬	pong	500
-旁	pong	1000
-滂	pong	500
+徬	pong
+旁	pong
+滂	pong
 篣	pong
 耪	pong
 肨	pong
 艕	pong
-蚌	pong	500
-螃	pong	500
-謗	pong	500
+蚌	pong
+螃	pong
+謗	pong
 谤	pong
 逄	pong
 雱	pong
 霶	pong
 龎	pong
-龐	pong	1000
+龐	pong
 䈬	pou
 䈻	pou
 䔕	pou
 䩣	pou
 䩣	tou
 䲕	pou
-匍	pou	500
-普	pou	1000
+匍	pou
+普	pou
 氆	pou
-浦	pou	500
-溥	pou	500
+浦	pou
+溥	pou
 舖	pou
-菩	pou	1000
-葡	pou	1000
+菩	pou
+葡	pou
 蒱	pou
-蒲	pou	1000
+蒲	pou
 袌	pou
-袍	pou	1000
-譜	pou	1000
+袍	pou
+譜	pou
 谱	pou
 酺	pou
-鋪	pou	1000
+鋪	pou
 鐠	pou
 铺	pou
 镨	pou
@@ -18172,35 +18173,35 @@ min_phrase_weight: 100
 㳈	pui
 㾦	pui
 䫊	pui
-佩	pui	1000
-倍	pui	1000
-坏	pui	500
+佩	pui
+倍	pui
+坏	pui
 坯	pui
-培	pui	1000
-徘	pui	1000
+培	pui
+徘	pui
 旆	pui
 昢	pui
 柸	pui
 毰	pui
-沛	pui	1000
-珮	pui	500
+沛	pui
+珮	pui
 琲	pui
 碚	pui
 肧	pui
-胚	pui	1000
+胚	pui
 衃	pui
-裴	pui	500
-賠	pui	1000
+裴	pui
+賠	pui
 赔	pui
-配	pui	1000
+配	pui
 醅	pui
-陪	pui	1000
+陪	pui
 霈	pui
 㢖	pun
 㩯	pun
 䆺	pun
 䰔	pun
-判	pun	1000
+判	pun
 幋	pun
 槃	pun
 沜	pun
@@ -18208,11 +18209,11 @@ min_phrase_weight: 100
 洀	pun
 洀	zau
 湓	pun
-潘	pun	500
-盆	pun	1000
+潘	pun
+盆	pun
 盘	pun
-盤	pun	1000
-磐	pun	500
+盤	pun
+磐	pun
 磻	pun
 縏	pun
 胓	pun
@@ -18225,17 +18226,17 @@ min_phrase_weight: 100
 䋽	pung
 掽	pung
 椪	pung
-碰	pung	1000
-篷	pung	500
+碰	pung
+篷	pung
 芃	pung
-踫	pung	500
+踫	pung
 髼	pung
 㔇	put
 㗶	put
 㧊	put
 䥽	put
 泼	put
-潑	put	1000
+潑	put
 酦	put
 醱	put
 鏺	put
@@ -18246,27 +18247,27 @@ min_phrase_weight: 100
 㲚	tim
 㸺	saa
 䩖	saa
-卅	saa	500
+卅	saa
 唦	saa
-啥	saa	1000
-沙	saa	1000
+啥	saa
+沙	saa
 洒	saa
 洒	sai
 洒	sin
-灑	saa	1000
+灑	saa
 猀	saa
 痧	saa
-砂	saa	1000
-紗	saa	1000
+砂	saa
+紗	saa
 纱	saa
-耍	saa	1000
-莎	saa	500
-莎	so	500
-裟	saa	500
+耍	saa
+莎	saa
+莎	so
+裟	saa
 逤	saa
 逤	so
 魦	saa
-鯊	saa	1000
+鯊	saa
 鲨	saa
 𧋊	saa
 㩄	saai	1000
@@ -18285,16 +18286,16 @@ min_phrase_weight: 100
 咶	si
 嘥	saai
 屣	saai
-徙	saai	1000
+徙	saai
 晒	saai
-曬	saai	1000
+曬	saai
 枲	saai
 枲	sai
 殺	saai	0%
-殺	saat	1000
+殺	saat
 漇	saai
 玺	saai
-璽	saai	500
+璽	saai
 縰	saai
 纚	saai
 舓	saai
@@ -18308,8 +18309,8 @@ min_phrase_weight: 100
 𫍰	saai
 𫍰	si
 梀	saak
-索	saak	1000
-索	sok	1000
+索	saak
+索	sok
 索	suk	0%
 𢱢	saak
 㓄	saam
@@ -18330,7 +18331,7 @@ min_phrase_weight: 100
 䏹	zin
 䥠	saam
 䥠	zaam
-三	saam	1000
+三	saam
 仨	saam
 叁	saam
 幓	saam
@@ -18341,9 +18342,9 @@ min_phrase_weight: 100
 穇	saam
 糁	saam
 糝	saam
-芟	saam	500
+芟	saam
 蔪	saam
-衫	saam	1000
+衫	saam
 釤	saam
 釤	sin
 鏒	saam
@@ -18378,38 +18379,38 @@ min_phrase_weight: 100
 䰠	saan
 䴮	saan
 伞	saan
-傘	saan	1000
+傘	saan
 删	saan
-刪	saan	1000
-姍	saan	500
+刪	saan
+姍	saan
 姗	saan
-山	saan	1000
-拴	saan	500
+山	saan
+拴	saan
 挻	saan
-散	saan	1000
-栓	saan	500
+散	saan
+栓	saan
 氙	saan
 氙	sin
 氥	saan
 氥	sai
 氥	sin
-汕	saan	500
-涮	saan	500
-潸	saan	500
-潺	saan	500
-珊	saan	1000
-疝	saan	500
-篡	saan	500
+汕	saan
+涮	saan
+潸	saan
+潺	saan
+珊	saan
+疝	saan
+篡	saan
 粣	saan
 糤	saan
 繖	saan
 膻	saan
 膻	zin
-舢	saan	500
-訕	saan	500
+舢	saan
+訕	saan
 讪	saan
-跚	saan	500
-閂	saan	1000
+跚	saan
+閂	saan
 闩	saan
 饊	saan
 㗂	saang
@@ -18429,19 +18430,19 @@ min_phrase_weight: 100
 渻	saang
 渻	sing
 牲	saang	0%
-牲	sang	1000
+牲	sang
 琤	saang
 琤	zaang
 琤	zang
-生	saang	501
-生	sang	1000
+生	saang
+生	sang
 甥	saang	0%
-甥	sang	1000
-省	saang	1000
-省	sing	1000
+甥	sang
+省	saang
+省	sing
 眚	saang
 笙	saang	0%
-笙	sang	1000
+笙	sang
 胜	saang
 胜	sing
 㒊	saap
@@ -18472,10 +18473,10 @@ min_phrase_weight: 100
 趿	taat
 鉔	saap
 霋	saap
-霎	saap	500
-霎	sap	500
+霎	saap
+霎	sap
 靸	saap
-颯	saap	500
+颯	saap
 飒	saap
 馺	saap
 𢶍	saap
@@ -18483,13 +18484,13 @@ min_phrase_weight: 100
 䊛	saat
 䶡	saat
 摋	saat
-撒	saat	1000
+撒	saat
 杀	saat
 樧	saat
-煞	saat	1000
+煞	saat
 萨	saat
 蔱	saat
-薩	saat	1000
+薩	saat
 鎩	saat
 铩	saat
 閷	saat
@@ -18519,14 +18520,14 @@ min_phrase_weight: 100
 䭉	seoi
 䭭	saau
 䭭	sou
-哨	saau	1000
+哨	saau
 弰	saau
-捎	saau	500
+捎	saau
 旓	saau
-梢	saau	1000
+梢	saau
 潲	saau
 潲	sau
-稍	saau	1000
+稍	saau
 筲	saau
 艄	saau
 莦	saau
@@ -18549,41 +18550,41 @@ min_phrase_weight: 100
 䤱	sai
 䵘	sai
 䵘	sam
-世	sai	1000
-使	sai	501
-使	si	1000
+世	sai
+使	sai
+使	si
 势	sai
-勢	sai	1000
-嘶	sai	500
-嘶	si	500
-噬	sai	500
+勢	sai
+嘶	sai
+嘶	si
+噬	sai
 壻	sai
-婿	sai	1000
+婿	sai
 恓	sai
 樨	sai
-洗	sai	1000
+洗	sai
 澨	sai
-犀	sai	1000
+犀	sai
 硒	sai
 筛	sai
 筮	sai
-篩	sai	1000
+篩	sai
 簁	sai
 簁	si
 簭	sai
 粞	sai
-細	sai	1000
+細	sai
 细	sai
 舾	sai
 茜	sai
 茜	sin
-西	sai	1000
-誓	sai	1000
+西	sai
+誓	sai
 貰	sai
 贳	sai
-逝	sai	1000
+逝	sai
 遾	sai
-駛	sai	1000
+駛	sai
 驶	sai
 𠀍	sai
 𩢲	sai
@@ -18612,32 +18613,32 @@ min_phrase_weight: 100
 䊏	sam
 䲋	sam
 䵇	sam
-什	sam	1000
+什	sam
 什	sap	0%
-什	zaap	200
+什	zaap
 伈	sam
 婶	sam
-嬸	sam	1000
+嬸	sam
 审	sam
-審	sam	1000
-岑	sam	500
-心	sam	1000
-忱	sam	1000
+審	sam
+岑	sam
+心	sam
+忱	sam
 愖	sam
 梣	sam
-森	sam	1000
+森	sam
 椹	sam
 椹	zam
 槮	sam
-沁	sam	500
+沁	sam
 涔	sam
-深	sam	1000
+深	sam
 渖	sam
 渗	sam
-滲	sam	1000
-瀋	sam	1000
+滲	sam
+瀋	sam
 琛	sam
-甚	sam	1000
+甚	sam
 甚	sap	0%
 瞫	sam
 綝	sam
@@ -18670,43 +18671,43 @@ min_phrase_weight: 100
 䫅	tam
 䫩	san
 䯂	san
-伸	san	1000
+伸	san
 侁	san
 兟	san
-呻	san	1000
-娠	san	500
-娠	zan	500
+呻	san
+娠	san
+娠	zan
 宸	san
 屾	san
 愼	san
-慎	san	1000
-新	san	1000
-晨	san	1000
+慎	san
+新	san
+晨	san
 桭	san
 氠	san
 燊	san
 珅	san
 甡	san
-申	san	1000
+申	san
 砷	san
-神	san	1000
+神	san
 祳	san
-紳	san	1000
+紳	san
 绅	san
 肾	san
 胂	san
 胂	seon
 脤	san
-腎	san	1000
-臣	san	1000
-莘	san	500
-薪	san	1000
-蜃	san	500
+腎	san
+臣	san
+莘	san
+薪	san
+蜃	san
 詵	san
 诜	san
-辛	san	1000
-辰	san	1000
-鋅	san	500
+辛	san
+辰	san
+鋅	san
 锌	san
 駪	san
 鷐	san
@@ -18717,7 +18718,7 @@ min_phrase_weight: 100
 䚇	sang
 䚇	sing
 僧	sang	0%
-僧	zang	1000
+僧	zang
 擤	sang
 狌	sang
 狌	sing
@@ -18729,32 +18730,32 @@ min_phrase_weight: 100
 䬃	sap
 䬃	seon
 䬃	sou
-十	sap	1000
+十	sap
 咂	sap
 咂	zaap
-拾	sap	1000
+拾	sap
 涩	sap
 湿	sap
 溼	sap
 澁	sap
-濕	sap	1000
+濕	sap
 譅	sap
 㒎	sat
 㻎	sat
 㻭	sat
 䣛	sat
-失	sat	1000
+失	sat
 实	sat
-室	sat	1000
+室	sat
 寔	sat
-實	sat	1000
+實	sat
 湜	sat
 湜	zik
-瑟	sat	1000
+瑟	sat
 璱	sat
-膝	sat	1000
-虱	sat	500
-蝨	sat	500
+膝	sat
+虱	sat
+蝨	sat
 㖟	sau
 㝊	sau
 㥅	sau
@@ -18774,78 +18775,78 @@ min_phrase_weight: 100
 䛵	sau
 䤇	sau
 䮟	sau
-修	sau	1000
+修	sau
 傁	sau
 兽	sau
 収	sau
-受	sau	1000
-叟	sau	500
-售	sau	1000
+受	sau
+叟	sau
+售	sau
 嗖	sau
-嗽	sau	1000
-嗾	sau	500
-嗾	zuk	500
-壽	sau	1000
+嗽	sau
+嗾	sau
+嗾	zuk
+壽	sau
 夀	sau
-守	sau	1000
-宿	sau	1000
-宿	suk	1000
+守	sau
+宿	sau
+宿	suk
 寿	sau
 廋	sau
-愁	sau	1000
-手	sau	1000
-授	sau	1000
-搜	sau	1000
+愁	sau
+手	sau
+授	sau
+搜	sau
 擞	sau
-擻	sau	1000
-收	sau	1000
+擻	sau
+收	sau
 棷	sau
 棷	zau
 溲	sau
 滫	sau
-漱	sau	1000
+漱	sau
 漱	sou	0%
 潃	sau
-狩	sau	500
+狩	sau
 獀	sau
-獸	sau	1000
+獸	sau
 琇	sau
-瘦	sau	1000
+瘦	sau
 瞍	sau
-秀	sau	1000
+秀	sau
 籔	sau
 籔	sou
 糔	sau
 綉	sau
 綬	sau
-繡	sau	1000
+繡	sau
 绣	sau
 绶	sau
-羞	sau	1000
-脩	sau	500
+羞	sau
+脩	sau
 艏	sau
-艘	sau	1000
-蒐	sau	1000
+艘	sau
+蒐	sau
 蓨	sau
 蓨	tiu
 薮	sau
-藪	sau	500
+藪	sau
 謏	sau
 謏	siu
 鄋	sau
 鉎	sau
 銹	sau
 鎪	sau
-鏽	sau	1000
+鏽	sau
 锈	sau
 锼	sau
-颼	sau	500
+颼	sau
 飕	sau
-餿	sau	500
+餿	sau
 饈	sau
 馊	sau
 馐	sau
-首	sau	1000
+首	sau
 騪	sau
 𢯱	sau
 𥈟	sau
@@ -18866,30 +18867,30 @@ min_phrase_weight: 100
 䥱	se
 䥾	se
 䬷	se
-些	se	1000
+些	se
 佘	se
 写	se
 冩	se
 卌	se
-卸	se	1000
+卸	se
 厍	se
 厙	se
-寫	se	1000
-捨	se	1000
+寫	se
+捨	se
 揳	se
 揳	sip
 揳	sit
 泻	se
-瀉	se	1000
+瀉	se
 猞	se
-社	se	1000
-舍	se	1000
-賒	se	500
+社	se
+舍	se
+賒	se
 赊	se
-赦	se	500
+赦	se
 阇	se
 騇	se
-麝	se	500
+麝	se
 𠶈	se
 㔌	sei
 㔌	tam
@@ -18901,15 +18902,15 @@ min_phrase_weight: 100
 㕜	si
 䏤	sei
 䏤	si
-四	sei	1000
-四	si	200
-死	sei	1000
-死	si	200
+四	sei
+四	si
+死	sei
+死	si
 殔	sei
 肂	sei
 肂	si
-肆	sei	1000
-肆	si	1000
+肆	sei
+肆	si
 蕼	sei
 㒪	sek
 㛫	sek
@@ -18921,28 +18922,28 @@ min_phrase_weight: 100
 䖨	sek
 䲽	sek
 硕	sek
-碩	sek	1000
+碩	sek
 祏	sek
 祏	sik
-錫	sek	1000
+錫	sek
 錫	sik	0%
 锡	sek
 鼫	sek
 𡃶	sek
-城	seng	501
-城	sing	1000
+城	seng
+城	sing
 声	seng
 声	sing
 姓	seng	0%
-姓	sing	1000
+姓	sing
 星	seng	0%
-星	sing	1000
-聲	seng	501
-聲	sing	1000
-腥	seng	501
-腥	sing	1000
+星	sing
+聲	seng
+聲	sing
+腥	seng
+腥	sing
 醒	seng	0%
-醒	sing	1000
+醒	sing
 鍟	seng
 㑔	seoi
 㑯	seoi
@@ -19000,54 +19001,54 @@ min_phrase_weight: 100
 䳠	seoi
 倕	seoi
 倠	seoi
-垂	seoi	1000
-墅	seoi	1000
+垂	seoi
+墅	seoi
 夊	seoi
 嬃	seoi
 岁	seoi
 嵗	seoi
 帅	seoi
-帥	seoi	1000
+帥	seoi
 帥	seot	0%
 帨	seoi
-彗	seoi	1000
+彗	seoi
 彗	wai	0%
-悴	seoi	1000
+悴	seoi
 挩	seoi
 挩	tyut
 摔	seoi	0%
-摔	seot	1000
+摔	seot
 楈	seoi
 槥	seoi
 槥	wai
 檖	seoi
-歲	seoi	1000
-水	seoi	1000
+歲	seoi
+水	seoi
 涗	seoi
 湑	seoi
 濉	seoi
 瀡	seoi
-燧	seoi	500
-瑞	seoi	1000
+燧	seoi
+瑞	seoi
 璲	seoi
-瘁	seoi	500
+瘁	seoi
 睟	seoi
-睡	seoi	1000
+睡	seoi
 睢	seoi
-碎	seoi	1000
-祟	seoi	1000
+碎	seoi
+祟	seoi
 稅	seoi
-税	seoi	1000
+税	seoi
 稰	seoi
-穗	seoi	1000
+穗	seoi
 穟	seoi
 篲	seoi
 篲	wai
-粹	seoi	1000
+粹	seoi
 糈	seoi
-絮	seoi	1000
-綏	seoi	500
-緒	seoi	1000
+絮	seoi
+綏	seoi
+緒	seoi
 緰	seoi
 緰	syu
 繀	seoi
@@ -19056,13 +19057,13 @@ min_phrase_weight: 100
 繻	seoi
 绥	seoi
 绪	seoi
-胥	seoi	500
+胥	seoi
 脽	seoi
 脽	zeoi
 膵	seoi
 荽	seoi
 荾	seoi
-萃	seoi	500
+萃	seoi
 葰	seoi
 葰	zeon
 蔧	seoi
@@ -19070,31 +19071,31 @@ min_phrase_weight: 100
 虽	seoi
 蛻	seoi
 蛻	teoi
-蜕	seoi	500
-蜕	teoi	500
+蜕	seoi
+蜕	teoi
 蝑	seoi
 裞	seoi
 襚	seoi
-誰	seoi	1000
+誰	seoi
 誶	seoi
 諝	seoi
 谁	seoi
 谇	seoi
 谞	seoi
 賥	seoi
-遂	seoi	1000
+遂	seoi
 邃	seoi
 醑	seoi
 鐆	seoi
 鐩	seoi
 鑐	seoi
-陲	seoi	1000
-隧	seoi	1000
-雖	seoi	1000
-需	seoi	1000
-須	seoi	1000
+陲	seoi
+隧	seoi
+雖	seoi
+需	seoi
+須	seoi
 须	seoi
-髓	seoi	1000
+髓	seoi
 𡑞	seoi
 𡻕	seoi
 㐰	seon
@@ -19132,22 +19133,22 @@ min_phrase_weight: 100
 䭀	seon
 䴄	seon
 侚	seon
-信	seon	1000
+信	seon
 唇	seon
 噀	seon
 囟	seon
 峋	seon
-巽	seon	500
-徇	seon	500
+巽	seon
+徇	seon
 恂	seon
 愻	seon
 楯	seon
 楯	teon
 榫	seon
-殉	seon	1000
+殉	seon
 汛	seon
 洵	seon
-淳	seon	500
+淳	seon
 湻	seon
 漘	seon
 潠	seon
@@ -19156,37 +19157,37 @@ min_phrase_weight: 100
 犉	seon
 狥	seon
 珣	seon
-皴	seon	500
+皴	seon
 盾	seon	0%
-盾	teon	1000
+盾	teon
 瞚	seon
-瞬	seon	1000
+瞬	seon
 笋	seon
-筍	seon	500
+筍	seon
 簨	seon
-純	seon	1000
+純	seon
 純	zeon	0%
 纯	seon
-脣	seon	1000
+脣	seon
 膞	seon
 膞	zyun
-舜	seon	1000
-荀	seon	500
+舜	seon
+荀	seon
 莼	seon
 蓴	seon
 蕣	seon
-訊	seon	1000
-詢	seon	1000
+訊	seon
+詢	seon
 讯	seon
 询	seon
-迅	seon	1000
+迅	seon
 迿	seon
 逊	seon
 逡	seon
-遜	seon	1000
+遜	seon
 郇	seon
-醇	seon	1000
-順	seon	1000
+醇	seon
+順	seon
 顺	seon
 鶉	seon	0%
 鹑	seon
@@ -19198,20 +19199,20 @@ min_phrase_weight: 100
 䆝	seot
 䘏	seot
 䢦	seot
-卹	seot	500
-恤	seot	1000
-戌	seot	1000
-朮	seot	500
+卹	seot
+恤	seot
+戌	seot
+朮	seot
 术	seot
 沭	seot
 秫	seot
 窣	seot
-蟀	seot	1000
-術	seot	1000
+蟀	seot
+術	seot
 裇	seot
 訹	seot
 訹	zeot
-述	seot	1000
+述	seot
 鉥	seot
 𣘚	seot
 㒋	si
@@ -19250,9 +19251,9 @@ min_phrase_weight: 100
 䲩	si
 䴓	si
 丝	si
-事	si	1000
-仕	si	500
-侍	si	1000
+事	si
+仕	si
+侍	si
 俬	si
 倳	si
 倳	zi
@@ -19263,45 +19264,45 @@ min_phrase_weight: 100
 剚	si
 剚	zi
 厮	si
-史	si	1000
-司	si	1000
-嗜	si	1000
+史	si
+司	si
+嗜	si
 埘	si
 塒	si
-士	si	1000
-尸	si	500
-屍	si	1000
-市	si	1000
+士	si
+尸	si
+屍	si
+市	si
 师	si
-師	si	1000
-廝	si	500
+師	si
+廝	si
 弑	si
-弒	si	500
-思	si	1000
+弒	si
+思	si
 思	soi	0%
 戺	si
-撕	si	1000
-斯	si	1000
+撕	si
+斯	si
 时	si
 旹	si
-是	si	1000
-時	si	1000
+是	si
+時	si
 柶	si
 榯	si
-氏	si	1000
+氏	si
 氏	zi	0%
-泗	si	500
+泗	si
 溮	si
 澌	si
 狮	si
-獅	si	1000
-示	si	1000
+獅	si
+示	si
 禗	si
 禠	si
-私	si	1000
+私	si
 糹	si
 絁	si
-絲	si	1000
+絲	si
 緦	si
 纟	si
 缌	si
@@ -19318,17 +19319,17 @@ min_phrase_weight: 100
 褆	si
 褷	si
 襹	si
-視	si	1000
+視	si
 视	si
-試	si	1000
-詩	si	1000
+試	si
+詩	si
 諟	si
 諡	si
 謚	si
 试	si
 诗	si
 谥	si
-豉	si	1000
+豉	si
 跱	si
 跱	zi
 邿	si
@@ -19341,13 +19342,13 @@ min_phrase_weight: 100
 锶	si
 颸	si
 飔	si
-駟	si	500
+駟	si
 驷	si
 鰣	si
 鰤	si
 鲥	si
 鳲	si
-鷥	si	500
+鷥	si
 鸤	si
 鸶	si
 鼶	si
@@ -19373,58 +19374,58 @@ min_phrase_weight: 100
 䵱	sik
 僁	sik
 啬	sik
-嗇	sik	1000
+嗇	sik
 奭	sik
-媳	sik	1000
-式	sik	1000
-息	sik	1000
-悉	sik	1000
-拭	sik	500
-昔	sik	1000
+媳	sik
+式	sik
+息	sik
+悉	sik
+拭	sik
+昔	sik
 晢	sik
 晢	zai
-晰	sik	1000
+晰	sik
 晹	sik
-淅	sik	500
-熄	sik	1000
+淅	sik
+熄	sik
 瘜	sik
 皙	sik
 穑	sik
-穡	sik	500
+穡	sik
 窸	sik
 緆	sik
 舄	sik
-色	sik	1000
+色	sik
 菥	sik
 蒠	sik
 蕮	sik
 蚀	sik
-蜥	sik	1000
-蝕	sik	1000
-蝕	sit	501
+蜥	sik
+蝕	sik
+蝕	sit
 螅	sik
-蟋	sik	1000
+蟋	sik
 衋	sik
 裼	sik
 裼	tik
 襫	sik
-識	sik	1000
-識	zi	1000
+識	sik
+識	zi
 识	sik
-軾	sik	500
+軾	sik
 轖	sik
 轼	sik
 鄎	sik
 释	sik
-釋	sik	1000
+釋	sik
 銫	sik
 鎴	sik
 铯	sik
-飾	sik	1000
+飾	sik
 餙	sik
 饰	sik
-骰	sik	500
-骰	tau	500
+骰	sik
+骰	tau
 㚒	sim
 㚒	sin
 㚲	sim
@@ -19440,31 +19441,31 @@ min_phrase_weight: 100
 䪜	zim
 婵	sim
 婵	sin
-嬋	sim	500
-嬋	sin	500
+嬋	sim
+嬋	sin
 掞	sim
 晱	sim
 煔	sim
 睒	sim
 禅	sim
 禅	sin
-禪	sim	500
-禪	sin	500
+禪	sim
+禪	sin
 笘	sim
 苫	sim
 蝉	sim
 蝉	sin
-蟬	sim	1000
+蟬	sim
 蟬	sin	0%
 蟾	sim
 裧	sim
-贍	sim	500
-贍	sin	500
+贍	sim
+贍	sin
 赡	sim
-閃	sim	1000
+閃	sim
 闪	sim
 陕	sim
-陝	sim	1000
+陝	sim
 鿃	sim
 㒨	sin
 㧥	sin
@@ -19489,33 +19490,33 @@ min_phrase_weight: 100
 䫪	song
 䱇	sin
 䱉	sin
-仙	sin	1000
-倩	sin	500
+仙	sin
+倩	sin
 僊	sin
-先	sin	1000
+先	sin
 冼	sin
-善	sin	1000
+善	sin
 墠	sin
 墡	sin
 姺	sin
 嬗	sin
 尟	sin
 廯	sin
-扇	sin	1000
+扇	sin
 搧	sin
-擅	sin	1000
+擅	sin
 樿	sin
 樿	zin
 毨	sin
 潬	sin
 潬	taan
 澶	sin
-煽	sin	500
+煽	sin
 燹	sin
 狝	sin
 獮	sin
 癣	sin
-癬	sin	500
+癬	sin
 硟	sin
 秈	sin
 筅	sin
@@ -19523,17 +19524,17 @@ min_phrase_weight: 100
 綪	sin
 綪	zang
 綫	sin
-線	sin	1000
-繕	sin	500
+線	sin
+繕	sin
 线	sin
 缮	sin
 羡	sin
-羨	sin	1000
-腺	sin	500
-膳	sin	1000
+羨	sin
+腺	sin
+膳	sin
 蒨	sin
 藓	sin
-蘚	sin	500
+蘚	sin
 蟮	sin
 蟺	sin
 褼	sin
@@ -19551,9 +19552,9 @@ min_phrase_weight: 100
 饍	sin
 騸	sin
 骟	sin
-鮮	sin	1000
+鮮	sin
 鱓	sin
-鱔	sin	500
+鱔	sin
 鲜	sin
 鳝	sin
 𠜎	sin
@@ -19575,34 +19576,34 @@ min_phrase_weight: 100
 䮪	zaang
 䱆	sing
 䳙	sing
-丞	sing	500
-乘	sing	1000
-剩	sing	1000
-剩	zing	501
-勝	sing	1000
-升	sing	1000
+丞	sing
+乘	sing
+剩	sing
+剩	zing
+勝	sing
+升	sing
 呏	sing
 圣	sing
 堘	sing
 塍	sing
 宬	sing
 嵊	sing
-性	sing	1000
-惺	sing	500
-承	sing	1000
-旌	sing	500
-旌	zing	500
-昇	sing	500
+性	sing
+惺	sing
+承	sing
+旌	sing
+旌	zing
+昇	sing
 晟	sing
 煋	sing
-猩	sing	500
+猩	sing
 瑆	sing
-盛	sing	1000
+盛	sing
 箵	sing
-繩	sing	1000
+繩	sing
 绳	sing
-聖	sing	1000
-誠	sing	1000
+聖	sing
+誠	sing
 诚	sing
 賸	sing
 郕	sing
@@ -19621,11 +19622,11 @@ min_phrase_weight: 100
 懾	sip
 懾	zip
 摄	sip
-涉	sip	1000
+涉	sip
 滠	sip
 灄	sip
-燮	sip	500
-燮	sit	500
+燮	sip
+燮	sit
 躞	sip
 躞	sit
 韘	sip
@@ -19645,21 +19646,21 @@ min_phrase_weight: 100
 伳	sit
 偰	sit
 媟	sit
-屑	sit	1000
+屑	sit
 屧	sit
-楔	sit	500
+楔	sit
 榍	sit
 渫	sit
 疶	sit
 窃	sit
-竊	sit	1000
+竊	sit
 紲	sit
 絏	sit
 緤	sit
 绁	sit
-舌	sit	1000
-薛	sit	500
-褻	sit	500
+舌	sit
+薛	sit
+褻	sit
 躠	sit
 靾	sit
 𧵳	sit
@@ -19689,59 +19690,59 @@ min_phrase_weight: 100
 䰑	siu
 䰑	sou
 䴛	siu
-兆	siu	1000
+兆	siu
 兆	ziu	0%
 劭	siu
 卲	siu
 召	siu	0%
-召	ziu	1000
+召	ziu
 啸	siu
-嘯	siu	1000
-宵	siu	1000
-小	siu	1000
-少	siu	1000
+嘯	siu
+宵	siu
+小	siu
+少	siu
 揱	siu
 揱	sok
 旐	siu
 旐	ziu
 櫹	siu
-消	siu	1000
+消	siu
 潇	siu
 潚	siu
-瀟	siu	1000
+瀟	siu
 烧	siu
-燒	siu	1000
+燒	siu
 痟	siu
-硝	siu	500
-笑	siu	1000
+硝	siu
+笑	siu
 筱	siu
 箫	siu
 箾	siu
 箾	sok
 篠	siu
-簫	siu	500
-紹	siu	1000
+簫	siu
+紹	siu
 綃	siu
 绍	siu
 绡	siu
 翛	siu
-肇	siu	500
+肇	siu
 肈	siu
 萧	siu
 萷	siu
 萷	sok
-蕭	siu	1000
+蕭	siu
 蟏	siu
 蠨	siu
 袑	siu
-迢	siu	500
-迢	tiu	500
-逍	siu	1000
-邵	siu	500
-銷	siu	1000
+迢	siu
+迢	tiu
+逍	siu
+邵	siu
+銷	siu
 销	siu
-霄	siu	1000
-韶	siu	500
+霄	siu
+韶	siu
 魈	siu
 鮡	siu
 㛖	so
@@ -19760,41 +19761,41 @@ min_phrase_weight: 100
 䟽	so
 䤬	so
 䵀	so
-傻	so	1000
+傻	so
 儍	so
-唆	so	500
+唆	so
 唢	so
-嗦	so	500
+嗦	so
 嗩	so
-娑	so	500
+娑	so
 惢	so
-所	so	1000
+所	so
 挱	so
 挲	so
 桫	so
-梭	so	1000
-梳	so	1000
+梭	so
+梳	so
 琐	so
-瑣	so	1000
+瑣	so
 璅	so
 璅	zou
 疎	so
-疏	so	1000
+疏	so
 簑	so
 綀	so
 羧	so
-蓑	so	1000
-蔬	so	1000
+蓑	so
+蔬	so
 趖	so
-鎖	so	1000
+鎖	so
 鏁	so
 锁	so
 𠿬	soe
 𡄽	soe
 䁻	soek
-削	soek	1000
+削	soek
 烁	soek
-鑠	soek	500
+鑠	soek
 铄	soek
 𠸑	soek
 㐮	soeng
@@ -19809,57 +19810,57 @@ min_phrase_weight: 100
 䵮	zoeng
 䵰	soeng
 䵼	soeng
-上	soeng	1000
+上	soeng
 伤	soeng
 倘	soeng	0%
-倘	tong	1000
+倘	tong
 偿	soeng
-傷	soeng	1000
+傷	soeng
 厢	soeng
 双	soeng
-商	soeng	1000
-嘗	soeng	1000
+商	soeng
+嘗	soeng
 嚐	soeng
 墑	soeng
-嫦	soeng	1000
-孀	soeng	500
-孀	sung	500
-尚	soeng	1000
+嫦	soeng
+孀	soeng
+孀	sung
+尚	soeng
 尝	soeng
-常	soeng	1000
-廂	soeng	1000
+常	soeng
+廂	soeng
 徜	soeng
 忀	soeng
-想	soeng	1000
+想	soeng
 欀	soeng
 殇	soeng
-殤	soeng	500
-湘	soeng	500
+殤	soeng
+湘	soeng
 湯	soeng	0%
-湯	tong	1000
+湯	tong
 熵	soeng
 瓖	soeng
 甞	soeng
-相	soeng	1000
+相	soeng
 礵	soeng
-箱	soeng	1000
+箱	soeng
 緗	soeng
 纕	soeng
 缃	soeng
 艭	soeng
 葙	soeng
 蔏	soeng
-裳	soeng	1000
-襄	soeng	500
+裳	soeng
+襄	soeng
 觞	soeng
-觴	soeng	500
+觴	soeng
 謪	soeng
-賞	soeng	1000
+賞	soeng
 赏	soeng
-鑲	soeng	1000
+鑲	soeng
 镶	soeng
-雙	soeng	1000
-霜	soeng	1000
+雙	soeng
+霜	soeng
 鞝	soeng
 鞝	zoeng
 驤	soeng
@@ -19878,21 +19879,21 @@ min_phrase_weight: 100
 愢	soi
 毢	soi
 毸	soi
-腮	soi	500
+腮	soi
 顋	soi
-鰓	soi	1000
+鰓	soi
 鳃	soi
 㮦	sok
 䂹	sok
 䅴	sok
 䞽	sok
 嗍	sok
-塑	sok	200
-塑	sou	1000
+塑	sok
+塑	sou
 搠	sok
 數	sok
 數	sou
-朔	sok	1000
+朔	sok
 槊	sok
 欶	sok
 溹	sok
@@ -19907,12 +19908,12 @@ min_phrase_weight: 100
 䫙	song
 䮣	song
 丧	song
-喪	song	1000
-嗓	song	1000
+喪	song
+嗓	song
 塽	song
 搡	song
-桑	song	1000
-爽	song	1000
+桑	song
+爽	song
 磉	song
 顙	song
 颡	song
@@ -19936,37 +19937,37 @@ min_phrase_weight: 100
 䲆	sou
 傃	sou
 嗉	sou
-囌	sou	500
+囌	sou
 埽	sou
 塐	sou
-嫂	sou	1000
+嫂	sou
 愫	sou
 愬	sou
 扫	sou
-掃	sou	1000
-搔	sou	500
+掃	sou
+搔	sou
 数	sou
 泝	sou
-溯	sou	1000
-甦	sou	1000
+溯	sou
+甦	sou
 瘙	sou
 稣	sou
-穌	sou	500
-素	sou	1000
-繅	sou	500
+穌	sou
+素	sou
+繅	sou
 缫	sou
 膆	sou
 臊	sou
 苏	sou
-蘇	sou	1000
-訴	sou	1000
+蘇	sou
+訴	sou
 诉	sou
 遡	sou
-酥	sou	500
+酥	sou
 颾	sou
-騷	sou	1000
+騷	sou
 骚	sou
-鬚	sou	1000
+鬚	sou
 㑐	suk
 㒔	suk
 㓘	suk
@@ -19993,35 +19994,35 @@ min_phrase_weight: 100
 䨹	suk
 䱙	suk
 䴰	suk
-倏	suk	500
+倏	suk
 倐	suk
 僳	suk
 儵	suk
-叔	suk	1000
-塾	suk	500
-夙	suk	500
-妯	suk	500
-妯	zuk	500
-孰	suk	1000
+叔	suk
+塾	suk
+夙	suk
+妯	suk
+妯	zuk
+孰	suk
 属	suk
 属	zuk
-屬	suk	1000
+屬	suk
 屬	zuk	0%
 橚	suk
-淑	suk	500
+淑	suk
 焂	suk
-熟	suk	1000
-粟	suk	1000
-縮	suk	1000
+熟	suk
+粟	suk
+縮	suk
 缩	suk
 肃	suk
-肅	suk	1000
-菽	suk	500
+肅	suk
+菽	suk
 蓿	suk
-蜀	suk	500
+蜀	suk
 謖	suk
 谡	suk
-贖	suk	1000
+贖	suk
 赎	suk
 蹜	suk
 钃	suk
@@ -20051,25 +20052,25 @@ min_phrase_weight: 100
 䯷	sung
 傱	sung
 娀	sung
-宋	sung	1000
-崇	sung	1000
+宋	sung
+崇	sung
 崧	sung
-嵩	sung	1000
+嵩	sung
 嵷	sung
 忪	sung
 忪	zung
 怂	sung
-悚	sung	500
-慫	sung	500
+悚	sung
+慫	sung
 摏	sung
-淞	sung	500
+淞	sung
 竦	sung
 耸	sung
-聳	sung	1000
+聳	sung
 菘	sung
-送	sung	1000
+送	sung
 駷	sung
-鬆	sung	1000
+鬆	sung
 𢥠	sung
 㓱	syu
 㛸	syu
@@ -20095,22 +20096,22 @@ min_phrase_weight: 100
 姝	syu
 姝	zyu
 尌	syu
-庶	syu	500
-恕	syu	1000
-戍	syu	1000
-抒	syu	1000
+庶	syu
+恕	syu
+戍	syu
+抒	syu
 摅	syu
 摴	syu
 攄	syu
-暑	syu	1000
-書	syu	1000
+暑	syu
+書	syu
 杸	syu
 枢	syu
 树	syu
 樗	syu
-樞	syu	1000
-樹	syu	1000
-殊	syu	1000
+樞	syu
+樹	syu
+殊	syu
 殳	syu
 洙	syu
 洙	zyu
@@ -20121,20 +20122,20 @@ min_phrase_weight: 100
 紓	syu
 纾	syu
 腧	syu
-舒	syu	1000
-薯	syu	1000
+舒	syu
+薯	syu
 藷	syu
 裋	syu
-豎	syu	1000
+豎	syu
 趎	syu
 趎	zyu
-輸	syu	1000
+輸	syu
 输	syu
 鄃	syu
-銖	syu	500
-銖	zyu	500
-黍	syu	500
-鼠	syu	1000
+銖	syu
+銖	zyu
+黍	syu
+鼠	syu
 㔯	syun
 㔵	syun
 㔵	wan
@@ -20158,23 +20159,23 @@ min_phrase_weight: 100
 僎	syun
 僎	zaan
 匴	syun
-吮	syun	500
+吮	syun
 孙	syun
-孫	syun	1000
-宣	syun	1000
+孫	syun
+宣	syun
 悛	syun
 损	syun
 揎	syun
-損	syun	1000
+損	syun
 搎	syun
-撰	syun	500
-撰	zaan	500
-旋	syun	1000
+撰	syun
+撰	zaan
+旋	syun
 朘	syun
 朘	zeoi
 朘	zeon
 槂	syun
-漩	syun	500
+漩	syun
 狲	syun
 狻	syun
 猻	syun
@@ -20185,20 +20186,20 @@ min_phrase_weight: 100
 璿	syun
 痠	syun
 筭	syun
-算	syun	1000
-篆	syun	1000
+算	syun
+篆	syun
 篹	syun
 篹	zaan
 腞	syun
-船	syun	1000
+船	syun
 荪	syun
-蒜	syun	500
-蓀	syun	500
+蒜	syun
+蓀	syun
 选	syun
-選	syun	1000
+選	syun
 還	syun	0%
-還	waan	1000
-酸	syun	1000
+還	waan
+酸	syun
 鏇	syun
 鐫	syun
 鐫	zeon
@@ -20206,27 +20207,27 @@ min_phrase_weight: 100
 镟	syun
 隽	syun
 隽	zeon
-雋	syun	500
-雋	zeon	500
-飧	syun	1000
+雋	syun
+雋	zeon
+飧	syun
 㡜	syut
 㥜	syut
 㥜	waai
 䨮	syut
-説	syut	1000
+説	syut
 说	syut
-雪	syut	1000
+雪	syut
 鱈	syut
 鳕	syut
 𠽌	syut
-他	taa	1000
+他	taa
 他	to	0%
 佗	taa	0%
-佗	to	1000
-它	taa	1000
+佗	to
+它	taa
 它	to	0%
 怹	taa
-牠	taa	1000
+牠	taa
 牠	to	0%
 祂	taa
 鉈	taa
@@ -20253,17 +20254,17 @@ min_phrase_weight: 100
 䧑	taai
 䴘	taai
 䶏	taai
-太	taai	1000
+太	taai
 忕	taai
 态	taai
-態	taai	1000
+態	taai
 殢	taai
 殢	tai
-汰	taai	1000
-泰	taai	1000
+汰	taai
+泰	taai
 舦	taai
 艜	taai
-貸	taai	1000
+貸	taai
 貸	tik	0%
 贷	taai
 鈦	taai
@@ -20280,26 +20281,26 @@ min_phrase_weight: 100
 墰	taam
 惔	taam
 憛	taam
-探	taam	1000
+探	taam
 撢	taam
 昙	taam
 曇	taam
 橝	taam
-毯	taam	1000
-毯	taan	1000
-潭	taam	1000
-痰	taam	1000
+毯	taam
+毯	taan
+潭	taam
+痰	taam
 緂	taam
-罈	taam	500
+罈	taam
 菼	taam
 藫	taam
 蟫	taam
-覃	taam	500
-談	taam	1000
-譚	taam	500
+覃	taam
+談	taam
+譚	taam
 谈	taam
 谭	taam
-貪	taam	1000
+貪	taam
 贉	taam
 贪	taam
 郯	taam
@@ -20322,24 +20323,24 @@ min_phrase_weight: 100
 叹	taan
 啴	taan
 嘆	taan
-坍	taan	500
+坍	taan
 坛	taan
-坦	taan	1000
-壇	taan	1000
+坦	taan
+壇	taan
 忐	taan
 摊	taan
-攤	taan	1000
+攤	taan
 枟	taan
-檀	taan	1000
-歎	taan	1000
+檀	taan
+歎	taan
 滩	taan
-灘	taan	1000
-炭	taan	1000
+灘	taan
+炭	taan
 疸	taan
 瘫	taan
-癱	taan	1000
-碳	taan	1000
-袒	taan	500
+癱	taan
+碳	taan
+袒	taan
 襢	taan
 贃	taan
 贃	zaam
@@ -20350,13 +20351,13 @@ min_phrase_weight: 100
 㙮	taap
 㯓	taap
 䌈	taap
-塌	taap	1000
-塔	taap	1000
-拓	taap	1000
-拓	tok	1000
+塌	taap
+塔	taap
+拓	taap
+拓	tok
 拓	zek	0%
 搨	taap
-榻	taap	500
+榻	taap
 毾	taap
 涾	taap
 褟	taap
@@ -20380,7 +20381,7 @@ min_phrase_weight: 100
 闥	taat
 闼	taat
 鞑	taat
-韃	taat	500
+韃	taat
 㪗	taau
 㪗	tau
 䞬	taau
@@ -20398,17 +20399,17 @@ min_phrase_weight: 100
 䶍	tai
 䶑	tai
 偍	tai
-剃	tai	1000
-啼	tai	1000
+剃	tai
+啼	tai
 嗁	tai
-嚏	tai	1000
-堤	tai	1000
+嚏	tai
+堤	tai
 媞	tai
 屉	tai
-屜	tai	1000
-替	tai	1000
-梯	tai	1000
-涕	tai	1000
+屜	tai
+替	tai
+梯	tai
+涕	tai
 禔	tai
 稊	tai
 綈	tai
@@ -20418,16 +20419,16 @@ min_phrase_weight: 100
 蕛	tai
 薙	tai
 謕	tai
-蹄	tai	1000
+蹄	tai
 蹏	tai
 醍	tai
-銻	tai	500
+銻	tai
 锑	tai
 隄	tai
-題	tai	1000
+題	tai
 题	tai
 騠	tai
-體	tai	1000
+體	tai
 鬀	tai
 鬄	tai
 鯷	tai
@@ -20456,32 +20457,32 @@ min_phrase_weight: 100
 㳩	tan
 䞡	tan
 䵍	tan
-吞	tan	1000
+吞	tan
 揗	tan
 揗	tang
 暾	tan
 氽	tan
 涒	tan
 涒	wan
-褪	tan	500
+褪	tan
 蹆	tan
-飩	tan	500
+飩	tan
 饨	tan
 䕨	tang
 䲍	tang
 䲢	tang
 滕	tang
-疼	tang	1000
+疼	tang
 疼	tung	0%
 籐	tang
 縢	tang
 腾	tang
-藤	tang	1000
+藤	tang
 誊	tang
-謄	tang	500
+謄	tang
 邆	tang
 駦	tang
-騰	tang	1000
+騰	tang
 䪚	tap
 佮	tap
 𠸊	tap
@@ -20490,25 +20491,25 @@ min_phrase_weight: 100
 䟝	tau
 䵉	tau
 亠	tau
-偷	tau	1000
+偷	tau
 偸	tau
 头	tau
 妵	tau
 媮	tau
-投	tau	1000
+投	tau
 敨	tau
-透	tau	1000
-頭	tau	1000
+透	tau
+頭	tau
 黈	tau
 𧿫	tau
-踢	tek	1000
+踢	tek
 㕔	teng
 㕔	ting
 厅	teng
-廳	teng	1000
-聽	teng	501
-聽	ting	1000
-艇	teng	1000
+廳	teng
+聽	teng
+聽	ting
+艇	teng
 艇	ting	0%
 㞂	teoi
 㞜	teoi
@@ -20532,12 +20533,12 @@ min_phrase_weight: 100
 僓	teoi
 墤	teoi
 穨	teoi
-腿	teoi	1000
+腿	teoi
 蓷	teoi
 藬	teoi
-退	teoi	1000
+退	teoi
 隤	teoi
-頹	teoi	1000
+頹	teoi
 颓	teoi
 魋	teoi
 䥴	teon
@@ -20550,7 +20551,7 @@ min_phrase_weight: 100
 啍	teon
 啍	zeon
 彖	teon
-湍	teon	500
+湍	teon
 芚	teon
 芚	tyun
 褖	teon
@@ -20564,17 +20565,17 @@ min_phrase_weight: 100
 䢰	tik
 䯜	tik
 倜	tik
-剔	tik	1000
+剔	tik
 忑	tik
 忒	tik
 悐	tik
-惕	tik	1000
+惕	tik
 惖	tik
 擿	tik
 擿	zek
 貣	tik
 趯	tik
-逖	tik	500
+逖	tik
 鋱	tik
 铽	tik
 㐁	tim
@@ -20588,14 +20589,14 @@ min_phrase_weight: 100
 㶺	tim
 䄼	tim
 䣶	tim
-忝	tim	500
-恬	tim	500
+忝	tim
+恬	tim
 掭	tim
-添	tim	1000
+添	tim
 湉	tim
-甜	tim	1000
+甜	tim
 簟	tim
-舔	tim	1000
+舔	tim
 菾	tim
 餂	tim
 㥏	tin
@@ -20613,21 +20614,21 @@ min_phrase_weight: 100
 䧃	tin
 䩄	tin
 塡	tin
-填	tin	1000
-天	tin	1000
+填	tin
+天	tin
 搷	tin
 沺	tin
 淟	tin
 瑱	tin
 瑱	zan
-田	tin	1000
+田	tin
 畋	tin
 磌	tin
 窴	tin
 窴	zi
-腆	tin	500
+腆	tin
 覥	tin
-闐	tin	500
+闐	tin
 阗	tin
 𧰊	tin
 㹶	ting
@@ -20639,15 +20640,15 @@ min_phrase_weight: 100
 䩠	ting
 䯕	ting
 䱓	ting
-亭	ting	1000
+亭	ting
 侹	ting
-停	ting	1000
-婷	ting	500
-庭	ting	1000
-廷	ting	1000
-挺	ting	1000
+停	ting
+婷	ting
+庭	ting
+廷	ting
+挺	ting
 桯	ting
-梃	ting	500
+梃	ting
 楟	ting
 渟	ting
 烃	ting
@@ -20658,10 +20659,10 @@ min_phrase_weight: 100
 脡	ting
 莛	ting
 葶	ting
-蜓	ting	1000
+蜓	ting
 鋌	ting
 铤	ting
-霆	ting	1000
+霆	ting
 頲	ting
 颋	ting
 鼮	ting
@@ -20669,13 +20670,13 @@ min_phrase_weight: 100
 䥌	tip
 䥌	zing
 䴴	tip
-帖	tip	1000
+帖	tip
 怗	tip
-貼	tip	1000
+貼	tip
 贴	tip
 鉄	tit
 銕	tit
-鐵	tit	1000
+鐵	tit
 铁	tit
 餮	tit
 驖	tit
@@ -20689,17 +20690,17 @@ min_phrase_weight: 100
 䩦	tiu
 䯾	tiu
 䱔	tiu
-佻	tiu	500
+佻	tiu
 嬥	tiu
 岧	tiu
 庣	tiu
 恌	tiu
-挑	tiu	1000
+挑	tiu
 挑	tou	0%
 朓	tiu
 条	tiu
-條	tiu	1000
-眺	tiu	1000
+條	tiu
+眺	tiu
 祧	tiu
 窱	tiu
 笤	tiu
@@ -20712,7 +20713,7 @@ min_phrase_weight: 100
 蜩	tiu
 覜	tiu
 趒	tiu
-跳	tiu	1000
+跳	tiu
 鞗	tiu
 髫	tiu
 鰷	tiu
@@ -20733,38 +20734,38 @@ min_phrase_weight: 100
 䲁	to
 䲁	waai
 䲊	to
-唾	to	1000
-唾	toe	1000
+唾	to
+唾	toe
 唾	tou	0%
 坨	to
 堶	to
-妥	to	1000
+妥	to
 嫷	to
 拕	to
-拖	to	1000
+拖	to
 柁	to
 梼	to
 椭	to
-橢	to	1000
+橢	to
 毻	to
-沱	to	500
+沱	to
 沲	to
 砣	to
 紽	to
-舵	to	1000
+舵	to
 詑	to
-跎	to	1000
+跎	to
 酡	to
-陀	to	500
-馱	to	1000
-駝	to	1000
+陀	to
+馱	to
+駝	to
 驒	to
 驮	to
 驼	to
 鮀	to
 鳚	to
 鳚	waai
-鴕	to	500
+鴕	to
 鸵	to
 鼉	to
 鼍	to
@@ -20778,20 +20779,20 @@ min_phrase_weight: 100
 䈚	toi
 䑓	toi
 儓	toi
-抬	toi	1000
+抬	toi
 擡	toi
-枱	toi	1000
+枱	toi
 檯	toi
 炱	toi
 籉	toi
-胎	toi	1000
+胎	toi
 臺	toi
-苔	toi	1000
+苔	toi
 薹	toi
-跆	toi	500
+跆	toi
 邰	toi
 鈶	toi
-颱	toi	1000
+颱	toi
 駘	toi
 骀	toi
 鮐	toi
@@ -20803,7 +20804,7 @@ min_phrase_weight: 100
 乇	zaak
 侂	tok
 庹	tok
-托	tok	1000
+托	tok
 柝	tok
 槖	tok
 橐	tok
@@ -20811,7 +20812,7 @@ min_phrase_weight: 100
 箨	tok
 籜	tok
 蘀	tok
-託	tok	1000
+託	tok
 讬	tok
 跅	tok
 飥	tok
@@ -20841,41 +20842,41 @@ min_phrase_weight: 100
 䣘	tong
 傥	tong
 儻	tong
-唐	tong	1000
-堂	tong	1000
-塘	tong	1000
+唐	tong
+堂	tong
+塘	tong
 捅	tong
 捅	tung
-搪	tong	500
+搪	tong
 摚	tong
 曭	tong
-棠	tong	500
+棠	tong
 樘	tong
 汤	tong
-淌	tong	1000
+淌	tong
 溏	tong
 烫	tong
 煻	tong
-熨	tong	500
-熨	wai	500
-熨	wan	500
-熨	wat	500
-燙	tong	1000
+熨	tong
+熨	wai
+熨	wan
+熨	wat
+燙	tong
 爣	tong
 瑭	tong
 矘	tong
-糖	tong	1000
+糖	tong
 羰	tong
-膛	tong	500
+膛	tong
 螗	tong
-螳	tong	500
+螳	tong
 赯	tong
-趟	tong	1000
+趟	tong
 蹚	tong
-躺	tong	1000
-醣	tong	500
+躺	tong
+醣	tong
 鎲	tong
-鏜	tong	500
+鏜	tong
 鐋	tong
 铴	tong
 镗	tong
@@ -20911,33 +20912,33 @@ min_phrase_weight: 100
 䮻	tou
 䳜	tou
 兎	tou
-兔	tou	1000
+兔	tou
 匋	tou
-吐	tou	1000
+吐	tou
 咷	tou
-啕	tou	500
+啕	tou
 图	tou
-圖	tou	1000
-土	tou	1000
+圖	tou
+土	tou
 堍	tou
-塗	tou	1000
-套	tou	1000
-屠	tou	1000
+塗	tou
+套	tou
+屠	tou
 廜	tou
 弢	tou
-徒	tou	1000
+徒	tou
 悇	tou
 慆	tou
-掏	tou	1000
+掏	tou
 搯	tou
-桃	tou	1000
+桃	tou
 槄	tou
 檮	tou
 涂	tou
 涛	tou
-淘	tou	1000
-滔	tou	1000
-濤	tou	1000
+淘	tou
+滔	tou
+濤	tou
 瘏	tou
 祷	tou
 絛	tou
@@ -20945,22 +20946,22 @@ min_phrase_weight: 100
 縚	tou
 绦	tou
 绹	tou
-肚	tou	1000
-荼	tou	500
+肚	tou
+荼	tou
 菟	tou
-萄	tou	1000
-討	tou	1000
+萄	tou
+討	tou
 謟	tou
 讨	tou
-逃	tou	1000
-途	tou	1000
+逃	tou
+途	tou
 酴	tou
 醄	tou
 釷	tou
 钍	tou
 鞀	tou
 鞉	tou
-韜	tou	500
+韜	tou
 韬	tou
 饕	tou
 駣	tou
@@ -20970,7 +20971,7 @@ min_phrase_weight: 100
 鷋	tou
 鼗	tou
 䛢	tuk
-禿	tuk	1000
+禿	tuk
 秃	tuk
 鵚	tuk
 㛚	tung
@@ -20991,30 +20992,30 @@ min_phrase_weight: 100
 䶱	tung
 仝	tung
 佟	tung
-僮	tung	500
-僮	zung	500
-同	tung	1000
-彤	tung	500
+僮	tung
+僮	zung
+同	tung
+彤	tung
 曈	tung
 朣	tung
-桐	tung	500
-桶	tung	1000
+桐	tung
+桶	tung
 氃	tung
-潼	tung	500
+潼	tung
 烔	tung
 熥	tung
 犝	tung
 獞	tung
 獞	zong
 痌	tung
-痛	tung	1000
-瞳	tung	1000
+痛	tung
+瞳	tung
 穜	tung
 穜	zung
-童	tung	1000
-筒	tung	1000
+童	tung
+筒	tung
 筩	tung
-統	tung	1000
+統	tung
 綂	tung
 统	tung
 膧	tung
@@ -21022,9 +21023,9 @@ min_phrase_weight: 100
 茼	tung
 蓪	tung
 赨	tung
-通	tung	1000
+通	tung
 酮	tung
-銅	tung	1000
+銅	tung
 铜	tung
 鲖	tung
 𧚔	tung
@@ -21034,9 +21035,9 @@ min_phrase_weight: 100
 剸	tyun
 剸	zyun
 团	tyun
-團	tyun	1000
-屯	tyun	500
-屯	zeon	500
+團	tyun
+屯	tyun
+屯	zeon
 庉	tyun
 忳	tyun
 忳	zeon
@@ -21047,9 +21048,9 @@ min_phrase_weight: 100
 篿	tyun
 篿	zyun
 糰	tyun
-臀	tyun	500
+臀	tyun
 豘	tyun
-豚	tyun	1000
+豚	tyun
 軘	tyun
 魨	tyun
 鲀	tyun
@@ -21057,11 +21058,11 @@ min_phrase_weight: 100
 鷻	tyun
 侻	tyut
 脫	tyut
-脱	tyut	1000
+脱	tyut
 莌	tyut
 瓮	ung
 齆	ung
-汙	waa	0
+汙	waa	0%
 汙	wu
 㕦	waa
 㕦	zyu
@@ -21079,40 +21080,40 @@ min_phrase_weight: 100
 䯄	waa
 䵷	waa
 䶤	waa
-划	waa	1000
+划	waa
 剐	waa
 剮	waa
 华	waa
-哇	waa	1000
+哇	waa
 哗	waa
 喎	waa
 喎	wo	1000
-娃	waa	1000
+娃	waa
 崋	waa
 挖	waa	0%
-挖	waat	1000
+挖	waat
 搲	waa
 搲	we
 摦	waa
 桦	waa
 槬	waa
-樺	waa	500
+樺	waa
 洼	waa
 漥	waa
-畫	waa	1000
-畫	waak	1000
+畫	waa
+畫	waak
 窊	waa
 窐	waa
-窪	waa	500
-蛙	waa	1000
+窪	waa
+蛙	waa
 蜗	waa
 蜗	wo
 蝸	waa	0%
-蝸	wo	1000
-話	waa	1000
-譁	waa	500
+蝸	wo
+話	waa
+譁	waa
 话	waa
-踝	waa	500
+踝	waa
 鏵	waa
 铧	waa
 驊	waa
@@ -21151,14 +21152,14 @@ min_phrase_weight: 100
 䵳	waai
 䵳	wui
 䵻	waai
-壞	waai	1000
+壞	waai
 怀	waai
-懷	waai	1000
-槐	waai	500
+懷	waai
+槐	waai
 櫰	waai
-淮	waai	1000
+淮	waai
 獲	waai	0%
-獲	wok	1000
+獲	wok
 蘹	waai
 蘾	waai
 褢	waai
@@ -21171,11 +21172,11 @@ min_phrase_weight: 100
 㩇	waak
 䬉	waak
 䰥	waak
-劃	waak	1000
+劃	waak
 婳	waak
 嫿	waak
-惑	waak	1000
-或	waak	1000
+惑	waak
+或	waak
 湱	waak
 画	waak
 砉	waak
@@ -21208,30 +21209,30 @@ min_phrase_weight: 100
 䰟	waat
 婠	waan
 婠	wun
-宦	waan	1000
+宦	waan
 寰	waan
-幻	waan	1000
+幻	waan
 弯	waan
-彎	waan	1000
-患	waan	1000
-挽	waan	1000
+彎	waan
+患	waan
+挽	waan
 攌	waan
 湾	waan
 漶	waan
 潫	waan
 澴	waan
-灣	waan	1000
-玩	waan	1000
-玩	wun	1000
+灣	waan
+玩	waan
+玩	wun
 环	waan
-環	waan	1000
+環	waan
 綄	waan
-綰	waan	500
+綰	waan
 绾	waan
 缳	waan
-豢	waan	500
+豢	waan
 豩	waan
-輓	waan	500
+輓	waan
 轘	waan
 还	waan
 鍰	waan
@@ -21240,7 +21241,7 @@ min_phrase_weight: 100
 镮	waan
 闤	waan
 阛	waan
-頑	waan	1000
+頑	waan
 鬟	waan
 鯇	waan
 鲩	waan
@@ -21253,7 +21254,7 @@ min_phrase_weight: 100
 䬖	waang
 䬝	waang
 横	waang
-橫	waang	1000
+橫	waang
 軭	waang
 㮧	waat
 㮧	wu
@@ -21271,7 +21272,7 @@ min_phrase_weight: 100
 䬇	waat
 䬇	zyun
 姡	waat
-猾	waat	1000
+猾	waat
 穵	waat
 螖	waat
 㕟	wai
@@ -21302,99 +21303,99 @@ min_phrase_weight: 100
 䴧	wai
 为	wai
 伟	wai
-位	wai	1000
-倭	wai	500
-倭	wo	500
-偉	wai	1000
-卉	wai	1000
+位	wai
+倭	wai
+倭	wo
+偉	wai
+卉	wai
 卫	wai
-唯	wai	1000
-喂	wai	1000
-喟	wai	500
+唯	wai
+喂	wai
+喟	wai
 喴	wai
 喴	wi
 嘒	wai
 囗	wai
 围	wai
-圍	wai	1000
+圍	wai
 壝	wai
-委	wai	1000
-威	wai	1000
+委	wai
+威	wai
 媦	wai
 寪	wai
-尉	wai	500
-尉	wat	500
+尉	wai
+尉	wat
 崣	wai
 崴	wai
 帏	wai
-帷	wai	1000
+帷	wai
 幃	wai
-彙	wai	500
-彙	wui	500
+彙	wai
+彙	wui
 恚	wai
-惟	wai	1000
-惠	wai	1000
-慧	wai	1000
-慰	wai	1000
+惟	wai
+惠	wai
+慧	wai
+慰	wai
 憓	wai
 暐	wai
 橞	wai
-毀	wai	1000
+毀	wai
 毁	wai
 毇	wai
 涠	wai
-渭	wai	1000
+渭	wai
 湋	wai
 潍	wai
 潿	wai
 濰	wai
 炜	wai
-為	wai	1000
+為	wai
 煒	wai
 煟	wai
-燬	wai	500
+燬	wai
 爲	wai
 犚	wai
-猥	wai	500
-猥	wui	500
+猥	wai
+猥	wui
 猬	wai
 獩	wai
 玮	wai
 瑋	wai
-畏	wai	1000
-痿	wai	500
+畏	wai
+痿	wai
 碨	wai
 碨	wui
 秽	wai
-穢	wai	1000
-維	wai	1000
-緯	wai	500
+穢	wai
+維	wai
+緯	wai
 纬	wai
 维	wai
 罻	wai
 罻	wat
 翽	wai
-胃	wai	1000
+胃	wai
 腲	wai
 苇	wai
-萎	wai	1000
-葦	wai	500
+萎	wai
+葦	wai
 葳	wai
 蒍	wai
-蔚	wai	1000
+蔚	wai
 蔚	wat	0%
-蕙	wai	500
+蕙	wai
 薉	wai
 蜼	wai
 蝛	wai
 蝟	wai
 蟪	wai
 衛	wai
-衞	wai	1000
+衞	wai
 褽	wai
-諉	wai	500
-諱	wai	500
-謂	wai	1000
+諉	wai
+諱	wai
+謂	wai
 譓	wai
 譭	wai
 讆	wai
@@ -21404,21 +21405,21 @@ min_phrase_weight: 100
 躗	wai
 违	wai
 逶	wai
-違	wai	1000
+違	wai
 遗	wai
-遺	wai	1000
+遺	wai
 鄬	wai
 鏏	wai
 鏸	wai
-闈	wai	500
+闈	wai
 闱	wai
 霨	wai
-韋	wai	500
+韋	wai
 韙	wai
 韡	wai
 韦	wai
 韪	wai
-餵	wai	1000
+餵	wai
 骫	wai
 𧬨	wai
 䇈	wak
@@ -21449,18 +21450,18 @@ min_phrase_weight: 100
 䮝	wan
 䲰	wan
 䴷	wan
-云	wan	1000
+云	wan
 倱	wan
-允	wan	1000
-勻	wan	1000
+允	wan
+勻	wan
 匀	wan
 呍	wan
 圂	wan
 妘	wan
-尹	wan	500
+尹	wan
 恽	wan
 惲	wan
-愠	wan	1000
+愠	wan
 慁	wan
 慍	wan
 抎	wan
@@ -21471,13 +21472,13 @@ min_phrase_weight: 100
 殒	wan
 殞	wan
 殟	wan
-氲	wan	500
+氲	wan
 氳	wan
 沄	wan
 浑	wan
-混	wan	1000
-温	wan	1000
-渾	wan	1000
+混	wan
+温	wan
+渾	wan
 溫	wan
 溳	wan
 溷	wan
@@ -21486,20 +21487,20 @@ min_phrase_weight: 100
 熅	wan
 狁	wan
 珲	wan
-琿	wan	500
+琿	wan
 畇	wan
-瘟	wan	500
+瘟	wan
 磒	wan
 秐	wan
 稳	wan
-穩	wan	1000
+穩	wan
 筼	wan
 篔	wan
-紜	wan	1000
+紜	wan
 縕	wan
 纭	wan
 缊	wan
-耘	wan	1000
+耘	wan
 芸	wan
 荺	wan
 蕓	wan
@@ -21516,7 +21517,7 @@ min_phrase_weight: 100
 轀	wan
 辒	wan
 运	wan
-運	wan	1000
+運	wan
 郓	wan
 郧	wan
 鄆	wan
@@ -21525,19 +21526,19 @@ min_phrase_weight: 100
 醞	wan
 鋆	wan
 陨	wan
-雲	wan	1000
+雲	wan
 霣	wan
 韗	wan
 韞	wan
 韫	wan
 韵	wan
-韻	wan	1000
+韻	wan
 顐	wan
 顽	wan
-餛	wan	500
+餛	wan
 餫	wan
 馄	wan
-魂	wan	1000
+魂	wan
 鼲	wan
 𨋍	wan
 𨋍	wen
@@ -21552,11 +21553,11 @@ min_phrase_weight: 100
 䩑	wang
 䫺	wang
 吰	wang
-宏	wang	1000
-弘	wang	1000
+宏	wang
+弘	wang
 彋	wang
 汯	wang
-泓	wang	500
+泓	wang
 浤	wang
 竑	wang
 紘	wang
@@ -21575,7 +21576,7 @@ min_phrase_weight: 100
 䴳	wok
 䵥	wat
 嗢	wat
-屈	wat	1000
+屈	wat
 抇	wat
 搰	wat
 欝	wat
@@ -21590,7 +21591,7 @@ min_phrase_weight: 100
 詘	zeot
 诎	wat
 驈	wat
-鬱	wat	1000
+鬱	wat
 鱊	wat
 鴥	wat
 鹬	wat
@@ -21600,7 +21601,7 @@ min_phrase_weight: 100
 㚜	wik
 㽣	wik
 䈅	wik
-域	wik	1000
+域	wik
 棫	wik
 窢	wik
 緎	wik
@@ -21614,16 +21615,16 @@ min_phrase_weight: 100
 㯋	wing
 咏	wing
 嵘	wing
-榮	wing	1000
-永	wing	1000
-泳	wing	1000
+榮	wing
+永	wing
+泳	wing
 潁	wing
 禜	wing
-穎	wing	1000
+穎	wing
 荣	wing
 蝾	wing
 蠑	wing
-詠	wing	1000
+詠	wing
 醟	wing
 颍	wing
 颎	wing
@@ -21636,7 +21637,7 @@ min_phrase_weight: 100
 䒩	wu
 䰀	wo
 咊	wo
-和	wo	1000
+和	wo
 啝	wo
 埚	wo
 堝	wo
@@ -21649,15 +21650,15 @@ min_phrase_weight: 100
 猧	wo
 盉	wo
 祸	wo
-禍	wo	1000
-禾	wo	1000
+禍	wo
+禾	wo
 窝	wo
-窩	wo	1000
+窩	wo
 莴	wo
-萵	wo	500
+萵	wo
 踒	wo
 鉌	wo
-鍋	wo	1000
+鍋	wo
 锅	wo
 龢	wo
 𡁜	wo
@@ -21670,10 +21671,10 @@ min_phrase_weight: 100
 濩	wok
 濩	wu
 瓁	wok
-瓠	wok	500
-瓠	wu	500
+瓠	wok
+瓠	wu
 矱	wok
-穫	wok	1000
+穫	wok
 穫	wu	0%
 臒	wok
 臒	wu
@@ -21699,44 +21700,44 @@ min_phrase_weight: 100
 䰣	wong
 䳨	wong
 偟	wong
-凰	wong	1000
+凰	wong
 喤	wong
 堭	wong
 尢	wong
 尪	wong
-往	wong	1000
+往	wong
 徃	wong
-徨	wong	500
-惶	wong	1000
-旺	wong	1000
-枉	wong	1000
-汪	wong	1000
+徨	wong
+惶	wong
+旺	wong
+枉	wong
+汪	wong
 湟	wong
 潢	wong
 瀇	wong
-煌	wong	1000
+煌	wong
 獚	wong
-王	wong	1000
-璜	wong	500
+王	wong
+璜	wong
 癀	wong
-皇	wong	1000
-磺	wong	500
-篁	wong	500
-簧	wong	500
+皇	wong
+磺	wong
+篁	wong
+簧	wong
 艎	wong
-蝗	wong	1000
+蝗	wong
 蟥	wong
 趪	wong
 迋	wong
-遑	wong	500
+遑	wong
 鍠	wong
 锽	wong
-隍	wong	500
+隍	wong
 餭	wong
 騜	wong
 鰉	wong
 鳇	wong
-黃	wong	1000
+黃	wong
 黄	wong
 𫗮	wong
 㕆	wu
@@ -21765,64 +21766,64 @@ min_phrase_weight: 100
 䭅	wu
 䭌	wu
 乌	wu
-互	wu	1000
+互	wu
 冱	wu
 呜	wu
-嗚	wu	1000
-圬	wu	500
+嗚	wu
+圬	wu
 坞	wu
-塢	wu	500
+塢	wu
 壶	wu
-壺	wu	1000
+壺	wu
 婟	wu
 嫭	wu
 嫮	wu
 岵	wu
-弧	wu	1000
+弧	wu
 怙	wu
 戶	wu
-户	wu	1000
-扈	wu	500
+户	wu
+扈	wu
 护	wu
-捂	wu	500
+捂	wu
 摀	wu
 杇	wu
 枑	wu
 楜	wu
 歍	wu
 汚	wu
-污	wu	1000
+污	wu
 沍	wu
 沪	wu
 洿	wu
 浒	wu
-湖	wu	1000
-滬	wu	500
+湖	wu
+滬	wu
 滸	wu
-烏	wu	1000
-狐	wu	1000
+烏	wu
+狐	wu
 猢	wu
-瑚	wu	1000
+瑚	wu
 祜	wu
-糊	wu	1000
-胡	wu	1000
-芋	wu	500
-葫	wu	1000
-蝴	wu	1000
+糊	wu
+胡	wu
+芋	wu
+葫	wu
+蝴	wu
 衚	wu
-護	wu	1000
+護	wu
 邬	wu
 鄔	wu
 鄠	wu
 醐	wu
 釫	wu
-鎢	wu	500
+鎢	wu
 钨	wu
 隝	wu
 靰	wu
 頀	wu
 餬	wu
-鬍	wu	1000
+鬍	wu
 魱	wu
 鶘	wu
 鶦	wu
@@ -21837,13 +21838,13 @@ min_phrase_weight: 100
 䋿	wui
 会	wui
 佪	wui
-偎	wui	500
-匯	wui	1000
+偎	wui
+匯	wui
 囘	wui
-回	wui	1000
+回	wui
 囬	wui
 廻	wui
-徊	wui	1000
+徊	wui
 恛	wui
 椳	wui
 汇	wui
@@ -21851,15 +21852,15 @@ min_phrase_weight: 100
 渨	wui
 滙	wui
 烩	wui
-煨	wui	500
-燴	wui	500
+煨	wui
+燴	wui
 痐	wui
 硙	wui
-茴	wui	500
+茴	wui
 蚘	wui
-蛔	wui	500
+蛔	wui
 蛕	wui
-迴	wui	1000
+迴	wui
 隈	wui
 㣪	wun
 㬇	wun
@@ -21876,51 +21877,51 @@ min_phrase_weight: 100
 䯘	wun
 䯛	wun
 䴟	wun
-剜	wun	500
+剜	wun
 唤	wun
-垣	wun	500
+垣	wun
 奂	wun
-奐	wun	500
+奐	wun
 峘	wun
 忨	wun
 换	wun
 捥	wun
-換	wun	1000
+換	wun
 晥	wun
-桓	wun	500
+桓	wun
 椀	wun
 浣	wun
 涣	wun
-渙	wun	500
+渙	wun
 澣	wun
 焕	wun
-煥	wun	1000
+煥	wun
 狟	wun
 獂	wun
 瓛	wun
 痪	wun
-瘓	wun	1000
-皖	wun	500
+瘓	wun
+皖	wun
 盌	wun
 睆	wun
-碗	wun	1000
-緩	wun	1000
+碗	wun
+緩	wun
 缓	wun
 羦	wun
 翫	wun
-腕	wun	1000
+腕	wun
 荁	wun
 萑	wun
-豌	wun	500
+豌	wun
 貆	wun
 輐	wun
 逭	wun
 雈	wun
 䄆	wut
 䄑	wut
-活	wut	1000
+活	wut
 咋	zaa	1000
-咋	zaak	500
+咋	zaak
 揸	zaa	1000
 㗬	zaa
 㡸	zaa
@@ -21937,27 +21938,27 @@ min_phrase_weight: 100
 䨨	zaa
 䨨	zeoi
 䵙	zaa
-乍	zaa	500
-乍	zok	0
+乍	zaa
+乍	zok	0%
 偺	zaa
 厏	zaa
-吒	zaa	500
+吒	zaa
 咤	zaa
-咱	zaa	1000
+咱	zaa
 喒	zaa
 嵖	zaa
 拃	zaa
 挓	zaa
-搾	zaa	500
+搾	zaa
 摣	zaa
 柤	zaa
 柤	zo
-榨	zaa	1000
+榨	zaa
 樝	zaa
 檛	zaa
-渣	zaa	1000
+渣	zaa
 溠	zaa
-炸	zaa	1000
+炸	zaa
 煠	zaa
 痄	zaa
 皻	zaa
@@ -21965,10 +21966,10 @@ min_phrase_weight: 100
 砟	zok
 膪	zaa
 苲	zaa
-蚱	zaa	500
-蚱	zaak	500
+蚱	zaa
+蚱	zaak
 觰	zaa
-詐	zaa	1000
+詐	zaa
 诈	zaa
 醡	zaa
 髽	zaa
@@ -22005,8 +22006,8 @@ min_phrase_weight: 100
 䜞	zi
 䰏	zaai
 债	zaai
-債	zaai	1000
-寨	zaai	1000
+債	zaai
+寨	zaai
 寨	zai	0%
 廌	zaai
 廌	zai
@@ -22019,8 +22020,8 @@ min_phrase_weight: 100
 砦	zaai
 豸	zaai
 豸	zi
-齋	zaai	500
-齋	zai	500
+齋	zaai
+齋	zai
 𡄡	zaai
 㖽	zaak
 㟙	zaak
@@ -22036,30 +22037,30 @@ min_phrase_weight: 100
 唶	ze
 啧	zaak
 啧	zik
-嘖	zaak	500
-嘖	zik	500
-宅	zaak	1000
+嘖	zaak
+嘖	zik
+宅	zaak
 岝	zaak
 岝	zok
 择	zaak
 掷	zaak
-摘	zaak	1000
-擇	zaak	1000
+摘	zaak
+擇	zaak
 擢	zaak
 擢	zok
-擲	zaak	1000
+擲	zaak
 柞	zaak
 柞	zok
 檡	zaak
 泽	zaak
-澤	zaak	1000
+澤	zaak
 矺	zaak
 碛	zaak
 碛	zik
 磔	zaak
 磧	zaak
 磧	zik
-窄	zaak	1000
+窄	zaak
 笮	zaak
 笮	zok
 箦	zaak
@@ -22069,12 +22070,12 @@ min_phrase_weight: 100
 謫	zaak
 讁	zaak
 谪	zaak
-責	zaak	1000
+責	zaak
 賾	zaak
 賾	zak
 责	zaak
 踯	zaak
-躑	zaak	500
+躑	zaak
 迮	zaak
 齰	zaak
 㕂	zaam
@@ -22110,19 +22111,19 @@ min_phrase_weight: 100
 寁	zaam
 寁	zaan
 崭	zaam
-嶄	zaam	1000
+嶄	zaam
 斩	zaam
-斬	zaam	1000
+斬	zaam
 暂	zaam
-暫	zaam	1000
-眨	zaam	501
-眨	zaap	1000
-站	zaam	1000
-簪	zaam	500
+暫	zaam
+眨	zaam
+眨	zaap
+站	zaam
+簪	zaam
 糌	zaam
-蘸	zaam	500
+蘸	zaam
 賺	zaam	0%
-賺	zaan	1000
+賺	zaan
 赚	zaam
 赚	zaan
 蹔	zaam
@@ -22182,19 +22183,19 @@ min_phrase_weight: 100
 攥	zaan
 昝	zaan
 栈	zaan
-棧	zaan	500
+棧	zaan
 灒	zaan
 琖	zaan
 瓒	zaan
 瓚	zaan
 盏	zaan
-盞	zaan	1000
-綻	zaan	1000
+盞	zaan
+綻	zaan
 绽	zaan
 譔	zaan
-讚	zaan	1000
+讚	zaan
 賛	zaan
-贊	zaan	1000
+贊	zaan
 赞	zaan
 趱	zaan
 趲	zaan
@@ -22217,30 +22218,30 @@ min_phrase_weight: 100
 䨸	zaang
 争	zaang
 争	zang
-崢	zaang	500
-崢	zang	500
+崢	zaang
+崢	zang
 挣	zaang
 挣	zang
 掙	zaang	0%
-掙	zang	1000
+掙	zang
 狰	zaang
 狰	zang
-猙	zaang	500
-猙	zang	500
+猙	zaang
+猙	zang
 睁	zaang
 睁	zang
 睜	zaang	0%
-睜	zang	1000
+睜	zang
 筝	zaang
 筝	zang
 箏	zaang	0%
-箏	zang	1000
-諍	zaang	500
-諍	zang	500
+箏	zang
+諍	zaang
+諍	zang
 诤	zaang
 诤	zang
-錚	zaang	500
-錚	zang	500
+錚	zaang
+錚	zang
 铮	zaang
 铮	zang
 𠲜	zaang
@@ -22270,22 +22271,22 @@ min_phrase_weight: 100
 亼	zaap
 剳	zaap
 劄	zaap
-匝	zaap	500
+匝	zaap
 嶍	zaap
-摺	zaap	501
-摺	zip	1000
+摺	zaap	4%
+摺	zip
 杂	zaap
 槢	zaap
-砸	zaap	500
-習	zaap	1000
+砸	zaap
+習	zaap
 袭	zaap
-襲	zaap	1000
+襲	zaap
 钑	zaap
-閘	zaap	1000
+閘	zaap
 闸	zaap
 隰	zaap
-集	zaap	1000
-雜	zaap	1000
+集	zaap
+雜	zaap
 雥	zaap
 霫	zaap
 霫	zap
@@ -22309,11 +22310,11 @@ min_phrase_weight: 100
 䬹	zaat
 䭿	zaat
 哳	zaat
-扎	zaat	1000
+扎	zaat
 拶	zaat
-札	zaat	500
+札	zaat
 紥	zaat
-紮	zaat	1000
+紮	zaat
 蚻	zaat
 鍘	zaat
 铡	zaat
@@ -22402,25 +22403,25 @@ min_phrase_weight: 100
 䰆	zaau
 䰍	zaau
 䱂	zaau
-嘲	zaau	1000
-帚	zaau	1000
+嘲	zaau
+帚	zaau
 帚	zau	0%
-找	zaau	1000
-棹	zaau	500
-棹	zoek	500
-櫂	zaau	500
-爪	zaau	1000
+找	zaau
+棹	zaau
+棹	zoek
+櫂	zaau
+爪	zaau
 爫	zaau
 瑵	zaau
 瑵	zou
 着	zaau	0%
 着	zau	0%
-着	zoek	1000
+着	zoek
 笊	zaau
-罩	zaau	1000
-肘	zaau	500
-肘	zau	500
-驟	zaau	1000
+罩	zaau
+肘	zaau
+肘	zau
+驟	zaau
 驟	zau	0%
 骤	zaau
 骤	zau
@@ -22428,7 +22429,7 @@ min_phrase_weight: 100
 鵫	zok
 𦻐	zaau
 仔	zai	1000
-仔	zi	1000
+仔	zi
 㨈	zai
 㸄	zai
 㿃	zai
@@ -22442,36 +22443,36 @@ min_phrase_weight: 100
 䬩	zok
 䭁	zai
 䮺	zai
-制	zai	1000
+制	zai
 剂	zai
-劑	zai	1000
+劑	zai
 挤	zai
-擠	zai	1000
+擠	zai
 櫅	zai
 泲	zai
 泲	zi
 济	zai
 滞	zai
-滯	zai	1000
+滯	zai
 漈	zai
-濟	zai	1000
+濟	zai
 狾	zai
 猘	zai
 癠	zai
 癠	zik
-祭	zai	1000
+祭	zai
 穄	zai
 穧	zai
 虀	zai
-製	zai	1000
+製	zai
 赍	zai
 跻	zai
 躋	zai
 际	zai
-際	zai	1000
+際	zai
 隮	zai
 霁	zai
-霽	zai	500
+霽	zai
 齌	zai
 齎	zai
 齏	zai
@@ -22484,11 +22485,11 @@ min_phrase_weight: 100
 䕉	zak
 䵂	zak
 䶦	zak
-仄	zak	500
+仄	zak
 侧	zak
-側	zak	1000
+側	zak
 则	zak
-則	zak	1000
+則	zak
 崱	zak
 庂	zak
 昃	zak
@@ -22507,29 +22508,29 @@ min_phrase_weight: 100
 寖	zam
 嶜	zam
 帎	zam
-怎	zam	1000
+怎	zam
 揕	zam
-斟	zam	500
-朕	zam	500
-枕	zam	1000
+斟	zam
+朕	zam
+枕	zam
 栚	zam
-浸	zam	1000
+浸	zam
 瑊	zam
 眹	zam
 眹	zan
-砧	zam	1000
+砧	zam
 祲	zam
-箴	zam	500
+箴	zam
 絼	zam
 絼	zi
 葴	zam
 谮	zam
-針	zam	1000
+針	zam
 鍖	zam
 鍼	zam
 针	zam
 鱵	zam
-鴆	zam	500
+鴆	zam
 鸩	zam
 𠹻	zam
 𩬎	zam
@@ -22545,14 +22546,14 @@ min_phrase_weight: 100
 䬤	zin
 䳲	zan
 侲	zan
-圳	zan	1000
+圳	zan
 抮	zan
-振	zan	1000
-珍	zan	1000
+振	zan
+珍	zan
 珎	zan
 畛	zan
 眞	zan
-真	zan	1000
+真	zan
 禛	zan
 稹	zan
 籈	zan
@@ -22562,16 +22563,16 @@ min_phrase_weight: 100
 薽	zan
 蜄	zan
 裖	zan
-賑	zan	1000
+賑	zan
 赈	zan
 軫	zan
 轸	zan
 鎭	zan
-鎮	zan	1000
+鎮	zan
 镇	zan
 阵	zan
-陣	zan	1000
-震	zan	1000
+陣	zan
+震	zan
 鬒	zan
 黰	zan
 𨸬	zan
@@ -22580,10 +22581,10 @@ min_phrase_weight: 100
 䎖	zang
 䰝	zang
 䱢	zang
-增	zang	1000
+增	zang
 峥	zang
 崝	zang
-憎	zang	1000
+憎	zang
 橧	zang
 甑	zang
 矰	zang
@@ -22591,18 +22592,18 @@ min_phrase_weight: 100
 繒	zang
 缯	zang
 罾	zang
-贈	zang	1000
+贈	zang
 赠	zang
 鬙	zang
 𢛵	zang
 𤺧	zang
 㙫	zap
 㳧	zap
-執	zap	1000
+執	zap
 慹	zap
 慹	zip
 执	zap
-汁	zap	1000
+汁	zap
 絷	zap
 縶	zap
 蓻	zap
@@ -22617,8 +22618,8 @@ min_phrase_weight: 100
 䵵	zyut
 侄	zat
 厔	zat
-姪	zat	1000
-嫉	zat	1000
+姪	zat
+嫉	zat
 庢	zat
 挃	zat
 揤	zat
@@ -22628,20 +22629,20 @@ min_phrase_weight: 100
 桎	zat
 槉	zat
 櫍	zat
-疾	zat	1000
+疾	zat
 礩	zat
 礩	zi
 秷	zat
-窒	zat	1000
+窒	zat
 膣	zat
 蒺	zat
-蛭	zat	500
+蛭	zat
 蛰	zat
 蟄	zat
 蟄	zik
 蟄	zit
-質	zat	1000
-質	zi	1000
+質	zat
+質	zi
 质	zat
 郅	zat
 銍	zat
@@ -22671,48 +22672,48 @@ min_phrase_weight: 100
 侜	zau
 僦	zau
 僽	zau
-冑	zau	500
-周	zau	1000
+冑	zau
+周	zau
 呪	zau
-咒	zau	1000
+咒	zau
 咮	zau
 咮	zyu
-啁	zau	500
-啾	zau	500
+啁	zau
+啾	zau
 喌	zau
-奏	zau	1000
+奏	zau
 娵	zau
 娵	zeoi
 婤	zau
-宙	zau	1000
-就	zau	1000
-岫	zau	500
-州	zau	1000
+宙	zau
+就	zau
+岫	zau
+州	zau
 掫	zau
-揍	zau	500
-揪	zau	500
+揍	zau
+揪	zau
 昼	zau
-晝	zau	1000
+晝	zau
 棸	zau
-洲	zau	1000
+洲	zau
 湫	zau
 湫	ziu
 甃	zau
 皱	zau
-皺	zau	1000
+皺	zau
 盩	zau
 睭	zau
 箒	zau
 籀	zau
-紂	zau	500
+紂	zau
 緅	zau
 縐	zau
 纣	zau
 绉	zau
 胄	zau
-舟	zau	1000
+舟	zau
 菆	zau
-袖	zau	1000
+袖	zau
 諏	zau
 謅	zau
 譸	zau
@@ -22721,17 +22722,17 @@ min_phrase_weight: 100
 诹	zau
 賙	zau
 赒	zau
-走	zau	1000
+走	zau
 輈	zau
 輖	zau
 辀	zau
-週	zau	1000
+週	zau
 邹	zau
 郰	zau
-鄒	zau	500
+鄒	zau
 鄹	zau
 酎	zau
-酒	zau	1000
+酒	zau
 陬	zau
 騶	zau
 驺	zau
@@ -22762,69 +22763,69 @@ min_phrase_weight: 100
 䥺	ze
 䦈	ze
 䩾	ze
-借	ze	1000
-嗟	ze	500
-姊	ze	501
-姊	zi	1000
-姐	ze	1000
+借	ze
+嗟	ze
+姊	ze	4%
+姊	zi
+姐	ze
 柘	ze
-榭	ze	500
+榭	ze
 罝	ze
 罝	zeoi
-者	ze	1000
-蔗	ze	1000
-藉	ze	1000
-藉	zik	1000
+者	ze
+蔗	ze
+藉	ze
+藉	zik
 蟅	ze
-謝	ze	1000
+謝	ze
 谢	ze
-赭	ze	500
+赭	ze
 这	ze
-這	ze	1000
-遮	ze	1000
+這	ze
+遮	ze
 鍺	ze
 锗	ze
-鷓	ze	500
+鷓	ze
 鹧	ze
 𡂪	ze
 只	zek	0%
-只	zi	1000
+只	zi
 呮	zek
-唧	zek	500
-唧	zik	500
+唧	zek
+唧	zik
 摭	zek
-炙	zek	1000
+炙	zek
 炙	zik	0%
 績	zek	0%
-績	zik	1000
-脊	zek	1000
+績	zik
+脊	zek
 脊	zik	0%
 膌	zek
-蓆	zek	500
-蓆	zik	500
+蓆	zek
+蓆	zik
 跖	zek
 跡	zek	0%
-跡	zik	1000
-隻	zek	1000
+跡	zik
+隻	zek
 丼	zeng
 丼	zing
-井	zeng	1000
+井	zeng
 井	zing	0%
 净	zeng
 净	zing
 凈	zeng
 凈	zing
-正	zeng	501
-正	zing	1000
+正	zeng	4%
+正	zing
 汫	zeng
 淨	zeng	0%
-淨	zing	1000
-精	zeng	501
-精	zing	1000
+淨	zing
+精	zeng	4%
+精	zing
 肼	zeng
 郑	zeng
-鄭	zeng	1000
-鄭	zing	0
+鄭	zeng
+鄭	zing	0%
 㐨	zeoi
 㑺	zeoi
 㑺	zeon
@@ -22864,51 +22865,51 @@ min_phrase_weight: 100
 䳡	zeoi
 䶥	zeoi
 叙	zeoi
-咀	zeoi	1000
-嘴	zeoi	1000
-墜	zeoi	1000
+咀	zeoi
+嘴	zeoi
+墜	zeoi
 岨	zeoi
 岨	zo
-序	zeoi	1000
+序	zeoi
 怚	zeoi
-敍	zeoi	1000
+敍	zeoi
 敘	zeoi
 晬	zeoi
-最	zeoi	1000
+最	zeoi
 檇	zeoi
-沮	zeoi	500
+沮	zeoi
 溆	zeoi
 漵	zeoi
-狙	zeoi	500
+狙	zeoi
 甀	zeoi
-疽	zeoi	500
+疽	zeoi
 砠	zeoi
 砠	zo
 硾	zeoi
-綴	zeoi	1000
-綴	zyut	200
+綴	zeoi
+綴	zyut
 縋	zeoi
 缀	zeoi
 缀	zyut
 缒	zeoi
-罪	zeoi	1000
-聚	zeoi	1000
+罪	zeoi
+聚	zeoi
 苴	zeoi
 菹	zeoi
 葅	zeoi
 蕞	zeoi
 觜	zeoi
 觜	zi
-贅	zeoi	500
+贅	zeoi
 赘	zeoi
 趄	zeoi
 足	zeoi	0%
-足	zuk	1000
+足	zuk
 跙	zeoi
 辠	zeoi
-追	zeoi	1000
-醉	zeoi	1000
-錐	zeoi	1000
+追	zeoi
+醉	zeoi
+錐	zeoi
 锥	zeoi
 隹	zeoi
 雎	zeoi
@@ -22919,7 +22920,7 @@ min_phrase_weight: 100
 鱮	zeoi
 鵻	zeoi
 鵻	zeon
-齟	zeoi	500
+齟	zeoi
 龃	zeoi
 𧐅	zeoi
 𨣦	zeoi
@@ -22946,43 +22947,43 @@ min_phrase_weight: 100
 䜭	zeon
 䝲	zeon
 䦞	zeon
-俊	zeon	1000
-儘	zeon	1000
-准	zeon	1000
+俊	zeon
+儘	zeon
+准	zeon
 埻	zeon
 寯	zeon
 尊	zeon	0%
-尊	zyun	1000
+尊	zyun
 尽	zeon
-峻	zeon	1000
+峻	zeon
 搢	zeon
-晉	zeon	1000
+晉	zeon
 晋	zeon
 晙	zeon
-榛	zeon	500
+榛	zeon
 樼	zeon
-津	zeon	1000
-浚	zeon	500
-準	zeon	1000
+津	zeon
+浚	zeon
+準	zeon
 溱	zeon
 濜	zeon
-濬	zeon	500
+濬	zeon
 烬	zeon
 燼	zeon
 獉	zeon
 璡	zeon
 畯	zeon
-盡	zeon	1000
+盡	zeon
 窀	zeon
-竣	zeon	1000
+竣	zeon
 綧	zeon
 縉	zeon
 缙	zeon
 罇	zeon
-肫	zeon	500
+肫	zeon
 脧	zeon
 臇	zeon
-臻	zeon	500
+臻	zeon
 荩	zeon
 蓁	zeon
 藎	zeon
@@ -22993,13 +22994,13 @@ min_phrase_weight: 100
 轃	zeon
 迍	zeon
 进	zeon
-進	zeon	1000
-遵	zeon	1000
+進	zeon
+遵	zeon
 遵	zyun	0%
 隼	zeon
 餕	zeon
 馂	zeon
-駿	zeon	500
+駿	zeon
 骏	zeon
 鵔	zeon
 㔘	zeot
@@ -23009,7 +23010,7 @@ min_phrase_weight: 100
 䚝	zeot
 崒	zeot
 崒	zyut
-怵	zeot	500
+怵	zeot
 蜶	zeot
 𠻘	zeot
 㑥	zi
@@ -23109,60 +23110,60 @@ min_phrase_weight: 100
 䳅	zi
 䵝	zi
 䵹	zi
-之	zi	1000
-伺	zi	500
+之	zi
+伺	zi
 傂	zi
-兕	zi	500
+兕	zi
 兹	zi
-卮	zi	500
+卮	zi
 厎	zi
-吱	zi	1000
+吱	zi
 呰	zi
 呲	zi
-咨	zi	500
-咫	zi	500
+咨	zi
+咫	zi
 嗞	zi
-嗣	zi	500
-址	zi	1000
+嗣	zi
+址	zi
 坁	zi
 姉	zi
-姿	zi	1000
-子	zi	1000
-字	zi	1000
-孜	zi	500
-孳	zi	500
+姿	zi
+子	zi
+字	zi
+孜	zi
+孳	zi
 寘	zi
-寺	zi	1000
+寺	zi
 嵫	zi
-巳	zi	1000
+巳	zi
 巵	zi
 庤	zi
 彘	zi
 徵	zi	0%
-徵	zing	1000
-志	zi	1000
+徵	zing
+志	zi
 恉	zi
 懫	zi
 扺	zi
-指	zi	1000
+指	zi
 挚	zi
 搘	zi
-摯	zi	1000
-支	zi	1000
-旨	zi	1000
-智	zi	1000
+摯	zi
+支	zi
+旨	zi
+智	zi
 栀	zi
-梓	zi	500
+梓	zi
 梔	zi
 椥	zi
 榰	zi
-止	zi	1000
+止	zi
 沚	zi
 涘	zi
-淄	zi	500
+淄	zi
 渍	zi
-滋	zi	1000
-滓	zi	1000
+滋	zi
+滓	zi
 漬	zi	0%
 牸	zi
 甾	zi
@@ -23170,45 +23171,45 @@ min_phrase_weight: 100
 畤	zi
 疐	zi
 疻	zi
-痔	zi	500
-痣	zi	500
+痔	zi
+痣	zi
 眦	zi
-知	zi	1000
-祀	zi	500
-祉	zi	500
-祗	zi	500
+知	zi
+祀	zi
+祉	zi
+祗	zi
 秄	zi
 秖	zi
 秭	zi
-稚	zi	1000
+稚	zi
 稺	zi
 竢	zi
 笥	zi
 籽	zi
 粢	zi
-紙	zi	1000
-紫	zi	1000
-緇	zi	500
-緻	zi	1000
+紙	zi
+紫	zi
+緇	zi
+緻	zi
 纸	zi
 缁	zi
-置	zi	1000
+置	zi
 耔	zi
-耜	zi	500
-肢	zi	1000
+耜	zi
+肢	zi
 胏	zi
 胑	zi
 胾	zi
-脂	zi	1000
-自	zi	1000
-至	zi	1000
-致	zi	1000
+脂	zi
+自	zi
+至	zi
+致	zi
 芓	zi
-芝	zi	1000
+芝	zi
 芷	zi
 菑	zi
 菑	zoi
-蜘	zi	1000
+蜘	zi
 螆	zi
 衹	zi
 覗	zi
@@ -23216,22 +23217,22 @@ min_phrase_weight: 100
 觶	zi
 訾	zi
 訿	zi
-誌	zi	1000
-諮	zi	1000
+誌	zi
+諮	zi
 谘	zi
-貲	zi	500
-資	zi	1000
+貲	zi
+資	zi
 贄	zi
 贽	zi
 赀	zi
 资	zi
 趑	zi
-趾	zi	1000
+趾	zi
 踬	zi
 躓	zi
 軹	zi
-輊	zi	500
-輜	zi	500
+輊	zi
+輜	zi
 轵	zi
 轾	zi
 辎	zi
@@ -23243,13 +23244,13 @@ min_phrase_weight: 100
 锱	zi
 镃	zi
 阯	zi
-雉	zi	500
+雉	zi
 飤	zi
-飼	zi	1000
+飼	zi
 饲	zi
 駤	zi
 騺	zi
-髭	zi	500
+髭	zi
 鯔	zi
 鲻	zi
 鳷	zi
@@ -23303,40 +23304,40 @@ min_phrase_weight: 100
 䴬	zik
 䴬	zim
 値	zik
-值	zik	1000
+值	zik
 勣	zik
-即	zik	1000
+即	zik
 卽	zik
 埴	zik
 堲	zik
-夕	zik	1000
-寂	zik	1000
-席	zik	1000
+夕	zik
+寂	zik
+席	zik
 帻	zik
 幘	zik
-植	zik	1000
+植	zik
 楖	zik
 楖	zit
 樴	zik
-殖	zik	1000
-汐	zik	500
+殖	zik
+汐	zik
 漃	zik
-瘠	zik	500
+瘠	zik
 癪	zik
-直	zik	1000
-矽	zik	500
+直	zik
+矽	zik
 积	zik
 稙	zik
-稷	zik	1000
-積	zik	1000
+稷	zik
+積	zik
 穸	zik
-籍	zik	1000
-織	zik	1000
+籍	zik
+織	zik
 织	zik
 绩	zik
 耤	zik
 职	zik
-職	zik	1000
+職	zik
 蘵	zik
 蝍	zik
 蟙	zik
@@ -23349,7 +23350,7 @@ min_phrase_weight: 100
 軄	zik
 迹	zik
 陟	zik
-鯽	zik	500
+鯽	zik
 鰿	zik
 鲫	zik
 鶺	zik
@@ -23385,16 +23386,16 @@ min_phrase_weight: 100
 䶫	zim
 䶮	zim
 䶲	zim
-佔	zim	1000
+佔	zim
 僣	zim
-占	zim	1000
-尖	zim	1000
+占	zim
+尖	zim
 惉	zim
-沾	zim	1000
+沾	zim
 渐	zim
-漸	zim	1000
+漸	zim
 熸	zim
-瞻	zim	1000
+瞻	zim
 秥	zim
 聻	zim
 臜	zim
@@ -23403,10 +23404,10 @@ min_phrase_weight: 100
 螹	zim
 覘	zim
 觇	zim
-詹	zim	1000
+詹	zim
 譫	zim
 谵	zim
-霑	zim	1000
+霑	zim
 颭	zim
 飐	zim
 魙	zim
@@ -23460,54 +23461,54 @@ min_phrase_weight: 100
 䳿	zin
 䴏	zin
 䵐	zin
-剪	zin	1000
+剪	zin
 劗	zin
-展	zin	1000
+展	zin
 帴	zin
 戋	zin
 戔	zin
 战	zin
 戩	zin
 戬	zin
-戰	zin	1000
+戰	zin
 揃	zin
 搌	zin
 旃	zin
 栫	zin
 栴	zin
 毡	zin
-氈	zin	1000
+氈	zin
 氊	zin
 洊	zin
-湔	zin	500
+湔	zin
 溅	zin
-濺	zin	1000
-煎	zin	1000
+濺	zin
+煎	zin
 牋	zin
 牮	zin
 皽	zin
 笺	zin
-箋	zin	500
-箭	zin	1000
+箋	zin
+箭	zin
 籛	zin
 繟	zin
-羶	zin	500
+羶	zin
 翦	zin
 荐	zin
 葥	zin
-薦	zin	1000
+薦	zin
 諓	zin
 譾	zin
 谫	zin
-賤	zin	1000
+賤	zin
 赕	zin
 辗	zin
 邅	zin
 鞯	zin
 韉	zin
-顫	zin	1000
+顫	zin
 颤	zin
-餞	zin	500
+餞	zin
 饘	zin
 饯	zin
 鬋	zin
@@ -23574,46 +23575,46 @@ min_phrase_weight: 100
 䯚	zoek
 䴖	zing
 侦	zing
-偵	zing	1000
+偵	zing
 凊	zing
 婧	zing
 帧	zing
-幀	zing	500
-征	zing	1000
-怔	zing	500
-政	zing	1000
-整	zing	1000
+幀	zing
+征	zing
+怔	zing
+政	zing
+整	zing
 旍	zing
-晶	zing	1000
+晶	zing
 晸	zing
 桢	zing
-楨	zing	500
+楨	zing
 浈	zing
 湞	zing
 烝	zing
-症	zing	1000
-癥	zing	500
+症	zing
+癥	zing
 眐	zing
-睛	zing	1000
+睛	zing
 祯	zing
-禎	zing	500
+禎	zing
 穽	zing
 竫	zing
 箐	zing
-蒸	zing	1000
+蒸	zing
 証	zing
-證	zing	1000
+證	zing
 证	zing
-貞	zing	500
+貞	zing
 贞	zing
 遉	zing
 鉦	zing
 钲	zing
-阱	zing	1000
+阱	zing
 陉	zing
-靖	zing	500
+靖	zing
 静	zing
-靜	zing	1000
+靜	zing
 鶄	zing
 㐖	zip
 㖕	zip
@@ -23638,17 +23639,17 @@ min_phrase_weight: 100
 倢	zip
 倢	zit
 嗫	zip
-囁	zip	500
+囁	zip
 慴	zip
-接	zip	1000
+接	zip
 椄	zip
-楫	zip	500
+楫	zip
 浃	zip
 耴	zip
 襵	zip
 讋	zip
 讘	zip
-輒	zip	1000
+輒	zip
 輒	zit	0%
 辄	zip
 霅	zip
@@ -23676,29 +23677,29 @@ min_phrase_weight: 100
 䯵	zit
 䲙	zit
 卩	zit
-哲	zit	500
+哲	zit
 喆	zit
 婕	zit
 岊	zit
 悊	zit
-截	zit	1000
-折	zit	1000
-捷	zit	1000
+截	zit
+折	zit
+捷	zit
 擮	zit
 擳	zit
 栉	zit
 楶	zit
-櫛	zit	500
-浙	zit	1000
+櫛	zit
+浙	zit
 淛	zit
 瀄	zit
 疌	zit
 疖	zit
 癤	zit
-睫	zit	500
-節	zit	1000
+睫	zit
+節	zit
 节	zit
-蜇	zit	500
+蜇	zit
 谒	zit
 踕	zit
 𡁶	zit
@@ -23735,28 +23736,28 @@ min_phrase_weight: 100
 僬	ziu
 噍	ziu
 嚼	ziu	0%
-嚼	zoek	1000
+嚼	zoek
 垗	ziu
-招	ziu	1000
+招	ziu
 曌	ziu
-椒	ziu	500
-沼	ziu	1000
+椒	ziu
+沼	ziu
 灂	ziu
 灂	zok
 灂	zuk
 炤	ziu
-焦	ziu	1000
-照	ziu	1000
+焦	ziu
+照	ziu
 皭	ziu
 皭	zoek
-礁	ziu	500
+礁	ziu
 膲	ziu
-蕉	ziu	1000
+蕉	ziu
 蟭	ziu
-詔	ziu	500
+詔	ziu
 诏	ziu
 赵	ziu
-趙	ziu	500
+趙	ziu
 趭	ziu
 醮	ziu
 釂	ziu
@@ -23767,17 +23768,17 @@ min_phrase_weight: 100
 咗	zo	100000
 㘴	zo
 㝾	zo
-佐	zo	500
-俎	zo	500
-助	zo	1000
+佐	zo
+俎	zo
+助	zo
 唑	zo
 唨	zo
-左	zo	1000
-座	zo	1000
-詛	zo	500
+左	zo
+座	zo
+詛	zo
 謯	zo
 诅	zo
-阻	zo	1000
+阻	zo
 㒂	zoek
 㩱	zoek
 㵸	zoek
@@ -23797,18 +23798,18 @@ min_phrase_weight: 100
 䶂	zoek
 䶳	zoek
 妁	zoek
-斫	zoek	500
+斫	zoek
 斮	zoek
 晫	zoek
 櫡	zoek
 櫡	zyu
 爝	zoek
-爵	zoek	1000
+爵	zoek
 禚	zoek
 著	zoek	0%
-著	zyu	1000
-酌	zoek	500
-雀	zoek	1000
+著	zyu
+酌	zoek
+雀	zoek
 㒕	zoeng
 㔦	zoeng
 㕩	zoeng
@@ -23837,59 +23838,59 @@ min_phrase_weight: 100
 䬗	zoeng
 䭥	zoeng
 䴂	zoeng
-丈	zoeng	1000
+丈	zoeng
 仉	zoeng
-仗	zoeng	1000
+仗	zoeng
 傽	zoeng
-像	zoeng	1000
-匠	zoeng	1000
+像	zoeng
+匠	zoeng
 奖	zoeng
 奬	zoeng
 嫜	zoeng
 将	zoeng
-將	zoeng	1000
+將	zoeng
 嶂	zoeng
 帐	zoeng
-帳	zoeng	1000
-幛	zoeng	500
+帳	zoeng
+幛	zoeng
 张	zoeng
-張	zoeng	1000
-彰	zoeng	1000
+張	zoeng
+彰	zoeng
 慞	zoeng
-掌	zoeng	1000
-杖	zoeng	1000
+掌	zoeng
+杖	zoeng
 桨	zoeng
-槳	zoeng	500
-樟	zoeng	500
-橡	zoeng	1000
+槳	zoeng
+樟	zoeng
+橡	zoeng
 浆	zoeng
 涨	zoeng
-漲	zoeng	1000
-漳	zoeng	500
-漿	zoeng	1000
-獎	zoeng	1000
-獐	zoeng	500
-璋	zoeng	500
-瘴	zoeng	500
-章	zoeng	1000
+漲	zoeng
+漳	zoeng
+漿	zoeng
+獎	zoeng
+獐	zoeng
+璋	zoeng
+瘴	zoeng
+章	zoeng
 粻	zoeng
 绱	zoeng
 胀	zoeng
-脹	zoeng	1000
+脹	zoeng
 蒋	zoeng
-蔣	zoeng	500
+蔣	zoeng
 螀	zoeng
 螿	zoeng
-蟑	zoeng	1000
+蟑	zoeng
 蟓	zoeng
 襐	zoeng
-象	zoeng	1000
-賬	zoeng	1000
+象	zoeng
+賬	zoeng
 账	zoeng
 鄣	zoeng
 酱	zoeng
-醬	zoeng	1000
-障	zoeng	1000
+醬	zoeng
+障	zoeng
 鱆	zoeng
 麞	zoeng
 𤕭	zoeng
@@ -23898,18 +23899,18 @@ min_phrase_weight: 100
 䔂	zoi
 䮨	zoi
 䵧	zoi
-再	zoi	1000
-哉	zoi	1000
-在	zoi	1000
-宰	zoi	1000
+再	zoi
+哉	zoi
+在	zoi
+宰	zoi
 崽	zoi
-栽	zoi	1000
+栽	zoi
 渽	zoi
-災	zoi	1000
+災	zoi
 灾	zoi
 烖	zoi
 縡	zoi
-載	zoi	1000
+載	zoi
 载	zoi
 㑅	zok
 㘀	zok
@@ -23919,17 +23920,17 @@ min_phrase_weight: 100
 䎰	zok
 䝫	zok
 䥣	zok
-作	zok	1000
+作	zok
 凿	zok
 怍	zok
-昨	zok	1000
+昨	zok
 浞	zok
 浞	zuk
-濯	zok	1000
+濯	zok
 筰	zok
 莋	zok
 鍩	zok
-鑿	zok	1000
+鑿	zok
 飵	zok
 鷟	zok
 㘸	zong
@@ -23940,30 +23941,30 @@ min_phrase_weight: 100
 䚎	zong
 塟	zong
 壮	zong
-壯	zong	1000
-奘	zong	500
+壯	zong
+奘	zong
 妆	zong
-妝	zong	500
+妝	zong
 庄	zong
 桩	zong
-樁	zong	1000
+樁	zong
 牂	zong
 状	zong
-狀	zong	1000
+狀	zong
 粧	zong
 脏	zong
-臟	zong	1000
-臧	zong	500
-莊	zong	1000
-葬	zong	1000
+臟	zong
+臧	zong
+莊	zong
+葬	zong
 装	zong
-裝	zong	1000
+裝	zong
 賍	zong
-贓	zong	1000
+贓	zong
 贜	zong
 赃	zong
 驵	zong
-髒	zong	1000
+髒	zong
 𥅾	zong
 𥊙	zong
 㡟	zou
@@ -23974,30 +23975,30 @@ min_phrase_weight: 100
 䗢	zou
 䜊	zou
 䲃	zou
-做	zou	1000
-早	zou	1000
+做	zou
+早	zou
 枣	zou
-棗	zou	500
-灶	zou	500
+棗	zou
+灶	zou
 璪	zou
 皁	zou
-皂	zou	1000
-祖	zou	1000
-祚	zou	500
-租	zou	1000
+皂	zou
+祖	zou
+祚	zou
+租	zou
 竈	zou
 簉	zou
-糟	zou	1000
-組	zou	1000
+糟	zou
+組	zou
 组	zou
 胙	zou
 葃	zou
 葄	zou
 蒩	zou
-藻	zou	1000
-蚤	zou	1000
+藻	zou
+蚤	zou
 蹧	zou
-遭	zou	1000
+遭	zou
 阼	zou
 靻	zou
 坠	zui
@@ -24024,41 +24025,41 @@ min_phrase_weight: 100
 䥮	zuk
 䮱	zuk
 䳑	zuk
-俗	zuk	1000
+俗	zuk
 哫	zuk
 嘱	zuk
-囑	zuk	1000
-捉	zuk	1000
+囑	zuk
+捉	zuk
 斸	zuk
-族	zuk	1000
+族	zuk
 柷	zuk
 欘	zuk
 浊	zuk
-濁	zuk	1000
+濁	zuk
 烛	zuk
-燭	zuk	1000
+燭	zuk
 瘃	zuk
 瞩	zuk
-矚	zuk	1000
-祝	zuk	1000
-竹	zuk	1000
-竺	zuk	500
+矚	zuk
+祝	zuk
+竹	zuk
+竺	zuk
 筑	zuk
-築	zuk	1000
-粥	zuk	1000
-續	zuk	1000
+築	zuk
+粥	zuk
+續	zuk
 续	zuk
 臅	zuk
 舳	zuk
 蓫	zuk
 藚	zuk
 蠋	zuk
-躅	zuk	500
-軸	zuk	1000
+躅	zuk
+軸	zuk
 轴	zuk
-逐	zuk	1000
-鏃	zuk	500
-鐲	zuk	500
+逐	zuk
+鏃	zuk
+鐲	zuk
 镞	zuk
 镯	zuk
 鱁	zuk
@@ -24120,8 +24121,8 @@ min_phrase_weight: 100
 䩺	zung
 䰌	zung
 䱵	zung
-中	zung	1000
-仲	zung	500
+中	zung
+仲	zung
 伀	zung
 众	zung
 倧	zung
@@ -24129,15 +24130,15 @@ min_phrase_weight: 100
 偬	zung
 傯	zung
 妐	zung
-宗	zung	1000
+宗	zung
 尰	zung
 嵕	zung
 彸	zung
-忠	zung	1000
+忠	zung
 总	zung
 惾	zung
 摠	zung
-棕	zung	1000
+棕	zung
 椶	zung
 歱	zung
 熜	zung
@@ -24146,44 +24147,44 @@ min_phrase_weight: 100
 瘇	zung
 瘲	zung
 盅	zung
-眾	zung	1000
-種	zung	1000
+眾	zung
+種	zung
 稯	zung
-粽	zung	1000
+粽	zung
 糉	zung
 糭	zung
-終	zung	1000
-綜	zung	1000
-縱	zung	1000
-總	zung	1000
+終	zung
+綜	zung
+縱	zung
+總	zung
 繌	zung
 纵	zung
 终	zung
 综	zung
 翪	zung
 肿	zung
-腫	zung	1000
-舂	zung	500
+腫	zung
+舂	zung
 舯	zung
 蔠	zung
 螽	zung
 衆	zung
-訟	zung	1000
-誦	zung	1000
+訟	zung
+誦	zung
 讼	zung
 诵	zung
 豵	zung
 踪	zung
-蹤	zung	1000
+蹤	zung
 鍐	zung
-鍾	zung	1000
-鐘	zung	1000
+鍾	zung
+鐘	zung
 钟	zung
 锺	zung
-頌	zung	1000
+頌	zung
 颂	zung
 騣	zung
-鬃	zung	500
+鬃	zung
 鬷	zung
 鱅	zung
 𠂝	zung
@@ -24267,54 +24268,54 @@ min_phrase_weight: 100
 䲣	zyu
 䴁	zyu
 丶	zyu
-主	zyu	1000
-住	zyu	1000
-侏	zyu	500
-拄	zyu	500
-朱	zyu	1000
-株	zyu	1000
+主	zyu
+住	zyu
+侏	zyu
+拄	zyu
+朱	zyu
+株	zyu
 槠	zyu
 橥	zyu
 櫧	zyu
 櫫	zyu
 殶	zyu
-注	zyu	1000
-渚	zyu	500
+注	zyu
+渚	zyu
 潴	zyu
 瀦	zyu
 炷	zyu
 煑	zyu
-煮	zyu	1000
+煮	zyu
 猪	zyu
-珠	zyu	1000
+珠	zyu
 疰	zyu
-硃	zyu	500
+硃	zyu
 祩	zyu
 筯	zyu
 箸	zyu
 紸	zyu
 罜	zyu
 翥	zyu
-茱	zyu	1000
+茱	zyu
 藸	zyu
-蛀	zyu	1000
-蛛	zyu	1000
+蛀	zyu
+蛛	zyu
 袾	zyu
-註	zyu	1000
-誅	zyu	1000
-諸	zyu	1000
+註	zyu
+誅	zyu
+諸	zyu
 诛	zyu
 诸	zyu
-豬	zyu	1000
+豬	zyu
 跦	zyu
 邾	zyu
 鉒	zyu
-鑄	zyu	1000
+鑄	zyu
 铢	zyu
 铸	zyu
 陼	zyu
 馵	zyu
-駐	zyu	1000
+駐	zyu
 驻	zyu
 麈	zyu
 𩅻	zyu
@@ -24367,27 +24368,27 @@ min_phrase_weight: 100
 僔	zyun
 啭	zyun
 噂	zyun
-囀	zyun	500
+囀	zyun
 塼	zyun
 嫥	zyun
-專	zyun	1000
+專	zyun
 捘	zyun
 撙	zyun
 甎	zyun
 砖	zyun
-磚	zyun	1000
+磚	zyun
 縳	zyun
-纂	zyun	500
+纂	zyun
 纘	zyun
 缵	zyun
 躜	zyun
 躦	zyun
-轉	zyun	1000
+轉	zyun
 转	zyun
 鄟	zyun
 酂	zyun
 鐏	zyun
-鑽	zyun	1000
+鑽	zyun
 钻	zyun
 镌	zyun
 顓	zyun
@@ -24410,7 +24411,7 @@ min_phrase_weight: 100
 䮕	zyut
 剟	zyut
 惙	zyut
-拙	zyut	500
+拙	zyut
 掇	zyut
 敪	zyut
 梲	zyut
@@ -24419,15 +24420,15 @@ min_phrase_weight: 100
 歠	zyut
 畷	zyut
 窋	zyut
-絕	zyut	1000
+絕	zyut
 绌	zyut
 绝	zyut
 腏	zyut
-茁	zyut	1000
+茁	zyut
 蕝	zyut
 裰	zyut
 諁	zyut
-輟	zyut	1000
+輟	zyut
 辍	zyut
 醊	zyut
 錣	zyut


### PR DESCRIPTION
# 問題

原有詞表中，常用字經常有多於一個不能配詞或只用於古文的讀音。

![image](https://user-images.githubusercontent.com/5143421/38819427-e76ca3fa-41cd-11e8-8a43-a3d503a395b1.png)

如上圖示，輸入「wu gau」後得出四個配詞，但其中只得一個（「污垢」）讀作「wu gau」。其餘三個配詞出現在選單，是因為「龜」「於」「惡」在舊表中有一些罕見音，卻沒有設置頻度。 （粗體為最常用讀法，斜體為罕見，母語話者一般不認識的讀音。）

- 龜　**gwai1**, _gwan1_, _gau1_, _kau1_　　　
- 於　**jyu1**, _wu1_     
- 惡　**ok3**, wu3

# 折衷解決方法

長遠而言，我們需要大型的粵語語料庫，並需要人手清理詞表。（注意部份錯誤、罕見發音亦見於「粵語審音配詞字庫」和 Unicode 的 kCantonese 欄，所以清理上有其困難。）

今次暫時用了較簡單的方法。首先是我抽出香港教育局公佈的「香港小學學習字詞表」列出的所有中文字和讀音3,171 個字，和出現在「常用字字形表」的 4,762 個字。然後對原詞表沒有標記頻度的單字項目，按照下列方式處理。

- 出現在「香港小學學習字詞表」，字音符合字詞表讀音，設定為 1000 分
- 出現在「常用字字形表」，不檢查字音（原表沒有提供），直接設定為 500分
- 出現在「香港小學學習字詞表」，字音和字詞表不符，但人手核對確認為粵語口語音，設定為 501分
- 出現在「香港小學學習字詞表」，字音和字詞表不符，但核對後可以視作可接受發音（口音差異或間中使用），設定為 200分
- 出現在「香港小學學習字詞表」，字音和字詞表不符，即視作 **常用字的罕見讀法** ，標記為 0%
- 不在以上兩表之內，不作任何改動